### PR TITLE
BDR-285: Hardcode template to `csv` only format for now

### DIFF
--- a/abis_mapping/base/types.py
+++ b/abis_mapping/base/types.py
@@ -8,6 +8,8 @@ from typing import IO, Union
 
 # Define Readable Filepath and IO Type
 ReadableType = Union[
+    str,
+    bytes,
     Union[str, PathLike[str]],
     IO[bytes],
     IO[str],

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -59,6 +59,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         # Construct Resource (Table with Schema)
         resource = frictionless.Resource(
             source=data,
+            format="csv",  # TODO -> Hardcoded to csv for now
             schema=self.schema(),
             onerror="ignore",  # Ignore errors, they will be handled in the report
         )
@@ -95,6 +96,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         # Construct Resource (Table with Schema)
         resource = frictionless.Resource(
             source=data,
+            format="csv",  # TODO -> Hardcoded to csv for now
             schema=self.schema(),
             onerror="raise",  # Raise errors, it should already be valid here
         )


### PR DESCRIPTION
## Description
* As per title, hardcoding template to \`csv\` only for now.
* This allows for raw buffer/bytes data to be inputted, which previously could not have its format automatically determined.
* In future this handling should be better