### PR TITLE
BDR-490: Allow flexible base iri to be used when mapping template

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -14,7 +14,6 @@ import rdflib
 
 # Local
 from . import types
-from abis_mapping import utils
 
 # Typing
 from typing import Any, Optional, final
@@ -47,13 +46,13 @@ class ABISMapper(abc.ABC):
     def apply_mapping(
         self,
         data: types.ReadableType,
-        base_iri: rdflib.Namespace = utils.namespaces.EXAMPLE,
+        base_iri: Optional[rdflib.Namespace] = None,
     ) -> rdflib.Graph:
         """Applies Mapping from Raw Data to ABIS conformant RDF.
 
         Args:
             data (ReadableType): Readable raw data.
-            base_iri (rdflib.Namespace): Base IRI namespace to use for mapping.
+            base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
 
         Returns:
             rdflib.Graph: ABIS Conformant RDF Graph.

--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -14,6 +14,7 @@ import rdflib
 
 # Local
 from . import types
+from abis_mapping import utils
 
 # Typing
 from typing import Any, Optional, final
@@ -46,11 +47,13 @@ class ABISMapper(abc.ABC):
     def apply_mapping(
         self,
         data: types.ReadableType,
+        base_iri: rdflib.Namespace = utils.namespaces.EXAMPLE,
     ) -> rdflib.Graph:
         """Applies Mapping from Raw Data to ABIS conformant RDF.
 
         Args:
             data (ReadableType): Readable raw data.
+            base_iri (rdflib.Namespace): Base IRI namespace to use for mapping.
 
         Returns:
             rdflib.Graph: ABIS Conformant RDF Graph.

--- a/abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -10,12 +10,12 @@
 @prefix void: <http://rdfs.org/ns/void#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.org/observation/scientificName/0> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/0> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/0> ;
-    sosa:hasResult <http://example.org/scientificName/Calothamnus-lateralis-var-crassus> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/0> ;
+    sosa:hasResult <http://createme.org/scientificName/Calothamnus-lateralis-var-crassus> ;
     sosa:hasSimpleResult "Calothamnus lateralis var. crassus" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -23,12 +23,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-24"^^xsd:date .
 
-<http://example.org/observation/scientificName/1> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/1> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/1> ;
-    sosa:hasResult <http://example.org/scientificName/Boronia-anceps> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/1> ;
+    sosa:hasResult <http://createme.org/scientificName/Boronia-anceps> ;
     sosa:hasSimpleResult "Boronia anceps" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -36,12 +36,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/10> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/10> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/10> ;
-    sosa:hasResult <http://example.org/scientificName/Caladenia-excelsa> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/10> ;
+    sosa:hasResult <http://createme.org/scientificName/Caladenia-excelsa> ;
     sosa:hasSimpleResult "Caladenia excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -49,12 +49,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
-<http://example.org/observation/scientificName/2> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/2> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/2> ;
-    sosa:hasResult <http://example.org/scientificName/Boronia-anceps> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/2> ;
+    sosa:hasResult <http://createme.org/scientificName/Boronia-anceps> ;
     sosa:hasSimpleResult "Boronia anceps" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -62,12 +62,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/3> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/3> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/3> ;
-    sosa:hasResult <http://example.org/scientificName/Boronia-anceps> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/3> ;
+    sosa:hasResult <http://createme.org/scientificName/Boronia-anceps> ;
     sosa:hasSimpleResult "Boronia anceps" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -75,12 +75,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/4> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/4> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/4> ;
-    sosa:hasResult <http://example.org/scientificName/Banksia-sessilis-var-cordata> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/4> ;
+    sosa:hasResult <http://createme.org/scientificName/Banksia-sessilis-var-cordata> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -88,12 +88,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/5> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/5> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/5> ;
-    sosa:hasResult <http://example.org/scientificName/Banksia-sessilis-var-cordata> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/5> ;
+    sosa:hasResult <http://createme.org/scientificName/Banksia-sessilis-var-cordata> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -101,12 +101,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/6> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/6> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/6> ;
-    sosa:hasResult <http://example.org/scientificName/Banksia-sessilis-var-cordata> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/6> ;
+    sosa:hasResult <http://createme.org/scientificName/Banksia-sessilis-var-cordata> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -114,12 +114,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/7> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/7> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/7> ;
-    sosa:hasResult <http://example.org/scientificName/Banksia-sessilis-var-cordata> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/7> ;
+    sosa:hasResult <http://createme.org/scientificName/Banksia-sessilis-var-cordata> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -127,12 +127,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/scientificName/8> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/8> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/8> ;
-    sosa:hasResult <http://example.org/scientificName/Caladenia-excelsa> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/8> ;
+    sosa:hasResult <http://createme.org/scientificName/Caladenia-excelsa> ;
     sosa:hasSimpleResult "Caladenia excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -140,12 +140,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
