### PR TITLE
BDR-523: Add initial instructions functionality

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -25,8 +25,9 @@ class ABISMapper(abc.ABC):
     # ABIS Mapper Registry
     registry: dict[str, type["ABISMapper"]] = {}
 
-    # ABIS Mapper Template ID
+    # ABIS Mapper Template ID and Instructions File
     template_id: str = NotImplemented  # Must be implemented
+    instructions_file: str = NotImplemented  # Must be implemented
 
     @abc.abstractmethod
     def apply_validation(
@@ -105,6 +106,22 @@ class ABISMapper(abc.ABC):
 
         # Read Schema and Return
         return json.loads(schema_file.read_text())  # type: ignore[no-any-return]
+
+    @final
+    @classmethod
+    @functools.lru_cache
+    def instructions(cls) -> pathlib.Path:
+        """Retrieves and Caches the Template Instructions
+
+        Returns:
+            pathlib.Path: Filepath for this Template's Instructions
+        """
+        # Retrieve Template Filepath
+        directory = pathlib.Path(inspect.getfile(cls)).parent
+        instructions_file = directory / cls.instructions_file
+
+        # Return
+        return instructions_file
 
     @final
     @classmethod

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -45,8 +45,9 @@ CONCEPT_SCIENTIFIC_NAME = utils.rdf.uri("concept/scientificName")  # TODO -> Nee
 class DWCMVPMapper(base.mapper.ABISMapper):
     """ABIS Mapper for `dwc_mvp.csv`"""
 
-    # Template ID
+    # Template ID and Instructions File
     template_id = "dwc_mvp.csv"
+    instructions_file = "README.md"
 
     def apply_validation(
         self,

--- a/abis_mapping/templates/dwc_mvp/metadata.json
+++ b/abis_mapping/templates/dwc_mvp/metadata.json
@@ -3,5 +3,6 @@
     "description": "A template to translate some Darwin Core fields",
     "version": "0.0.1",
     "template_url": "https://raw.githubusercontent.com/gaiaresources/abis-mapping/main/abis_mapping/templates/dwc_mvp/dwc_mvp.csv",
-    "schema_url": "https://raw.githubusercontent.com/gaiaresources/abis-mapping/main/abis_mapping/templates/dwc_mvp/schema.json"
+    "schema_url": "https://raw.githubusercontent.com/gaiaresources/abis-mapping/main/abis_mapping/templates/dwc_mvp/schema.json",
+    "instructions_url": "https://raw.githubusercontent.com/gaiaresources/abis-mapping/main/abis_mapping/templates/dwc_mvp/README.md"
 }

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -49,6 +49,7 @@ def test_base_get_template() -> None:
     assert real_mapper is not None
     template = real_mapper.template()
     assert isinstance(template, pathlib.Path)
+    assert template.is_file()
 
 
 def test_base_get_metadata() -> None:
@@ -67,3 +68,13 @@ def test_base_get_schema() -> None:
     assert real_mapper is not None
     schema = real_mapper.schema()
     assert isinstance(schema, dict)
+
+
+def test_base_get_instructions() -> None:
+    """Tests the functionality of the base mapper"""
+    # Test Real Template ID
+    real_mapper = base.mapper.get_mapper(TEMPLATE_ID_REAL)
+    assert real_mapper is not None
+    instructions = real_mapper.instructions()
+    assert isinstance(instructions, pathlib.Path)
+    assert instructions.is_file()


### PR DESCRIPTION
### Description
* Mapper implementations must now supply a `instructions_file: str` class attribute
* Mapper base class provides a `.instructions()` class method to retrieve a path to instructions file for the template
* Set `dwc_mvp.csv` instructions to its `README.md` for now
* Added unit tests