### PR TITLE
BDR-389: Re-define `pandas` types so they can be resolved by `mypy`

### DIFF
--- a/abis_mapping/base/types.py
+++ b/abis_mapping/base/types.py
@@ -1,17 +1,21 @@
 """Provides Base Types for the Package"""
 
 
-# Third-Party
-import pandas._typing as pdt
-
 # Typing
-from typing import Union
+from os import PathLike
+from typing import IO, Union
 
+
+# Define Pandas Types
+# pandas._typing cannot be resolved properly, so re-defining them here
+FilePath = Union[str, PathLike[str]]
+ReadCsvBuffer = IO
 
 # Constants
 # See: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+# See: https://github.com/pandas-dev/pandas/blob/v1.4.1/pandas/io/parsers/readers.py#L597
 CSVType = Union[
-    pdt.FilePath,
-    pdt.ReadCsvBuffer[bytes],
-    pdt.ReadCsvBuffer[str],
+    FilePath,
+    ReadCsvBuffer[bytes],
+    ReadCsvBuffer[str],
 ]


### PR DESCRIPTION
## Description
* Importing types from `pandas._typing` does not work (for whatever reason, I cannot find out)
* `mypy` complains that the `types.CSVType` is of type `Union[Any, Any, Any]`
* This PR re-defines the pandas types, so they can be resolved properly