### PR TITLE
BDRC-67: Frictionless Mutual Inclusion Plugin & Custom Checks Refactor

### DIFF
--- a/abis_mapping/plugins/__init__.py
+++ b/abis_mapping/plugins/__init__.py
@@ -1,6 +1,9 @@
 """Exports sub-package interface"""
 
 # Local
-from . import checks
+from . import coordinates
+from . import empty
 from . import list
+from . import mutual_inclusion
+from . import tabular
 from . import timestamp

--- a/abis_mapping/plugins/coordinates.py
+++ b/abis_mapping/plugins/coordinates.py
@@ -1,4 +1,4 @@
-"""Provides extra frictionless checks for the package"""
+"""Provides extra frictionless coordinate validation checks for the package"""
 
 
 # Third-Party
@@ -63,47 +63,4 @@ class ValidCoordinates(frictionless.Check):
             yield frictionless.errors.RowConstraintError.from_row(
                 row=row,
                 note="the specified coordinates are not within the allowed boundaries",
-            )
-
-
-class NotEmpty(frictionless.Check):
-    """Checks whether the resource has at least 1 row."""
-
-    # Check Attributes
-    code = "not-empty"
-    Errors = [frictionless.errors.TableDimensionsError]
-
-    def validate_end(self) -> Iterator[frictionless.Error]:
-        """Called to validate the resource before closing.
-
-        Yields:
-            frictionless.Error: If the table is empty.
-        """
-        # Check Number of Rows
-        if not self.resource.stats.get("rows"):
-            # Yield Error
-            yield frictionless.errors.TableDimensionsError(
-                note="Current number of rows is 0, the minimum is 1",
-                limits={"minRows": 1, "numberRows": 0},
-            )
-
-
-class NotTabular(frictionless.Check):
-    """Checks whether the resource is at least tabular data in nature."""
-
-    # Check Attributes
-    code = "not-tabular"
-    Errors = [frictionless.errors.SourceError]
-
-    def validate_start(self) -> Iterator[frictionless.Error]:
-        """Called to validate the resource after opening
-
-        Yields:
-            frictionless.Error: If the resource is not tabular data.
-        """
-        # Check if tabular
-        if not self.resource.tabular:
-            # Yield Error
-            yield frictionless.errors.SourceError(
-                note="the source is not tabular data",
             )

--- a/abis_mapping/plugins/empty.py
+++ b/abis_mapping/plugins/empty.py
@@ -1,0 +1,30 @@
+"""Provides extra frictionless empty data checks for the package"""
+
+
+# Third-Party
+import frictionless
+
+# Typing
+from typing import Iterator
+
+
+class NotEmpty(frictionless.Check):
+    """Checks whether the resource has at least 1 row."""
+
+    # Check Attributes
+    code = "not-empty"
+    Errors = [frictionless.errors.TableDimensionsError]
+
+    def validate_end(self) -> Iterator[frictionless.Error]:
+        """Called to validate the resource before closing.
+
+        Yields:
+            frictionless.Error: If the table is empty.
+        """
+        # Check Number of Rows
+        if not self.resource.stats.get("rows"):
+            # Yield Error
+            yield frictionless.errors.TableDimensionsError(
+                note="Current number of rows is 0, the minimum is 1",
+                limits={"minRows": 1, "numberRows": 0},
+            )

--- a/abis_mapping/plugins/mutual_inclusion.py
+++ b/abis_mapping/plugins/mutual_inclusion.py
@@ -1,0 +1,58 @@
+"""Provides extra frictionless mutual inclusion checks for the package"""
+
+
+# Third-Party
+import frictionless
+
+# Typing
+from typing import Any, Iterator
+
+
+class MutuallyInclusive(frictionless.Check):
+    """Checks whether mutually inclusive columns are provided together."""
+
+    # Check Attributes
+    code = "mutually-inclusive"
+    Errors = [frictionless.errors.RowConstraintError]
+
+    def __init__(
+        self,
+        descriptor: Any = None,
+        *,
+        field_names: list[str],
+    ) -> None:
+        """Instantiate the MutuallyInclusive Checker"""
+        # Initialise Super Class
+        super().__init__(descriptor)
+
+        # Instance Attributes
+        self.__field_names = field_names
+
+    def validate_row(self, row: frictionless.Row) -> Iterator[frictionless.Error]:
+        """Called to validate the given row (on every row).
+
+        Args:
+            row (frictionless.Row): The row to check the mutual inclusion of.
+
+        Yields:
+            frictionless.Error: For when the mutual inclusion is violated.
+        """
+        # Retrieve Field Names for Missing Cells
+        missing = [f for f in self.__field_names if not row[f]]
+
+        # Check Mutual Inclusivity
+        # Either none of the cells must be missing, or all of them must be
+        # missing, which is checked below by comparing the number of missing
+        # cells against the expected number of cells
+        if len(missing) in (0, len(self.__field_names)):
+            # Short-circuit
+            return
+
+        # Yield Error
+        yield frictionless.errors.RowConstraintError.from_row(
+            row=row,
+            note=(
+                f"the columns {self.__field_names} are mutually inclusive and must be provided together "
+                f"(columns {missing} are missing)"
+            ),
+        )