-<http://example.org/observation/scientificName/9> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/scientificName/9> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/9> ;
-    sosa:hasResult <http://example.org/scientificName/Caladenia-excelsa> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/9> ;
+    sosa:hasResult <http://createme.org/scientificName/Caladenia-excelsa> ;
     sosa:hasSimpleResult "Caladenia excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -153,12 +153,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
-<http://example.org/observation/verbatimID/0> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/0> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/0> ;
-    sosa:hasResult <http://example.org/verbatimID/0> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/0> ;
+    sosa:hasResult <http://createme.org/verbatimID/0> ;
     sosa:hasSimpleResult "Calothamnus lateralis var. crassus" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -166,12 +166,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-24"^^xsd:date .
 
-<http://example.org/observation/verbatimID/1> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/1> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/1> ;
-    sosa:hasResult <http://example.org/verbatimID/1> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/1> ;
+    sosa:hasResult <http://createme.org/verbatimID/1> ;
     sosa:hasSimpleResult "Boronia anceps" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -179,12 +179,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/10> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/10> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/10> ;
-    sosa:hasResult <http://example.org/verbatimID/10> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/10> ;
+    sosa:hasResult <http://createme.org/verbatimID/10> ;
     sosa:hasSimpleResult "Caladenia ?excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -192,12 +192,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
-<http://example.org/observation/verbatimID/2> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/2> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/2> ;
-    sosa:hasResult <http://example.org/verbatimID/2> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/2> ;
+    sosa:hasResult <http://createme.org/verbatimID/2> ;
     sosa:hasSimpleResult "Boronia anceps" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -205,12 +205,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/3> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/3> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/3> ;
-    sosa:hasResult <http://example.org/verbatimID/3> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/3> ;
+    sosa:hasResult <http://createme.org/verbatimID/3> ;
     sosa:hasSimpleResult "Boronia anceps" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -218,12 +218,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/4> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/4> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/4> ;
-    sosa:hasResult <http://example.org/verbatimID/4> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/4> ;
+    sosa:hasResult <http://createme.org/verbatimID/4> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -231,12 +231,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/5> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/5> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/5> ;
-    sosa:hasResult <http://example.org/verbatimID/5> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/5> ;
+    sosa:hasResult <http://createme.org/verbatimID/5> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -244,12 +244,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/6> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/6> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/6> ;
-    sosa:hasResult <http://example.org/verbatimID/6> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/6> ;
+    sosa:hasResult <http://createme.org/verbatimID/6> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -257,12 +257,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/7> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/7> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/7> ;
-    sosa:hasResult <http://example.org/verbatimID/7> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/7> ;
+    sosa:hasResult <http://createme.org/verbatimID/7> ;
     sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -270,12 +270,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-21"^^xsd:date .
 
-<http://example.org/observation/verbatimID/8> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/8> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/8> ;
-    sosa:hasResult <http://example.org/verbatimID/8> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/8> ;
+    sosa:hasResult <http://createme.org/verbatimID/8> ;
     sosa:hasSimpleResult "Caladenia excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -283,12 +283,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
-<http://example.org/observation/verbatimID/9> a tern:Observation ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/observation/verbatimID/9> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/specimen/9> ;
-    sosa:hasResult <http://example.org/verbatimID/9> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/9> ;
+    sosa:hasResult <http://createme.org/verbatimID/9> ;
     sosa:hasSimpleResult "Caladenia excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:phenomenonTime [ a time:Instant ;
@@ -296,493 +296,493 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
-<http://example.org/attribute/identificationQualifier/10> a tern:Attribute ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/attribute/identificationQualifier/10> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
     tern:hasSimpleValue "?" ;
-    tern:hasValue <http://example.org/value/identificationQualifier/10> .
+    tern:hasValue <http://createme.org/value/identificationQualifier/10> .
 
