### PR TITLE
BDR-275: Add `template.json` to the MVP DWC Template

### DIFF
--- a/templates/01_dwc_mvp/metadata.json
+++ b/templates/01_dwc_mvp/metadata.json
@@ -1,0 +1,5 @@
+{
+    "id": "01_dwc_mvp.xlsx",
+    "description": "A template to translate some Darwin Core fields",
+    "version": "0.0.1"
+}

--- a/templates/01_dwc_mvp/template.json
+++ b/templates/01_dwc_mvp/template.json
@@ -1,6 +1,0 @@
-{
-    "id": "01_dwc_mvp",
-    "description": "A template to translate some Darwin Core fields",
-    "version": "0.0.1",
-    "instructions": "See README.md for further details"
-}

--- a/templates/01_dwc_mvp/template.json
+++ b/templates/01_dwc_mvp/template.json
@@ -1,0 +1,6 @@
+{
+    "id": "01_dwc_mvp",
+    "description": "A template to translate some Darwin Core fields",
+    "version": "0.0.1",
+    "instructions": "See README.md for further details"
+}


### PR DESCRIPTION
## Description
* This PR adds the discussed `template.json` to the template skeleton
* Questions to resolve before merging:
  * Should the filename be `template.json`, or `01_dwc_mvp.json`?
  * Should `id` be `01_dwc_mvp` or `01_dwc_mvp.xlsx` (i.e., include extension)?
  * If the `id` is not the filename, should we include a `"filename": "01_dwc_mvp.xlsx"`?
  * Should we include `instructions` at the moment, when none exist?