### PR TITLE
BDR-500: Add dataset IRI argument to mapping interface

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -47,12 +47,14 @@ class ABISMapper(abc.ABC):
     def apply_mapping(
         self,
         data: types.ReadableType,
+        dataset_iri: Optional[rdflib.URIRef] = None,
         base_iri: Optional[rdflib.Namespace] = None,
     ) -> rdflib.Graph:
         """Applies Mapping from Raw Data to ABIS conformant RDF.
 
         Args:
             data (ReadableType): Readable raw data.
+            dataset_iri (Optional[rdflib.URIRef]): Optional dataset IRI.
             base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
 
         Returns:


### PR DESCRIPTION
## Description
* Adds `dataset_iri: Optional[rdflib.URIRef]` argument to `.apply_mapping()` interface
* This will allow us to optionally pre-generate the `tern:RDFDataset` using submission form metadata
* Otherwise, if not provided the functionality remains the same as before (default "Example" values are generated and used)