-<http://example.org/attribute/identificationRemarks/10> a tern:Attribute ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/attribute/identificationRemarks/10> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
     tern:hasSimpleValue "One unopened flower when recorded and one leaf only. ID not cofirmed" ;
-    tern:hasValue <http://example.org/value/identificationRemarks/10> .
+    tern:hasValue <http://createme.org/value/identificationRemarks/10> .
 
-<http://example.org/sampling/field/0> a tern:Sampling ;
+<http://createme.org/sampling/field/0> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.21, -33.80)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/0> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/0> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2019-09-24"^^xsd:date .
 
-<http://example.org/sampling/field/1> a tern:Sampling ;
+<http://createme.org/sampling/field/1> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.01, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/1> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/1> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/10> a tern:Sampling ;
+<http://createme.org/sampling/field/10> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.02, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/10> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/10> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
-<http://example.org/sampling/field/2> a tern:Sampling ;
+<http://createme.org/sampling/field/2> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.01, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/2> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/2> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/3> a tern:Sampling ;
+<http://createme.org/sampling/field/3> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.01, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/3> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/3> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/4> a tern:Sampling ;
+<http://createme.org/sampling/field/4> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(114.99, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/4> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/4> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/5> a tern:Sampling ;
+<http://createme.org/sampling/field/5> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(114.99, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/5> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/5> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/6> a tern:Sampling ;
+<http://createme.org/sampling/field/6> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(114.99, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/6> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/6> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/7> a tern:Sampling ;
+<http://createme.org/sampling/field/7> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(114.99, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/7> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/7> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/field/8> a tern:Sampling ;
+<http://createme.org/sampling/field/8> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.02, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/8> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/8> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
-<http://example.org/sampling/field/9> a tern:Sampling ;
+<http://createme.org/sampling/field/9> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "POINT(115.02, -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "field-sampling" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/sample/field/9> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/sample/field/9> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
-<http://example.org/sampling/specimen/0> a tern:Sampling ;
+<http://createme.org/sampling/specimen/0> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/0> ;
-    sosa:hasResult <http://example.org/sample/specimen/0> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/0> ;
+    sosa:hasResult <http://createme.org/sample/specimen/0> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2019-09-24"^^xsd:date .
 
-<http://example.org/sampling/specimen/1> a tern:Sampling ;
+<http://createme.org/sampling/specimen/1> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/1> ;
-    sosa:hasResult <http://example.org/sample/specimen/1> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/1> ;
+    sosa:hasResult <http://createme.org/sample/specimen/1> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/10> a tern:Sampling ;
+<http://createme.org/sampling/specimen/10> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/10> ;
-    sosa:hasResult <http://example.org/sample/specimen/10> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/10> ;
+    sosa:hasResult <http://createme.org/sample/specimen/10> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
-<http://example.org/sampling/specimen/2> a tern:Sampling ;
+<http://createme.org/sampling/specimen/2> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/2> ;
-    sosa:hasResult <http://example.org/sample/specimen/2> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/2> ;
+    sosa:hasResult <http://createme.org/sample/specimen/2> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/3> a tern:Sampling ;
+<http://createme.org/sampling/specimen/3> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/3> ;
-    sosa:hasResult <http://example.org/sample/specimen/3> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/3> ;
+    sosa:hasResult <http://createme.org/sample/specimen/3> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/4> a tern:Sampling ;
+<http://createme.org/sampling/specimen/4> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/4> ;
-    sosa:hasResult <http://example.org/sample/specimen/4> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/4> ;
+    sosa:hasResult <http://createme.org/sample/specimen/4> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/5> a tern:Sampling ;
+<http://createme.org/sampling/specimen/5> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/5> ;
-    sosa:hasResult <http://example.org/sample/specimen/5> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/5> ;
+    sosa:hasResult <http://createme.org/sample/specimen/5> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/6> a tern:Sampling ;
+<http://createme.org/sampling/specimen/6> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/6> ;
-    sosa:hasResult <http://example.org/sample/specimen/6> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/6> ;
+    sosa:hasResult <http://createme.org/sample/specimen/6> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/7> a tern:Sampling ;
+<http://createme.org/sampling/specimen/7> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/7> ;
-    sosa:hasResult <http://example.org/sample/specimen/7> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/7> ;
+    sosa:hasResult <http://createme.org/sample/specimen/7> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
-<http://example.org/sampling/specimen/8> a tern:Sampling ;
+<http://createme.org/sampling/specimen/8> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/8> ;
-    sosa:hasResult <http://example.org/sample/specimen/8> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/8> ;
+    sosa:hasResult <http://createme.org/sample/specimen/8> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
-<http://example.org/sampling/specimen/9> a tern:Sampling ;
+<http://createme.org/sampling/specimen/9> a tern:Sampling ;
     rdfs:comment "specimen-sampling" ;
