### PR TITLE
BDR-621: Initial pass of lazy iterator chunking interface

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -16,7 +16,7 @@ import rdflib
 from . import types
 
 # Typing
-from typing import Any, Optional, final
+from typing import Any, Iterator, Optional, final
 
 
 class ABISMapper(abc.ABC):
@@ -47,18 +47,20 @@ class ABISMapper(abc.ABC):
     def apply_mapping(
         self,
         data: types.ReadableType,
+        chunk_size: Optional[int] = None,
         dataset_iri: Optional[rdflib.URIRef] = None,
         base_iri: Optional[rdflib.Namespace] = None,
-    ) -> rdflib.Graph:
+    ) -> Iterator[rdflib.Graph]:
         """Applies Mapping from Raw Data to ABIS conformant RDF.
 
         Args:
             data (ReadableType): Readable raw data.
+            chunk_size (Optional[int]): Optional number of rows to chunk into.
             dataset_iri (Optional[rdflib.URIRef]): Optional dataset IRI.
             base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
 
-        Returns:
-            rdflib.Graph: ABIS Conformant RDF Graph.
+        Yields:
+            rdflib.Graph: ABIS Conformant RDF Sub-Graph from Raw Data Chunk.
         """
 
     @final

--- a/abis_mapping/templates/dwc_mvp/mapping.py
+++ b/abis_mapping/templates/dwc_mvp/mapping.py
@@ -13,7 +13,7 @@ from abis_mapping import base
 from abis_mapping import utils
 
 # Typing
-from typing import Optional
+from typing import Iterator, Optional
 
 
 # Default Dataset Metadata
@@ -84,9 +84,10 @@ class DWCMVPMapper(base.mapper.ABISMapper):
     def apply_mapping(
         self,
         data: base.types.ReadableType,
+        chunk_size: Optional[int] = None,
         dataset_iri: Optional[rdflib.URIRef] = None,
         base_iri: Optional[rdflib.Namespace] = None,
-    ) -> rdflib.Graph:
+    ) -> Iterator[rdflib.Graph]:
         """Applies Mapping for the `dwc_mvp.csv` Template
 
         Args:
@@ -94,8 +95,8 @@ class DWCMVPMapper(base.mapper.ABISMapper):
             dataset_iri (Optional[rdflib.URIRef]): Optional dataset IRI.
             base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
 
-        Returns:
-            rdflib.Graph: ABIS Conformant RDF Graph.
+        Yields:
+            rdflib.Graph: ABIS Conformant RDF Sub-Graph from Raw Data Chunk.
         """
         # Construct Resource (Table with Schema)
         resource = frictionless.Resource(
@@ -104,6 +105,10 @@ class DWCMVPMapper(base.mapper.ABISMapper):
             schema=self.schema(),
             onerror="raise",  # Raise errors, it should already be valid here
         )
+
+        # Infer Statistics and Count Number of Rows
+        resource.infer(stats=True)
+        rows = resource.stats["rows"]
 
         # Initialise Graph
         graph = utils.rdf.create_graph()
@@ -131,6 +136,14 @@ class DWCMVPMapper(base.mapper.ABISMapper):
         for row_number, row in enumerate(resource):
             # Map Row
             self.apply_mapping_row(row, row_number, dataset_iri, australia, graph, base_iri)
+
+            # Check Whether to Yield a Chunk
+            if utils.chunking.should_chunk(row, rows, chunk_size):
+                # Yield Chunk
+                yield graph
+
+                # Initialise New Graph
+                graph = utils.rdf.create_graph()
 
         # Return
         return graph

--- a/abis_mapping/utils/__init__.py
+++ b/abis_mapping/utils/__init__.py
@@ -2,6 +2,7 @@
 
 # Local
 from . import checks
+from . import chunking
 from . import coords
 from . import namespaces
 from . import plugin