--- a/abis_mapping/plugins/tabular.py
+++ b/abis_mapping/plugins/tabular.py
@@ -1,0 +1,29 @@
+"""Provides extra frictionless tabular checks for the package"""
+
+
+# Third-Party
+import frictionless
+
+# Typing
+from typing import Iterator
+
+
+class NotTabular(frictionless.Check):
+    """Checks whether the resource is at least tabular data in nature."""
+
+    # Check Attributes
+    code = "not-tabular"
+    Errors = [frictionless.errors.SourceError]
+
+    def validate_start(self) -> Iterator[frictionless.Error]:
+        """Called to validate the resource after opening
+
+        Yields:
+            frictionless.Error: If the resource is not tabular data.
+        """
+        # Check if tabular
+        if not self.resource.tabular:
+            # Yield Error
+            yield frictionless.errors.SourceError(
+                note="the source is not tabular data",
+            )

--- a/abis_mapping/templates/occurrence_data/mapping.py
+++ b/abis_mapping/templates/occurrence_data/mapping.py
@@ -82,9 +82,9 @@ class OccurrenceDataMapper(base.mapper.ABISMapper):
         report: frictionless.Report = resource.validate(
             checks=[
                 # Extra Custom Checks
-                plugins.checks.NotTabular(),
-                plugins.checks.NotEmpty(),
-                plugins.checks.ValidCoordinates(
+                plugins.tabular.NotTabular(),
+                plugins.empty.NotEmpty(),
+                plugins.coordinates.ValidCoordinates(
                     latitude_name="decimalLatitude",
                     longitude_name="decimalLongitude",
                 ),

--- a/abis_mapping/templates/occurrence_extended/mapping.py
+++ b/abis_mapping/templates/occurrence_extended/mapping.py
@@ -82,12 +82,15 @@ class OccurrenceExtendedMapper(base.mapper.ABISMapper):
         report: frictionless.Report = resource.validate(
             checks=[
                 # Extra Custom Checks
-                plugins.checks.NotTabular(),
-                plugins.checks.NotEmpty(),
-                plugins.checks.ValidCoordinates(
+                plugins.tabular.NotTabular(),
+                plugins.empty.NotEmpty(),
+                plugins.coordinates.ValidCoordinates(
                     latitude_name="decimalLatitude",
                     longitude_name="decimalLongitude",
                 ),
+                plugins.mutual_inclusion.MutuallyInclusive(
+                    field_names=["threatStatus", "conservationJurisdiction"],
+                )
             ]
         )
 

--- a/tests/plugins/test_coordinates.py
+++ b/tests/plugins/test_coordinates.py
@@ -1,4 +1,4 @@
-"""Provides Unit Tests for the `abis_mapping.plugins.checks` module"""
+"""Provides Unit Tests for the `abis_mapping.plugins.coordinates` module"""
 
 
 # Third-Party
@@ -29,48 +29,10 @@ def test_checks_valid_coordinates() -> None:
     # Validate
     report: frictionless.Report = resource.validate(
         checks=[
-            plugins.checks.ValidCoordinates(
+            plugins.coordinates.ValidCoordinates(
                 latitude_name="lat",
                 longitude_name="lon",
             ),
-        ]
-    )
-
-    # Check
-    assert not report.valid
-    assert len(report.flatten()) == 1
-
-
-def test_checks_not_empty() -> None:
-    """Tests the NotEmpty Checker"""
-    # Construct Fake Resource
-    resource = frictionless.Resource(
-        source=__file__,
-    )
-
-    # Validate
-    report: frictionless.Report = resource.validate(
-        checks=[
-            plugins.checks.NotEmpty(),
-        ]
-    )
-
-    # Check
-    assert not report.valid
-    assert len(report.flatten()) == 1
-
-
-def test_checks_not_tabular() -> None:
-    """Tests the NotTabular Checker"""
-    # Construct Fake Resource
-    resource = frictionless.Resource(
-        source=__file__,
-    )
-
-    # Validate
-    report: frictionless.Report = resource.validate(
-        checks=[
-            plugins.checks.NotTabular(),
         ]
     )
 

--- a/tests/plugins/test_empty.py
+++ b/tests/plugins/test_empty.py
@@ -1,0 +1,27 @@
+"""Provides Unit Tests for the `abis_mapping.plugins.empty` module"""
+
+
+# Third-Party
+import frictionless
+
+# Local
+from abis_mapping import plugins
+
+
+def test_checks_not_empty() -> None:
+    """Tests the NotEmpty Checker"""
+    # Construct Fake Resource
+    resource = frictionless.Resource(
+        source=__file__,
+    )
+
+    # Validate
+    report: frictionless.Report = resource.validate(
+        checks=[
+            plugins.empty.NotEmpty(),
+        ]
+    )
+
+    # Check
+    assert not report.valid
+    assert len(report.flatten()) == 1

--- a/tests/plugins/test_mutual_inclusion.py
+++ b/tests/plugins/test_mutual_inclusion.py
@@ -1,0 +1,40 @@
+"""Provides Unit Tests for the `abis_mapping.plugins.mutual_inclusion` module"""
+
+
+# Third-Party
+import frictionless
+
+# Local
+from abis_mapping import plugins
+
+
+def test_checks_mutually_inclusive() -> None:
+    """Tests the MutuallyInclusive Checker"""
+    # Construct Fake Resource
+    resource = frictionless.Resource(
+        source=[
+            # Valid
+            {"a": "A", "b": "B", "c": "C"},
+            {"a": "A", "b": "B", "c": None},
+            {"a": None, "b": None, "c": "C"},
+
+            # Invalid
+            {"a": None, "b": "B", "c": "C"},
+            {"a": None, "b": "B", "c": None},
+            {"a": "A", "b": None, "c": "C"},
+            {"a": "A", "b": None, "c": None},
+        ],
+    )
+
+    # Validate
+    report: frictionless.Report = resource.validate(
+        checks=[
+            plugins.mutual_inclusion.MutuallyInclusive(
+                field_names=["a", "b"],
+            ),
+        ]
+    )
+
+    # Check
+    assert not report.valid
+    assert len(report.flatten()) == 4

--- a/tests/plugins/test_tabular.py
+++ b/tests/plugins/test_tabular.py
@@ -1,0 +1,27 @@
+"""Provides Unit Tests for the `abis_mapping.plugins.tabular` module"""
+
+
+# Third-Party
+import frictionless
+
+# Local
+from abis_mapping import plugins
+
+
+def test_checks_not_tabular() -> None:
+    """Tests the NotTabular Checker"""
+    # Construct Fake Resource
+    resource = frictionless.Resource(
+        source=__file__,
+    )
+
+    # Validate
+    report: frictionless.Report = resource.validate(
+        checks=[
+            plugins.tabular.NotTabular(),
+        ]
+    )
+
+    # Check
+    assert not report.valid
+    assert len(report.flatten()) == 1


### PR DESCRIPTION
## Summary
* Adds `plugins.mutual_inclusion` with the `MutuallyInclusive` Frictionless checker
    * This checker allows the user to specify fields that _must_ be provided together
* Adds the `MutuallyInclusive` checker to `occurrence_extended.csv` for `threatStatus` and `conservationJurisdiction`
     * As per Mieke in BDRC-42 / BDRC-67, these fields must be provided together or not at all
* Refactors the `plugins.checks` module to (moves checkers into their own modules):
    * `plugin.coordinates` - for coordinate checking plugin
    * `plugin.empty` - empty dataset checking plugin
    * `plugin.tabular` - for tabular dataset checking plugin
* Adds and refactors unit tests for checking plugins