-    sosa:hasFeatureOfInterest <http://example.org/sample/field/9> ;
-    sosa:hasResult <http://example.org/sample/specimen/9> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/9> ;
+    sosa:hasResult <http://createme.org/sample/specimen/9> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
-<http://example.org/scientificName/Calothamnus-lateralis-var-crassus> a tern:FeatureOfInterest,
+<http://createme.org/scientificName/Calothamnus-lateralis-var-crassus> a tern:FeatureOfInterest,
         tern:Text,
         tern:Value ;
     rdfs:label "scientificName" ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdf:value "Calothamnus lateralis var. crassus" ;
-    tern:featureType <http://example.org/concept/scientificName> .
+    tern:featureType <http://createme.org/concept/scientificName> .
 
-<http://example.org/site-establishment/Cowaramup-Bay-Road> a tern:Sampling ;
+<http://createme.org/site-establishment/Cowaramup-Bay-Road> a tern:Sampling ;
     rdfs:comment "site-establishment" ;
-    prov:wasAssociatedWith <http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://example.org/site/Cowaramup-Bay-Road> ;
-    sosa:hasResult <http://example.org/site/Cowaramup-Bay-Road> ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/site/Cowaramup-Bay-Road> ;
+    sosa:hasResult <http://createme.org/site/Cowaramup-Bay-Road> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/a1685655-f8e2-46ee-9a74-767c648b54f4> ;
     tern:resultDateTime "2019-09-24"^^xsd:date .
 
-<http://example.org/site-landform/Cowaramup-Bay-Road> a tern:FeatureOfInterest ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+<http://createme.org/site-landform/Cowaramup-Bay-Road> a tern:FeatureOfInterest ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> .
 
-<http://example.org/value/identificationQualifier/10> a tern:Text,
+<http://createme.org/value/identificationQualifier/10> a tern:Text,
         tern:Value ;
     rdf:value "?" .
 
-<http://example.org/value/identificationRemarks/10> a tern:Text,
+<http://createme.org/value/identificationRemarks/10> a tern:Text,
         tern:Value ;
     rdf:value "One unopened flower when recorded and one leaf only. ID not cofirmed" .
 
-<http://example.org/verbatimID/0> a tern:Text,
+<http://createme.org/verbatimID/0> a tern:Text,
         tern:Value ;
     rdf:value "Calothamnus lateralis var. crassus" .
 
-<http://example.org/verbatimID/1> a tern:Text,
+<http://createme.org/verbatimID/1> a tern:Text,
         tern:Value ;
     rdf:value "Boronia anceps" .
 
-<http://example.org/verbatimID/10> a tern:Text,
+<http://createme.org/verbatimID/10> a tern:Text,
         tern:Value ;
     rdf:value "Caladenia ?excelsa" ;
-    tern:hasAttribute <http://example.org/attribute/identificationQualifier/10>,
-        <http://example.org/attribute/identificationRemarks/10> .
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/10>,
+        <http://createme.org/attribute/identificationRemarks/10> .
 
-<http://example.org/verbatimID/2> a tern:Text,
+<http://createme.org/verbatimID/2> a tern:Text,
         tern:Value ;
     rdf:value "Boronia anceps" .
 
-<http://example.org/verbatimID/3> a tern:Text,
+<http://createme.org/verbatimID/3> a tern:Text,
         tern:Value ;
     rdf:value "Boronia anceps" .
 
-<http://example.org/verbatimID/4> a tern:Text,
+<http://createme.org/verbatimID/4> a tern:Text,
         tern:Value ;
     rdf:value "Banksia sessilis var. cordata" .
 
-<http://example.org/verbatimID/5> a tern:Text,
+<http://createme.org/verbatimID/5> a tern:Text,
         tern:Value ;
     rdf:value "Banksia sessilis var. cordata" .
 
-<http://example.org/verbatimID/6> a tern:Text,
+<http://createme.org/verbatimID/6> a tern:Text,
         tern:Value ;
     rdf:value "Banksia sessilis var. cordata" .
 