--- a/abis_mapping/utils/chunking.py
+++ b/abis_mapping/utils/chunking.py
@@ -1,0 +1,39 @@
+"""Provides chunking utilities for the package"""
+
+
+# Third-Party
+import frictionless
+
+# Typing
+from typing import Optional
+
+
+def should_chunk(
+    row: frictionless.Row,
+    rows: int,
+    chunk_size: Optional[int] = None,
+) -> bool:
+    """Determines whether a mapper should chunk at this row.
+
+    Args:
+        row (frictionless.Row): The row that has just been mapped.
+        rows (int): The total number of rows in the raw data.
+        chunk_size (Optional[int]): The optional size to chunk at.
+
+    Returns:
+        bool: Whether chunking should occur.
+    """
+    # Normalize Chunk Size
+    if (chunk_size is None) or (chunk_size < 1) or (chunk_size > rows):
+        # If `chunk_size` is not provided, an integer less than one is provided
+        # or an integer greater than the total number of rows is provided, then
+        # the behaviour is to "not chunk", or more accurately just provide a
+        # single chunk. As such, set the chunk size to the total number of rows
+        # so that the chunking will only occur on the final row.
+        chunk_size = rows
+
+    # Check and Return
+    return (  # type: ignore[no-any-return]
+        row.row_number % chunk_size == 0  # Check if chunk-boundary reached
+        or row.row_number == rows  # Must always chunk at the last row
+    )

--- a/tests/templates/test_dwc_mvp.py
+++ b/tests/templates/test_dwc_mvp.py
@@ -40,10 +40,13 @@ def test_mapping() -> None:
     assert mapper
 
     # Map
-    graph = mapper().apply_mapping(data)
+    graphs = list(mapper().apply_mapping(data))
+
+    # Assert
+    assert len(graphs) == 1
 
     # Compare Graphs
     assert tests.conftest.compare_graphs(
-        graph1=graph,
+        graph1=graphs[0],
         graph2=expected,
     )

--- a/tests/utils/test_chunking.py
+++ b/tests/utils/test_chunking.py
@@ -1,0 +1,67 @@
+"""Provides Unit Tests for the `abis_mapping.utils.chunking` module"""
+
+
+# Third-Party
+import frictionless
+import pytest
+
+# Local
+from abis_mapping import utils
+
+# Typing
+from typing import Optional
+
+
+@pytest.mark.parametrize(
+    [
+        "rows",
+        "row_number",
+        "chunk_size",
+        "result",
+    ],
+    [
+        # Regular Usage
+        (100, 1, 7, False),
+        (100, 7, 7, True),
+        (100, 14, 7, True),
+        (100, 99, 7, False),
+        (100, 100, 7, True),
+        # Edge Cases (Chunk Size: 1, None, 0, -1, 999)
+        (100, 1, 1, True),
+        (100, 2, 1, True),
+        (100, 3, 1, True),
+        (100, 1, None, False),
+        (100, 100, None, True),
+        (100, 1, 0, False),
+        (100, 100, 0, True),
+        (100, 1, -1, False),
+        (100, 100, -1, True),
+        (100, 1, 999, False),
+        (100, 100, 999, True),
+    ]
+)
+def test_chunking_should_chunk(
+    rows: int,
+    row_number: int,
+    chunk_size: Optional[int],
+    result: bool,
+) -> None:
+    """Tests the `should_chunk()` Utility Function.
+
+    Args:
+        rows (int): Total number of rows in the "resource" to test
+        row_number (int): Row number to test
+        chunk_size (Optional[int]): Chunk size to test
+        result (bool): Expected result of whether to perform a chunk
+    """
+    # Test `should_chunk()`
+    assert utils.chunking.should_chunk(
+        row=frictionless.Row(
+            cells={},  # We don't need any cells for this unit test
+            field_info={},  # We don't need any field info for this unit test
+            row_number=row_number,  # Set the row number as specified
+            row_position=row_number,  # Set the row position as specified
+        ),
+        rows=rows,
+        chunk_size=chunk_size,
+    ) is result


### PR DESCRIPTION
## Description
* Changes `ABISMapper.apply_mapping()` interface to return an `Iterator[rdflib.Graph]` instead of just `rdflib.Graph`
* Added argument `chunk_size: Optional[int]` to `ABISMapper.apply_mapping()` to specify chunk size
* Implementors are expected to provide a lazy iterator interface for mappers
* Added `utils.chunking.should_chunk()` utility function to determine when to yield a chunk