### PR TITLE
BDR-525: More mapping updates, new utils and improved unit tests

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,5 +9,8 @@ warn_unused_ignores = True
 no_implicit_optional = True
 show_error_codes = True
 
+[mypy-tests.*]
+ignore_missing_imports = True
+
 [mypy-frictionless.*]
 ignore_missing_imports = True

--- a/abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.csv
+++ b/abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.csv
@@ -10,3 +10,4 @@ Cowaramup Bay Road,-33.86,114.99,2020-09-21,Stream Environment and Water Pty Ltd
 Cowaramup Bay Road,-33.86,115.02,2020-09-23,Stream Environment and Water Pty Ltd,Caladenia excelsa,2019-09-23,Stream Environment and Water Pty Ltd,Caladenia excelsa,,
 Cowaramup Bay Road,-33.86,115.02,2020-09-23,Stream Environment and Water Pty Ltd,Caladenia excelsa,2019-09-23,Stream Environment and Water Pty Ltd,Caladenia excelsa,,
 Cowaramup Bay Road,-33.86,115.02,2020-09-23,Stream Environment and Water Pty Ltd,Caladenia ?excelsa,2019-09-23,Stream Environment and Water Pty Ltd,Caladenia excelsa,?,One unopened flower when recorded and one leaf only. ID not cofirmed
+Cowaramup Bay Road,-33.80,115.21,2019-09-24,Stream Environment and Water Pty Ltd,Caladenia ?excelsa,,Stream Environment and Water Pty Ltd,Caladenia excelsa,species incerta,no flowers present

--- a/abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -49,6 +49,23 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
+<http://createme.org/observation/scientificName/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/11> ;
+    sosa:hasResult <http://createme.org/scientificName/11> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:phenomenonTime,
+                tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
 <http://createme.org/observation/scientificName/2> a tern:Observation ;
     void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "scientificName-observation" ;
@@ -192,6 +209,23 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
     tern:resultDateTime "2019-09-23"^^xsd:date .
 
+<http://createme.org/observation/verbatimID/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/11> ;
+    sosa:hasResult <http://createme.org/verbatimID/11> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:phenomenonTime,
+                tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
 <http://createme.org/observation/verbatimID/2> a tern:Observation ;
     void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "verbatimID-observation" ;
@@ -302,11 +336,23 @@
     tern:hasSimpleValue "?" ;
     tern:hasValue <http://createme.org/value/identificationQualifier/10> .
 
+<http://createme.org/attribute/identificationQualifier/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "species incerta" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/11> .
+
 <http://createme.org/attribute/identificationRemarks/10> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
     tern:hasSimpleValue "One unopened flower when recorded and one leaf only. ID not cofirmed" ;
     tern:hasValue <http://createme.org/value/identificationRemarks/10> .
+
+<http://createme.org/attribute/identificationRemarks/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "no flowers present" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/11> .
 
 <http://createme.org/sampling/field/0> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