-<http://example.org/verbatimID/7> a tern:Text,
+<http://createme.org/verbatimID/7> a tern:Text,
         tern:Value ;
     rdf:value "Banksia sessilis var. cordata" .
 
-<http://example.org/verbatimID/8> a tern:Text,
+<http://createme.org/verbatimID/8> a tern:Text,
         tern:Value ;
     rdf:value "Caladenia excelsa" .
 
-<http://example.org/verbatimID/9> a tern:Text,
+<http://createme.org/verbatimID/9> a tern:Text,
         tern:Value ;
     rdf:value "Caladenia excelsa" .
 
-<http://example.org/sample/field/0> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/0> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/0> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/0> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/1> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/1> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/1> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/1> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/10> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/10> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/10> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/10> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/2> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/2> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/2> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/2> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/3> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/3> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/3> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/3> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/4> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/4> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/4> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/4> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/5> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/5> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/5> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/5> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/6> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/6> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/6> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/6> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/7> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/7> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/7> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/7> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/8> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/8> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/8> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/8> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/field/9> a tern:FeatureOfInterest,
+<http://createme.org/sample/field/9> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://example.org/sampling/field/9> ;
-    sosa:isSampleOf <http://example.org/site/Cowaramup-Bay-Road> ;
+    sosa:isResultOf <http://createme.org/sampling/field/9> ;
+    sosa:isSampleOf <http://createme.org/site/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://example.org/sample/specimen/0> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/0> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/0> ;
-    sosa:isSampleOf <http://example.org/sample/field/0> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/0> ;
+    sosa:isSampleOf <http://createme.org/sample/field/0> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/1> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/1> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/1> ;
-    sosa:isSampleOf <http://example.org/sample/field/1> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/1> ;
+    sosa:isSampleOf <http://createme.org/sample/field/1> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/10> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/10> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/10> ;
-    sosa:isSampleOf <http://example.org/sample/field/10> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/10> ;
+    sosa:isSampleOf <http://createme.org/sample/field/10> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/2> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/2> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/2> ;
-    sosa:isSampleOf <http://example.org/sample/field/2> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/2> ;
+    sosa:isSampleOf <http://createme.org/sample/field/2> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/3> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/3> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/3> ;
-    sosa:isSampleOf <http://example.org/sample/field/3> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/3> ;
+    sosa:isSampleOf <http://createme.org/sample/field/3> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/4> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/4> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/4> ;
-    sosa:isSampleOf <http://example.org/sample/field/4> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/4> ;
+    sosa:isSampleOf <http://createme.org/sample/field/4> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/5> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/5> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/5> ;
-    sosa:isSampleOf <http://example.org/sample/field/5> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/5> ;
+    sosa:isSampleOf <http://createme.org/sample/field/5> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/6> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/6> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/6> ;
-    sosa:isSampleOf <http://example.org/sample/field/6> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/6> ;
+    sosa:isSampleOf <http://createme.org/sample/field/6> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/7> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/7> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/7> ;
-    sosa:isSampleOf <http://example.org/sample/field/7> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/7> ;
+    sosa:isSampleOf <http://createme.org/sample/field/7> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/8> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/8> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/8> ;
-    sosa:isSampleOf <http://example.org/sample/field/8> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/8> ;
+    sosa:isSampleOf <http://createme.org/sample/field/8> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/sample/specimen/9> a tern:FeatureOfInterest,
+<http://createme.org/sample/specimen/9> a tern:FeatureOfInterest,
         tern:Sample ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://example.org/sampling/specimen/9> ;
-    sosa:isSampleOf <http://example.org/sample/field/9> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/9> ;
+    sosa:isSampleOf <http://createme.org/sample/field/9> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
-<http://example.org/scientificName/Boronia-anceps> a tern:FeatureOfInterest,
+<http://createme.org/scientificName/Boronia-anceps> a tern:FeatureOfInterest,
         tern:Text,
         tern:Value ;
     rdfs:label "scientificName" ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdf:value "Boronia anceps" ;
-    tern:featureType <http://example.org/concept/scientificName> .
+    tern:featureType <http://createme.org/concept/scientificName> .
 
-<http://example.org/scientificName/Caladenia-excelsa> a tern:FeatureOfInterest,
+<http://createme.org/scientificName/Caladenia-excelsa> a tern:FeatureOfInterest,
         tern:Text,
         tern:Value ;
     rdfs:label "scientificName" ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdf:value "Caladenia excelsa" ;
