### PR TITLE
BDR-459: Improve and simplify metadata by adding `template_url` and `schema_url`

### DIFF
--- a/abis_mapping/templates/dwc_mvp/metadata.json
+++ b/abis_mapping/templates/dwc_mvp/metadata.json
@@ -1,5 +1,7 @@
 {
     "id": "dwc_mvp.xlsx",
     "description": "A template to translate some Darwin Core fields",
-    "version": "0.0.1"
+    "version": "0.0.1",
+    "template_url": "https://raw.githubusercontent.com/gaiaresources/abis-mapping/main/abis_mapping/templates/dwc_mvp/dwc_mvp.xlsx",
+    "schema_url": "https://raw.githubusercontent.com/gaiaresources/abis-mapping/main/abis_mapping/templates/dwc_mvp/schema.json"
 }


### PR DESCRIPTION
## Description
* As per title above
* Is this something we want to do?
* This simplifies the whole `GET /template/list` workflow, we don't need to do any GitHub API stuff, or generation/inference of links - as the links are already in the metadata
* There is an argument to be made that this is not elegant (i.e., we could generate the links at run-time), but it is a very simple solution
* Up for discussion