@@ -337,6 +383,16 @@
     sosa:hasResult <http://createme.org/sample/field/10> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/11> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.21 -33.80)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/11> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
 
 <http://createme.org/sampling/field/2> a tern:Sampling ;
     geo:hasGeometry [ a geo:Geometry ;
@@ -419,80 +475,183 @@
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
 <http://createme.org/sampling/specimen/0> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.21 -33.80)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/0> ;
     sosa:hasResult <http://createme.org/sample/specimen/0> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
     tern:resultDateTime "2019-09-24"^^xsd:date .
 
 <http://createme.org/sampling/specimen/1> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/1> ;
     sosa:hasResult <http://createme.org/sample/specimen/1> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/10> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/10> ;
     sosa:hasResult <http://createme.org/sample/specimen/10> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ] ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
+<http://createme.org/sampling/specimen/11> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.21 -33.80)"^^geo:wktLiteral ] ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
+    sosa:hasResult <http://createme.org/sample/specimen/11> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
 <http://createme.org/sampling/specimen/2> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/2> ;
     sosa:hasResult <http://createme.org/sample/specimen/2> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/3> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/3> ;
     sosa:hasResult <http://createme.org/sample/specimen/3> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/4> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/4> ;
     sosa:hasResult <http://createme.org/sample/specimen/4> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/5> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/5> ;
     sosa:hasResult <http://createme.org/sample/specimen/5> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/6> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/6> ;
     sosa:hasResult <http://createme.org/sample/specimen/6> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/7> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/7> ;
     sosa:hasResult <http://createme.org/sample/specimen/7> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
     tern:resultDateTime "2020-09-21"^^xsd:date .
 
 <http://createme.org/sampling/specimen/8> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/8> ;
     sosa:hasResult <http://createme.org/sample/specimen/8> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
 <http://createme.org/sampling/specimen/9> a tern:Sampling ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/9> ;
     sosa:hasResult <http://createme.org/sample/specimen/9> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location inferred from the field sampling" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date inferred from the eventDate" ] ;
     tern:resultDateTime "2020-09-23"^^xsd:date .
 
 <http://createme.org/scientificName/0> a tern:FeatureOfInterest,
@@ -512,6 +671,14 @@
     tern:featureType <http://createme.org/concept/scientificName> .
 
 <http://createme.org/scientificName/10> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://createme.org/concept/scientificName> .
+
+<http://createme.org/scientificName/11> a tern:FeatureOfInterest,
         tern:Text,
         tern:Value ;
     rdfs:label "scientificName" ;
@@ -587,9 +754,17 @@
         tern:Value ;
     rdf:value "?" .
 
+<http://createme.org/value/identificationQualifier/11> a tern:Text,
+        tern:Value ;
+    rdf:value "species incerta" .
+
 <http://createme.org/value/identificationRemarks/10> a tern:Text,
         tern:Value ;
     rdf:value "One unopened flower when recorded and one leaf only. ID not cofirmed" .
+
+<http://createme.org/value/identificationRemarks/11> a tern:Text,
+        tern:Value ;
+    rdf:value "no flowers present" .
 
 <http://createme.org/verbatimID/0> a tern:Text,
         tern:Value ;
@@ -604,6 +779,12 @@
     rdf:value "Caladenia ?excelsa" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/10>,
         <http://createme.org/attribute/identificationRemarks/10> .
+
+<http://createme.org/verbatimID/11> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/11>,
+        <http://createme.org/attribute/identificationRemarks/11> .
 
 <http://createme.org/verbatimID/2> a tern:Text,
         tern:Value ;
@@ -658,6 +839,14 @@
     void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
     rdfs:comment "field-sample" ;
     sosa:isResultOf <http://createme.org/sampling/field/10> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/11> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/11> ;
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
@@ -749,6 +938,14 @@
     sosa:isSampleOf <http://createme.org/sample/field/10> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
 
+<http://createme.org/sample/specimen/11> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/11> ;
+    sosa:isSampleOf <http://createme.org/sample/field/11> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> .
+
 <http://createme.org/sample/specimen/2> a tern:FeatureOfInterest,
         tern:Sample ;
     void:inDataset <http://createme.org/dataset/Example-DWC-MVP-Dataset> ;
@@ -824,6 +1021,6 @@
 
 <http://createme.org/dataset/Example-DWC-MVP-Dataset> a tern:RDFDataset ;
     dcterms:description "Example DWC MVP Dataset by Gaia Resources" ;
-    dcterms:issued "2022-05-04"^^xsd:date ;
+    dcterms:issued "2022-05-07"^^xsd:date ;
     dcterms:title "Example DWC MVP Dataset" .
 

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -118,7 +118,7 @@ class DWCMVPMapper(base.mapper.ABISMapper):
             graph.add((dataset_iri, rdflib.DCTERMS.issued, rdflib.Literal(datetime.date.today())))
 
         # Create Terminal FOI (Australia)
-        australia = utils.rdf.uri("location/Australia")
+        australia = utils.rdf.uri("location/Australia", base_iri)
         geometry = rdflib.BNode()
         graph.add((australia, a, utils.namespaces.TERN.FeatureOfInterest))
         graph.add((australia, utils.namespaces.GEO.hasGeometry, geometry))

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -174,13 +174,15 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{row_number}", base_iri)
         id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{row_number}", base_iri)
 
-        # Add Providers
-        self.add_provider(
+        # Add Provider Identified By
+        self.add_provider_identified(
             uri=provider_identified,
             row=row,
             graph=graph,
         )
-        self.add_provider(
+
+        # Add Provider Recorded By
+        self.add_provider_recorded(
             uri=provider_recorded,
             row=row,
             graph=graph,
@@ -297,13 +299,13 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         # Return
         return graph
 
-    def add_provider(
+    def add_provider_identified(
         self,
         uri: rdflib.URIRef,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
-        """Adds Provider to the Graph
+        """Adds Identified By Provider to the Graph
 
         Args:
             uri (rdflib.URIRef): URI to use for this node.
@@ -313,6 +315,23 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         # Add to Graph
         graph.add((uri, a, rdflib.PROV.Agent))
         graph.add((uri, rdflib.FOAF.name, rdflib.Literal(row["identifiedBy"])))
+
+    def add_provider_recorded(
+        self,
+        uri: rdflib.URIRef,
+        row: frictionless.Row,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Adds Recorded By Provider to the Graph
+
+        Args:
+            uri (rdflib.URIRef): URI to use for this node.
+            row (frictionless.Row): Row to retrieve data from
+            graph (rdflib.Graph): Graph to add to
+        """
+        # Add to Graph
+        graph.add((uri, a, rdflib.PROV.Agent))
+        graph.add((uri, rdflib.FOAF.name, rdflib.Literal(row["recordedBy"])))
 
     def add_observation_scientific_name(
         self,
@@ -356,14 +375,15 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         graph.add((uri, utils.namespaces.TERN.resultDateTime, rdflib.Literal(timestamp)))
         graph.add((uri, rdflib.SOSA.usedProcedure, CONCEPT_PROCEDURE_ID))
 
-        # TODO: Waiting for: https://github.com/ternaustralia/ontology_tern/issues/176
-        # # Check
-        # if not row["dateIdentified"]:
-        #     qualifier = rdflib.BNode()
-        #     graph.add((uri, utils.namespaces.TERN.qualifiedValue, qualifier))
-        #     graph.add((qualifier, rdflib.RDF.value, utils.namespaces.TERN.resultDateTime))
-        #     graph.add((qualifier, rdflib.RDF.value, rdflib.SOSA.phenomenonTime))
-        #     graph.add((qualifier, rdflib.RDFS.comment, rdflib.Literal("Date inferred from the eventDate")))
+        # Check for dateIdentified
+        if not row["dateIdentified"]:
+            # Add Temporal Qualifier
+            temporal_qualifier = rdflib.BNode()
+            graph.add((uri, utils.namespaces.TERN.qualifiedValue, temporal_qualifier))
+            graph.add((temporal_qualifier, a, rdflib.RDF.Statement))
+            graph.add((temporal_qualifier, rdflib.RDF.value, utils.namespaces.TERN.resultDateTime))
+            graph.add((temporal_qualifier, rdflib.RDF.value, rdflib.SOSA.phenomenonTime))
+            graph.add((temporal_qualifier, rdflib.RDFS.comment, rdflib.Literal("Date inferred from the eventDate")))
 
     def add_observation_verbatim_id(
         self,
@@ -406,14 +426,15 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         graph.add((uri, utils.namespaces.TERN.resultDateTime, rdflib.Literal(timestamp)))
         graph.add((uri, rdflib.SOSA.usedProcedure, CONCEPT_PROCEDURE_ID))
 
-        # TODO: Waiting for: https://github.com/ternaustralia/ontology_tern/issues/176
-        # # Check
-        # if not row["dateIdentified"]:
-        #     qualifier = rdflib.BNode()
-        #     graph.add((uri, utils.namespaces.TERN.qualifiedValue, qualifier))
-        #     graph.add((qualifier, rdflib.RDF.value, utils.namespaces.TERN.resultDateTime))
-        #     graph.add((qualifier, rdflib.RDF.value, rdflib.SOSA.phenomenonTime))
-        #     graph.add((qualifier, rdflib.RDFS.comment, rdflib.Literal("Date inferred from the eventDate")))
+        # Check for dateIdentified
+        if not row["dateIdentified"]:
+            # Add Temporal Qualifier
+            temporal_qualifier = rdflib.BNode()
+            graph.add((uri, utils.namespaces.TERN.qualifiedValue, temporal_qualifier))
+            graph.add((temporal_qualifier, a, rdflib.RDF.Statement))
+            graph.add((temporal_qualifier, rdflib.RDF.value, utils.namespaces.TERN.resultDateTime))
+            graph.add((temporal_qualifier, rdflib.RDF.value, rdflib.SOSA.phenomenonTime))
+            graph.add((temporal_qualifier, rdflib.RDFS.comment, rdflib.Literal("Date inferred from the eventDate")))
 
     def add_sampling_field(
         self,
@@ -436,11 +457,8 @@ class DWCMVPMapper(base.mapper.ABISMapper):
                 node
             graph (rdflib.Graph): Graph to add to
         """
-        # Create WKT from Lat/Long
-        wkt = rdflib.Literal(
-            f"POINT ({row['decimalLongitude']} {row['decimalLatitude']})",
-            datatype=utils.namespaces.GEO.wktLiteral,
-        )
+        # Create WKT from Latitude and Longitude
+        wkt = utils.rdf.toWKT(row["decimalLatitude"], row["decimalLongitude"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Sampling))
@@ -593,18 +611,34 @@ class DWCMVPMapper(base.mapper.ABISMapper):
                 this node
             graph (rdflib.Graph): Graph to add to
         """
+        # Create WKT from Latitude and Longitude
+        wkt = utils.rdf.toWKT(row["decimalLatitude"], row["decimalLongitude"])
+
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Sampling))
         graph.add((uri, rdflib.RDFS.comment, rdflib.Literal("specimen-sampling")))
         graph.add((uri, rdflib.SOSA.hasFeatureOfInterest, sample_field))
         graph.add((uri, rdflib.SOSA.hasResult, sample_specimen))
-        graph.add((uri, utils.namespaces.TERN.resultDateTime, rdflib.Literal(row["eventDate"])))
-        # TODO: Waiting for: https://github.com/ternaustralia/ontology_tern/issues/176
-        # qualifier = rdflib.BNode()
-        # graph.add((uri, utils.namespaces.TERN.qualifiedValue, qualifier))
-        # graph.add((qualifier, rdflib.RDF.value, utils.namespaces.TERN.resultDateTime))
-        # graph.add((qualifier, rdflib.RDFS.comment, rdflib.Literal("Date inferred from the eventDate")))
         graph.add((uri, rdflib.SOSA.usedProcedure, CONCEPT_PROCEDURE_SAMPLING))
+        graph.add((uri, utils.namespaces.TERN.resultDateTime, rdflib.Literal(row["eventDate"])))
+        geometry = rdflib.BNode()
+        graph.add((uri, utils.namespaces.GEO.hasGeometry, geometry))
+        graph.add((geometry, a, utils.namespaces.GEO.Geometry))
+        graph.add((geometry, utils.namespaces.GEO.asWKT, wkt))
+
+        # Add Temporal Qualifier
+        temporal_qualifier = rdflib.BNode()
+        graph.add((uri, utils.namespaces.TERN.qualifiedValue, temporal_qualifier))
+        graph.add((temporal_qualifier, a, rdflib.RDF.Statement))
+        graph.add((temporal_qualifier, rdflib.RDF.value, utils.namespaces.TERN.resultDateTime))
+        graph.add((temporal_qualifier, rdflib.RDFS.comment, rdflib.Literal("Date inferred from the eventDate")))
+
+        # Add Spatial Qualifier
+        spatial_qualifier = rdflib.BNode()
+        graph.add((uri, utils.namespaces.TERN.qualifiedValue, spatial_qualifier))
+        graph.add((spatial_qualifier, a, rdflib.RDF.Statement))
+        graph.add((spatial_qualifier, rdflib.RDF.value, utils.namespaces.GEO.hasGeometry))
+        graph.add((spatial_qualifier, rdflib.RDFS.comment, rdflib.Literal("Location inferred from the field sampling")))
 
     def add_text_verbatim_id(
         self,

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -98,3 +98,20 @@ def inXSDSmart(timestamp: types.DateOrDatetime) -> rdflib.URIRef:
 
     # inXSDDate
     return rdflib.TIME.inXSDDate
+
+
+def toWKT(latitude: float, longitude: float) -> rdflib.Literal:
+    """Generates a Literal WKT Point Representation of Latitude and Longitude.
+
+    Args:
+        latitude (float): Latitude to generate WKT.
+        longitude (float): Longitude to generate WKT.
+
+    Returns:
+        rdflib.Literal: Literal WKT Point.
+    """
+    # Create and Return WKT from Latitude and Longitude
+    return rdflib.Literal(
+        f"POINT ({longitude} {latitude})",
+        datatype=namespaces.GEO.wktLiteral,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Provides Fixtures and Helpers for the Unit Tests"""
+
+
+# Third-Party
+import rdflib
+import rdflib.compare
+
+# Typing
+from typing import Union
+
+
+def compare_graphs(
+    graph1: Union[rdflib.Graph, str],
+    graph2: Union[rdflib.Graph, str],
+) -> bool:
+    """Isomorphically compares to graphs for equality.
+
+    Args:
+        graph1 (Union[rdflib.Graph, str]): Graph or Turtle String to Compare
+        graph2 (Union[rdflib.Graph, str]): Graph or Turtle String to Compare
+
+    Returns:
+        bool: Whether the graphs are isomorphically equivalent.
+    """
+    # Check and Parse Graphs if Applicable
+    if isinstance(graph1, str):
+        graph1 = rdflib.Graph().parse(data=graph1, format="text/turtle")
+    if isinstance(graph2, str):
+        graph2 = rdflib.Graph().parse(data=graph2, format="text/turtle")
+
+    # Asserts
+    assert isinstance(graph1, rdflib.Graph)
+    assert isinstance(graph2, rdflib.Graph)
+
+    # Replace Timestamps
+    # In many cases, dates and datetimes are generately systematically as a
+    # timestamp for "now". When unit testing, we don't care if "now" has
+    # changed when comparing graphs. As such, we want to replace all literals
+    # with a datatype `xsd:date`, `xsd:dateTime` or `xsd:dateTimeStamp` with a
+    # pre-generate value.
+    for graph in (graph1, graph2):
+        for (s, p, o) in graph.triples((None, None, None)):
+            if isinstance(o, rdflib.Literal):
+                if o.datatype in (rdflib.XSD.date, rdflib.XSD.dateTime, rdflib.XSD.dateTimeStamp):
+                    graph.set((s, p, rdflib.Literal("test-value")))
+
+    # Compare Graphs
+    return rdflib.compare.isomorphic(  # type: ignore[no-any-return]
+        graph1=graph1,
+        graph2=graph2,
+    )

--- a/tests/templates/test_dwc_mvp.py
+++ b/tests/templates/test_dwc_mvp.py
@@ -3,24 +3,25 @@
 
 # Standard
 import pathlib
-import re
 
 # Local
 import abis_mapping
+import tests.conftest
 
 
 # Constants
-TEMPLATE = "dwc_mvp.csv"
-DATA_DIR = pathlib.Path("abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/")
+TEMPLATE_ID = "dwc_mvp.csv"
+DATA = pathlib.Path("abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.csv")
+EXPECTED = pathlib.Path("abis_mapping/templates/dwc_mvp/examples/margaret_river_flora/margaret_river_flora.ttl")
 
 
 def test_validation() -> None:
     """Tests the validation for the template"""
     # Load Data
-    data = (DATA_DIR / "margaret_river_flora.csv").read_bytes()
+    data = DATA.read_bytes()
 
     # Get Mapper
-    mapper = abis_mapping.get_mapper(TEMPLATE)
+    mapper = abis_mapping.get_mapper(TEMPLATE_ID)
     assert mapper
 
     # Validate
@@ -31,19 +32,18 @@ def test_validation() -> None:
 def test_mapping() -> None:
     """Tests the mapping for the template"""
     # Load Data and Expected Output
-    data = (DATA_DIR / "margaret_river_flora.csv").read_bytes()
-    output = (DATA_DIR / "margaret_river_flora.ttl").read_text()
+    data = DATA.read_bytes()
+    expected = EXPECTED.read_text()
 
     # Get Mapper
-    mapper = abis_mapping.get_mapper(TEMPLATE)
+    mapper = abis_mapping.get_mapper(TEMPLATE_ID)
     assert mapper
 
     # Map
     graph = mapper().apply_mapping(data)
-    result = graph.serialize(format="ttl")
 
-    # Everything should currently match except for the `dcterms:issued` date
-    # The following code replaces that line with regex
-    result = re.sub(r"dcterms:issued.+", "test", result)
-    output = re.sub(r"dcterms:issued.+", "test", output)
-    assert result == output
+    # Compare Graphs
+    assert tests.conftest.compare_graphs(
+        graph1=graph,
+        graph2=expected,
+    )

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -50,3 +50,16 @@ def test_rdf_inXSDSmart() -> None:
     time = datetime.datetime.now()
     predicate = utils.rdf.inXSDSmart(time)
     assert predicate == rdflib.TIME.inXSDDateTimeStamp
+
+
+def test_rdf_toWKT() -> None:
+    """Tests the toWKT() Function"""
+    # Test Lat and Long
+    wkt = utils.rdf.toWKT(
+        latitude=-31.953512,
+        longitude=115.857048,
+    )
+    assert wkt == rdflib.Literal(
+        "POINT (115.857048 -31.953512)",
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )


### PR DESCRIPTION
## Description
### Features & Additions
* Fixed two small bugs:
  * Terminal FeatureOfInterest IRI generation was missing optional alternate `base_iri` argument
  * Correctly separated the generation of `identifiedBy` and `recordedBy` provider IRIs
* Updated mapping to match the latest expected model provided in BDR-525
  * Updated unit test data to match changes
* Added new `utils.rdf.toWKT()` function
  * Generates `rdflib.Literal` WKT objects from a latitude and longitude
  * Added unit test for the new `utils.rdf.toWKT()` function

### Refactors & Improvements
* Fixed `mypy` falsely flagging the `tests` module with import errors
* Added new `tests.conftest.compare_graphs()` unit test helper function
  * Helps compare graphs for isomorphic equality, considering different format and different systematically generated datetimes
* Updated `margaret_river_flora.csv` with new row purposely missing the `dateIdentified` for better unit testing