-    tern:featureType <http://example.org/concept/scientificName> .
+    tern:featureType <http://createme.org/concept/scientificName> .
 
-<http://example.org/scientificName/Banksia-sessilis-var-cordata> a tern:FeatureOfInterest,
+<http://createme.org/scientificName/Banksia-sessilis-var-cordata> a tern:FeatureOfInterest,
         tern:Text,
         tern:Value ;
     rdfs:label "scientificName" ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdf:value "Banksia sessilis var. cordata" ;
-    tern:featureType <http://example.org/concept/scientificName> .
+    tern:featureType <http://createme.org/concept/scientificName> .
 
-<http://example.org/site/Cowaramup-Bay-Road> a tern:FeatureOfInterest,
+<http://createme.org/site/Cowaramup-Bay-Road> a tern:FeatureOfInterest,
         tern:Sample,
         tern:Site ;
-    void:inDataset <http://example.org/dataset/Example-DWC-MVP-Dataset> ;
-    sosa:isResultOf <http://example.org/site-establishment/Cowaramup-Bay-Road> ;
-    sosa:isSampleOf <http://example.org/site-landform/Cowaramup-Bay-Road> ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    sosa:isResultOf <http://createme.org/site-establishment/Cowaramup-Bay-Road> ;
+    sosa:isSampleOf <http://createme.org/site-landform/Cowaramup-Bay-Road> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
-<http://example.org/provider/Stream-Environment-and-Water-Pty-Ltd> a prov:Agent,
+<http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> a prov:Agent,
         prov:Organization ;
     foaf:name "Stream Environment and Water Pty Ltd" .
 
-<http://example.org/dataset/Example-DWC-MVP-Dataset> a tern:RDFDataset ;
+<http://createme.org/dataset/Example-DWC-MVP-Dataset> a tern:RDFDataset ;
     dcterms:description "Example DWC MVP Dataset by Gaia Resources" ;
-    dcterms:issued "2022-04-06"^^xsd:date ;
+    dcterms:issued "2022-04-08"^^xsd:date ;
     dcterms:title "Example DWC MVP Dataset" .

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -12,6 +12,9 @@ import rdflib
 from abis_mapping import base
 from abis_mapping import utils
 
+# Typing
+from typing import Optional
+
 
 # Temporary Metadata
 # The mappings need a method of retrieving dataset "metadata" external to the
@@ -85,13 +88,13 @@ class DWCMVPMapper(base.mapper.ABISMapper):
     def apply_mapping(
         self,
         data: base.types.ReadableType,
-        base_iri: rdflib.Namespace = utils.namespaces.EXAMPLE,
+        base_iri: Optional[rdflib.Namespace] = None,
     ) -> rdflib.Graph:
         """Applies Mapping for the `dwc_mvp.csv` Template
 
         Args:
             data (base.types.ReadableType): Valid raw data to be mapped.
-            base_iri (rdflib.Namespace): Base IRI namespace to use for mapping.
+            base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
 
         Returns:
             rdflib.Graph: ABIS Conformant RDF Graph.
@@ -146,8 +149,8 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         provider_identified = utils.rdf.uri(f"provider/{row['identifiedBy']}", base_iri)
         provider_recorded = utils.rdf.uri(f"provider/{row['recordedBy']}", base_iri)
         site = utils.rdf.uri(f"site/{row['locality']}", base_iri)
-        site_landform = utils.rdf.uri(f"site-landform/{row['locality']}", base_iri)  # TODO -> Under investigation
-        site_establishment = utils.rdf.uri(f"site-establishment/{row['locality']}", base_iri)  # TODO -> Under investigation
+        site_landform = utils.rdf.uri(f"site-landform/{row['locality']}", base_iri)  # TODO -> Not final
+        site_establishment = utils.rdf.uri(f"site-establishment/{row['locality']}", base_iri)  # TODO -> Not final
         sample_field = utils.rdf.uri(f"sample/field/{row_number}", base_iri)
         sampling_field = utils.rdf.uri(f"sampling/field/{row_number}", base_iri)
         sample_specimen = utils.rdf.uri(f"sample/specimen/{row_number}", base_iri)

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -85,11 +85,13 @@ class DWCMVPMapper(base.mapper.ABISMapper):
     def apply_mapping(
         self,
         data: base.types.ReadableType,
+        base_iri: rdflib.Namespace = utils.namespaces.EXAMPLE,
     ) -> rdflib.Graph:
         """Applies Mapping for the `dwc_mvp.csv` Template
 
         Args:
             data (base.types.ReadableType): Valid raw data to be mapped.
