### PR TITLE
BDR-497: Add base method to retrieve template filepath

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -61,6 +61,22 @@ class ABISMapper(abc.ABC):
     @final
     @classmethod
     @functools.lru_cache
+    def template(cls) -> pathlib.Path:
+        """Retrieves and Caches the Template Filepath
+
+        Returns:
+            pathlib.Path: Filepath for this Template
+        """
+        # Retrieve Template Filepath
+        directory = pathlib.Path(inspect.getfile(cls)).parent
+        template_file = directory / cls.template_id  # Template File is the Template ID
+
+        # Return
+        return template_file
+
+    @final
+    @classmethod
+    @functools.lru_cache
     def metadata(cls) -> dict[str, Any]:
         """Retrieves and Caches the Template Metadata for this Template
 


### PR DESCRIPTION
## Description
* Adds base `.template()` method to retrieve the `pathlib.Path` filepath of the template file for a mapper
* Usage:
  ```python
  import abis_mapping  # same as before
  mapper = abis_mapping.get_mapper("dwc_mvp.csv")  # same as before
  template_file = mapper.template()  # retrieve template filepath
  ```