+            base_iri (rdflib.Namespace): Base IRI namespace to use for mapping.
 
         Returns:
             rdflib.Graph: ABIS Conformant RDF Graph.
@@ -106,7 +108,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         graph = utils.rdf.create_graph()
 
         # Create Dataset
-        dataset = utils.rdf.uri(f"dataset/{DATASET_NAME}")
+        dataset = utils.rdf.uri(f"dataset/{DATASET_NAME}", namespace=base_iri)
         graph.add((dataset, a, utils.namespaces.TERN.RDFDataset))
         graph.add((dataset, rdflib.DCTERMS.title, rdflib.Literal(DATASET_NAME)))
         graph.add((dataset, rdflib.DCTERMS.description, rdflib.Literal(DATASET_DESCRIPTION)))
@@ -115,7 +117,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         # Loop through Rows
         for row_number, row in enumerate(resource):
             # Map Row
-            self.apply_mapping_row(row, row_number, dataset, graph)
+            self.apply_mapping_row(row, row_number, dataset, graph, base_iri)
 
         # Return
         return graph
@@ -126,6 +128,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         row_number: int,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace,
     ) -> rdflib.Graph:
         """Applies Mapping for a Row in the `dwc_mvp.csv` Template
 
@@ -134,28 +137,29 @@ class DWCMVPMapper(base.mapper.ABISMapper):
             row_number (int): Row number to be processed.
             dataset (rdflib.URIRef): Dataset uri this row is apart of.
             graph (rdflib.Graph): Graph to map row into.
+            base_iri (rdflib.Namespace): Base IRI namespace to use for mapping.
 
         Returns:
             rdflib.Graph: Graph with row mapped into it.
         """
         # Create URIs
-        provider_identified = utils.rdf.uri(f"provider/{row['identifiedBy']}")
-        provider_recorded = utils.rdf.uri(f"provider/{row['recordedBy']}")
-        site = utils.rdf.uri(f"site/{row['locality']}")
-        site_landform = utils.rdf.uri(f"site-landform/{row['locality']}")  # TODO -> Under investigation
-        site_establishment = utils.rdf.uri(f"site-establishment/{row['locality']}")  # TODO -> Under investigation
-        sample_field = utils.rdf.uri(f"sample/field/{row_number}")
-        sampling_field = utils.rdf.uri(f"sampling/field/{row_number}")
-        sample_specimen = utils.rdf.uri(f"sample/specimen/{row_number}")
-        sampling_specimen = utils.rdf.uri(f"sampling/specimen/{row_number}")
-        text_scientific_name = utils.rdf.uri(f"scientificName/{row['scientificName']}")
-        text_verbatim_id = utils.rdf.uri(f"verbatimID/{row_number}")
-        observation_scientific_name = utils.rdf.uri(f"observation/scientificName/{row_number}")
-        observation_verbatim_id = utils.rdf.uri(f"observation/verbatimID/{row_number}")
-        id_qualifier_attribute = utils.rdf.uri(f"attribute/identificationQualifier/{row_number}")
-        id_qualifier_value = utils.rdf.uri(f"value/identificationQualifier/{row_number}")
-        id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{row_number}")
-        id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{row_number}")
+        provider_identified = utils.rdf.uri(f"provider/{row['identifiedBy']}", base_iri)
+        provider_recorded = utils.rdf.uri(f"provider/{row['recordedBy']}", base_iri)
+        site = utils.rdf.uri(f"site/{row['locality']}", base_iri)
+        site_landform = utils.rdf.uri(f"site-landform/{row['locality']}", base_iri)  # TODO -> Under investigation
+        site_establishment = utils.rdf.uri(f"site-establishment/{row['locality']}", base_iri)  # TODO -> Under investigation
+        sample_field = utils.rdf.uri(f"sample/field/{row_number}", base_iri)
+        sampling_field = utils.rdf.uri(f"sampling/field/{row_number}", base_iri)
+        sample_specimen = utils.rdf.uri(f"sample/specimen/{row_number}", base_iri)
+        sampling_specimen = utils.rdf.uri(f"sampling/specimen/{row_number}", base_iri)
+        text_scientific_name = utils.rdf.uri(f"scientificName/{row['scientificName']}", base_iri)
+        text_verbatim_id = utils.rdf.uri(f"verbatimID/{row_number}", base_iri)
+        observation_scientific_name = utils.rdf.uri(f"observation/scientificName/{row_number}", base_iri)
+        observation_verbatim_id = utils.rdf.uri(f"observation/verbatimID/{row_number}", base_iri)
+        id_qualifier_attribute = utils.rdf.uri(f"attribute/identificationQualifier/{row_number}", base_iri)
+        id_qualifier_value = utils.rdf.uri(f"value/identificationQualifier/{row_number}", base_iri)
+        id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{row_number}", base_iri)
+        id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{row_number}", base_iri)
 
         # Add Providers
         self.add_provider(

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -108,7 +108,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         graph = utils.rdf.create_graph()
 
         # Create Dataset
-        dataset = utils.rdf.uri(f"dataset/{DATASET_NAME}", namespace=base_iri)
+        dataset = utils.rdf.uri(f"dataset/{DATASET_NAME}", base_iri)
         graph.add((dataset, a, utils.namespaces.TERN.RDFDataset))
         graph.add((dataset, rdflib.DCTERMS.title, rdflib.Literal(DATASET_NAME)))
         graph.add((dataset, rdflib.DCTERMS.description, rdflib.Literal(DATASET_DESCRIPTION)))

--- a/abis_mapping/utils/namespaces.py
+++ b/abis_mapping/utils/namespaces.py
@@ -5,8 +5,10 @@
 import rdflib
 
 
+# Default Base IRI Namespace
+CREATEME = rdflib.Namespace("http://createme.org/")
+
 # Namespaces
 GEO = rdflib.Namespace("http://www.opengis.net/ont/geosparql#")
 TERN = rdflib.Namespace("https://w3id.org/tern/ontologies/tern/")
 DWC = rdflib.Namespace("http://rs.tdwg.org/dwc/terms/")
-EXAMPLE = rdflib.Namespace("http://example.org/")

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -45,7 +45,7 @@ def create_graph() -> rdflib.Graph:
 
 def uri(
     internal_id: Optional[str] = None,
-    namespace: rdflib.Namespace = namespaces.EXAMPLE,
+    namespace: Optional[rdflib.Namespace] = None,
 ) -> rdflib.URIRef:
     """Generates an rdflib.URIRef using the EXAMPLE namespace
 
@@ -54,7 +54,7 @@ def uri(
 
     Args:
         internal_id (Optional[str]): Optional human readable id.
-        namespace (rdflib.Namespace): Namespace for the uri.
+        namespace (Optional[rdflib.Namespace]): Optional namespace for the uri.
 
     Returns:
         rdflib.URIRef: Generated URI for internal usage.
@@ -63,6 +63,11 @@ def uri(
     if internal_id is None:
         # Generate a UUID
         internal_id = str(uuid.uuid4())
+
+    # Check for namespace
+    if namespace is None:
+        # Set Default Namespace
+        namespace = namespaces.EXAMPLE
 
     # Slugify
     # We split and re-join on the `/`, as forward-slashes are valid for our

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -47,7 +47,7 @@ def uri(
     internal_id: Optional[str] = None,
     namespace: Optional[rdflib.Namespace] = None,
 ) -> rdflib.URIRef:
-    """Generates an rdflib.URIRef using the EXAMPLE namespace
+    """Generates an rdflib.URIRef using the supplied namespace
 
     The internal id is sanitised (slugified), or if not a provided a uuidv4 is
     generated instead.
@@ -67,7 +67,7 @@ def uri(
     # Check for namespace
     if namespace is None:
         # Set Default Namespace
-        namespace = namespaces.EXAMPLE
+        namespace = namespaces.CREATEME
 
     # Slugify
     # We split and re-join on the `/`, as forward-slashes are valid for our


### PR DESCRIPTION
## Description
* Currently, mapping always uses the `example.org/` base IRI for mapping
* This PR adds *optional* argument `base_iri` to `apply_mapping()` method
* Intended usage is for user to pass `createme.org/`, `deleteme.org/`, `updateme.org/` etc. for a flexible base IRI when mapping
* This will be required down the track, and will fix issue discovered in BDR-490