### PR TITLE
BDRC-66: Vocab Improvements

### DIFF
--- a/abis_mapping/templates/occurrence_extended/schema.json
+++ b/abis_mapping/templates/occurrence_extended/schema.json
@@ -477,10 +477,9 @@
         "required": false,
         "enum": [
           "EPBC",
+          "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION",
           "WA",
           "WESTERN AUSTRALIA",
-          "WESTERN-AUSTRALIA",
-          "WESTERN_AUSTRALIA",
           "QLD",
           "QUEENSLAND"
         ]

--- a/abis_mapping/utils/__init__.py
+++ b/abis_mapping/utils/__init__.py
@@ -5,6 +5,7 @@ from . import chunking
 from . import coords
 from . import namespaces
 from . import rdf
+from . import strings
 from . import timestamps
 from . import types
 from . import vocabs

--- a/abis_mapping/utils/strings.py
+++ b/abis_mapping/utils/strings.py
@@ -1,0 +1,25 @@
+"""Provides string utilities for the package"""
+
+
+# Standard
+import re
+
+
+# Constants
+REGEX_STRIP = re.compile(
+    pattern=r"[\W_]+",
+    flags=re.IGNORECASE | re.UNICODE,
+)
+
+
+def sanitise(value: str) -> str:
+    """Capitalises and strips all non-alphanumeric characters from a string.
+
+    Args:
+        value (str): String to be stripped and capitalised
+
+    Returns:
+        str: The stripped and capitalised string
+    """
+    # Strip, Capitalise and Return
+    return REGEX_STRIP.sub("", value.upper())

--- a/abis_mapping/utils/strings.py
+++ b/abis_mapping/utils/strings.py
@@ -22,4 +22,4 @@ def sanitise(value: str) -> str:
         str: The stripped and capitalised string
     """
     # Strip, Capitalise and Return
-    return REGEX_STRIP.sub("", value.upper())
+    return REGEX_STRIP.sub("", value).upper()

--- a/abis_mapping/utils/vocabs.py
+++ b/abis_mapping/utils/vocabs.py
@@ -6,6 +6,7 @@ import rdflib
 
 # Local
 from . import rdf
+from . import strings
 
 # Typing
 from typing import Optional, Iterable
@@ -28,7 +29,7 @@ class Term:
             iri: rdflib.URIRef: IRI for the vicabulary term.
         """
         # Set Instance Attributes
-        self.labels = tuple(label.upper() for label in labels)  # Uppercase
+        self.labels = tuple(strings.sanitise(label) for label in labels)  # Sanitise
         self.iri = iri
 
     def to_mapping(self) -> dict[str, rdflib.URIRef]:
@@ -49,8 +50,8 @@ class Term:
         Returns:
             bool: Whether the value matches this term.
         """
-        # Check and Return
-        return value.upper() in self.labels
+        # Sanitise, Check and Return
+        return strings.sanitise(value) in self.labels
 
 
 class RestrictedVocabulary:
@@ -86,8 +87,11 @@ class RestrictedVocabulary:
             VocabularyError: Raised if supplied value does not match an
                 existing vocabulary term.
         """
+        # Sanitise Value
+        sanitised_value = strings.sanitise(value)
+
         # Retrieve if Applicable
-        if iri := self.mapping.get(value.upper()):  # Uppercase
+        if iri := self.mapping.get(sanitised_value):
             # Return
             return iri
 
@@ -168,8 +172,11 @@ class FlexibleVocabulary:
             VocabularyError: Raised if a value is not supplied and there is no
                 default fall-back value in the vocabulary.
         """
+        # Sanitise Value if Applicable
+        sanitised_value = strings.sanitise(value) if value else None
+
         # Retrieve if Applicable
-        if iri := self.mapping.get(value.upper() if value else None):  # Uppercase
+        if iri := self.mapping.get(sanitised_value):
             # Return
             return iri
 

--- a/abis_mapping/vocabs/basis_of_record.py
+++ b/abis_mapping/vocabs/basis_of_record.py
@@ -10,7 +10,7 @@ from abis_mapping import utils
 
 # Terms
 HUMAN_OBSERVATION = utils.vocabs.Term(
-    labels=("HUMAN OBSERVATION", "HUMANOBSERVATION", "HUMAN_OBSERVATION", "HUMAN-OBSERVATION"),
+    labels=("HUMAN OBSERVATION", ),
     iri=utils.rdf.uri("basisOfRecord/HumanObservation", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 OCCURRENCE = utils.vocabs.Term(
@@ -18,23 +18,23 @@ OCCURRENCE = utils.vocabs.Term(
     iri=utils.rdf.uri("basisOfRecord/Occurrence", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 PRESERVED_SPECIMEN = utils.vocabs.Term(
-    labels=("PRESERVED SPECIMEN", "PRESERVEDSPECIMEN", "PRESERVED_SPECIMEN", "PRESERVED-SPECIMEN"),
+    labels=("PRESERVED SPECIMEN", ),
     iri=utils.rdf.uri("basisOfRecord/PreservedSpecimen", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 FOSSIL_SPECIMEN = utils.vocabs.Term(
-    labels=("FOSSIL SPECIMEN", "FOSSILSPECIMEN", "FOSSIL_SPECIMEN", "FOSSIL-SPECIMEN"),
+    labels=("FOSSIL SPECIMEN", ),
     iri=utils.rdf.uri("basisOfRecord/FossilSpecimen", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 LIVING_SPECIMEN = utils.vocabs.Term(
-    labels=("LIVING SPECIMEN", "LIVINGSPECIMEN", "LIVING_SPECIMEN", "LIVING-SPECIMEN"),
+    labels=("LIVING SPECIMEN", ),
     iri=utils.rdf.uri("basisOfRecord/LivingSpecimen", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 MACHINE_OBSERVATION = utils.vocabs.Term(
-    labels=("MACHINE OBSERVATION", "MACHINEOBSERVATION", "MACHINE_OBSERVATION", "MACHINE-OBSERVATION"),
+    labels=("MACHINE OBSERVATION", ),
     iri=utils.rdf.uri("basisOfRecord/MachineObservation", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 MATERIAL_SAMPLE = utils.vocabs.Term(
-    labels=("MATERIAL SAMPLE", "MATERIALSAMPLE", "MATERIAL_SAMPLE", "MATERIAL-SAMPLE"),
+    labels=("MATERIAL SAMPLE", ),
     iri=utils.rdf.uri("basisOfRecord/MaterialSample", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 

--- a/abis_mapping/vocabs/conservation_jurisdiction.py
+++ b/abis_mapping/vocabs/conservation_jurisdiction.py
@@ -10,11 +10,11 @@ from abis_mapping import utils
 
 # Terms
 EPBC = utils.vocabs.Term(
-    labels=("EPBC", ),
+    labels=("EPBC", "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION"),
     iri=rdflib.URIRef("https://sws.geonames.org/2077456/"),
 )
 WA = utils.vocabs.Term(
-    labels=("WA", "WESTERN AUSTRALIA", "WESTERN-AUSTRALIA", "WESTERN_AUSTRALIA"),
+    labels=("WA", "WESTERN AUSTRALIA"),
     iri=rdflib.URIRef("https://sws.geonames.org/2058645/"),
 )
 QLD = utils.vocabs.Term(

--- a/abis_mapping/vocabs/establishment_means.py
+++ b/abis_mapping/vocabs/establishment_means.py
@@ -14,8 +14,7 @@ INTRODUCED = utils.vocabs.Term(
     iri=utils.rdf.uri("establishmentMeans/introduced", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 INTRODUCED_ASSISTED_COLONISATION = utils.vocabs.Term(
-    labels=("INTRODUCEDASSISTEDCOLONISATION", "INTRODUCED ASSISTED COLONISATION",
-            "INTRODUCED_ASSISTED_COLONISATION", "INTRODUCED-ASSISTED-COLONISATION"),
+    labels=("INTRODUCED ASSISTED COLONISATION", ),
     iri=utils.rdf.uri("establishmentMeans/introducedAssistedColonisation", utils.namespaces.EXAMPLE),  # TODO -> Need real URI  # noqa: E501
 )
 NATIVE = utils.vocabs.Term(
@@ -23,7 +22,7 @@ NATIVE = utils.vocabs.Term(
     iri=utils.rdf.uri("establishmentMeans/native", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 NATIVE_REINTRODUCED = utils.vocabs.Term(
-    labels=("NATIVEREINTRODUCED", "NATIVE REINTRODUCED", "NATIVE_REINTRODUCED", "NATIVE-REINTRODUCED"),
+    labels=("NATIVE REINTRODUCED", ),
     iri=utils.rdf.uri("establishmentMeans/nativeReintroduced", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 UNCERTAIN = utils.vocabs.Term(

--- a/abis_mapping/vocabs/identification_qualifier.py
+++ b/abis_mapping/vocabs/identification_qualifier.py
@@ -10,7 +10,7 @@ from abis_mapping import utils
 
 # Terms
 ANIMALIA_CETERA = utils.vocabs.Term(
-    labels=("ANIMALIACETERA", "ANIMALIA CETERA", "ANIMALIA_CETERA", "ANIMALIA-CETERA"),
+    labels=("ANIMALIA CETERA", ),
     iri=utils.rdf.uri("identificationQualifier/animalia-cetera", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 CONFER = utils.vocabs.Term(
@@ -18,23 +18,23 @@ CONFER = utils.vocabs.Term(
     iri=utils.rdf.uri("identificationQualifier/confer", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 EX_GREGE = utils.vocabs.Term(
-    labels=("EXGREGE", "EX GREGE", "EX_GREGE", "EX-GREGE"),
+    labels=("EX GREGE", ),
     iri=utils.rdf.uri("identificationQualifier/ex-grege", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 FAMILIA_GENUS_SPECIES = utils.vocabs.Term(
-    labels=("FAMILIAGENUSSPECIES", "FAMILIA GENUS SPECIES", "FAMILIA_GENUS_SPECIES", "FAMILIA-GENUS-SPECIES"),
+    labels=("FAMILIA GENUS SPECIES", ),
     iri=utils.rdf.uri("identificationQualifier/familia-genus-species", utils.namespaces.EXAMPLE),  # TODO -> Need real URI  # noqa: E501
 )
 GENUS_ET_SPECIES_NOVA = utils.vocabs.Term(
-    labels=("GENUSETSPECIESNOVA", "GENUS ET SPECIES NOVA", "GENUS_ET_SPECIES_NOVA", "GENUS-ET-SPECIES-NOVA"),
+    labels=("GENUS ET SPECIES NOVA", ),
     iri=utils.rdf.uri("identificationQualifier/genus-et-species-nova", utils.namespaces.EXAMPLE),  # TODO -> Need real URI  # noqa: E501
 )
 GENUS_NOVUM = utils.vocabs.Term(
-    labels=("GENUSNOVUM", "GENUS NOVUM", "GENUS_NOVUM", "GENUS-NOVUM"),
+    labels=("GENUS NOVUM", ),
     iri=utils.rdf.uri("identificationQualifier/genus-novum", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 GENUS_SPECIES = utils.vocabs.Term(
-    labels=("GENUSSPECIES", "GENUS SPECIES", "GENUS_SPECIES", "GENUS-SPECIES"),
+    labels=("GENUS SPECIES", ),
     iri=utils.rdf.uri("identificationQualifier/genus-species", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SP = utils.vocabs.Term(
@@ -42,23 +42,23 @@ SP = utils.vocabs.Term(
     iri=utils.rdf.uri("identificationQualifier/sp", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SPECIES_AFFINIS = utils.vocabs.Term(
-    labels=("SPECIESAFFINIS", "SPECIES AFFINIS", "SPECIES_AFFINIS", "SPECIES-AFFINIS",),
+    labels=("SPECIES AFFINIS", ),
     iri=utils.rdf.uri("identificationQualifier/species-affinis", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SPECIES_INCERTA = utils.vocabs.Term(
-    labels=("SPECIESINCERTA", "SPECIES INCERTA", "SPECIES_INCERTA", "SPECIES-INCERTA",),
+    labels=("SPECIES INCERTA", ),
     iri=utils.rdf.uri("identificationQualifier/species-incerta", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SPECIES_INDETERMINABILIS = utils.vocabs.Term(
-    labels=("SPECIESINDETERMINABILIS", "SPECIES INDETERMINABILIS", "SPECIES_INDETERMINABILIS", "SPECIES-INDETERMINABILIS",),  # noqa: E501
+    labels=("SPECIES INDETERMINABILIS", ),  # noqa: E501
     iri=utils.rdf.uri("identificationQualifier/species-indeterminabilis", utils.namespaces.EXAMPLE),  # TODO -> Need real URI  # noqa: E501
 )
 SPECIES_NOVA = utils.vocabs.Term(
-    labels=("SPECIESNOVA", "SPECIES NOVA", "SPECIES_NOVA", "SPECIES-NOVA",),
+    labels=("SPECIES NOVA", ),
     iri=utils.rdf.uri("identificationQualifier/species-nova", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SPECIES_PROXIMA = utils.vocabs.Term(
-    labels=("SPECIESPROXIMA", "SPECIES PROXIMA", "SPECIES_PROXIMA", "SPECIES-PROXIMA",),
+    labels=("SPECIES PROXIMA", ),
     iri=utils.rdf.uri("identificationQualifier/species-proxima", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SPP = utils.vocabs.Term(
@@ -70,7 +70,7 @@ STETIT = utils.vocabs.Term(
     iri=utils.rdf.uri("identificationQualifier/stetit", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SUBSPECIES = utils.vocabs.Term(
-    labels=("SUBSPECIES", ),
+    labels=("SUB SPECIES", ),
     iri=utils.rdf.uri("identificationQualifier/subspecies", utils.namespaces.EXAMPLE),  # TODO -> Need real URI  # noqa: E501
 )
 

--- a/abis_mapping/vocabs/preparations.py
+++ b/abis_mapping/vocabs/preparations.py
@@ -14,7 +14,7 @@ ALCOHOL = utils.vocabs.Term(
     iri=utils.rdf.uri("preparations/alcohol", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 DEEPFROZEN = utils.vocabs.Term(
-    labels=("DEEPFROZEN", "DEEP FROZEN", "DEEP_FROZEN", "DEEP-FROZEN"),
+    labels=("DEEP FROZEN", ),
     iri=utils.rdf.uri("preparations/deepFrozen", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 DRIED = utils.vocabs.Term(
@@ -22,7 +22,7 @@ DRIED = utils.vocabs.Term(
     iri=utils.rdf.uri("preparations/dried", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 DRIEDANDPRESSED = utils.vocabs.Term(
-    labels=("DRIEDANDPRESSED", "DRIED AND PRESSED", "DRIED_AND_PRESSED", "DRIED-AND-PRESSED"),
+    labels=("DRIED AND PRESSED", ),
     iri=utils.rdf.uri("preparations/driedAndPressed", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 FORMALIN = utils.vocabs.Term(
@@ -30,7 +30,7 @@ FORMALIN = utils.vocabs.Term(
     iri=utils.rdf.uri("preparations/formalin", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 FREEZEDRIED = utils.vocabs.Term(
-    labels=("FREEZEDRIED", "FREEZE DRIED", "FREEZE_DRIED", "FREEZE-DRIED"),
+    labels=("FREEZE DRIED", ),
     iri=utils.rdf.uri("preparations/freezeDried", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 GLYCERIN = utils.vocabs.Term(
@@ -38,11 +38,11 @@ GLYCERIN = utils.vocabs.Term(
     iri=utils.rdf.uri("preparations/glycerin", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 GUMARABIC = utils.vocabs.Term(
-    labels=("GUMARABIC", ),
+    labels=("GUM ARABIC", ),
     iri=utils.rdf.uri("preparations/gumArabic", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 MICROSCOPICPREPARATION = utils.vocabs.Term(
-    labels=("MICROSCOPICPREPARATION", "MICROSCOPIC PREPARATION", "MICROSCOPIC_PREPARATION", "MICROSCOPIC-PREPARATION"),
+    labels=("MICROSCOPIC PREPARATION", ),
     iri=utils.rdf.uri("preparations/microscopicPreparation", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 MOUNTED = utils.vocabs.Term(
@@ -50,7 +50,7 @@ MOUNTED = utils.vocabs.Term(
     iri=utils.rdf.uri("preparations/mounted", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 NOTREATMENT = utils.vocabs.Term(
-    labels=("NOTREATMENT", "NO TREATMENT", "NO_TREATMENT", "NO-TREATMENT"),
+    labels=("NO TREATMENT", ),
     iri=utils.rdf.uri("preparations/noTreatment", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 OTHER = utils.vocabs.Term(

--- a/abis_mapping/vocabs/sampling_protocol.py
+++ b/abis_mapping/vocabs/sampling_protocol.py
@@ -10,7 +10,7 @@ from abis_mapping import utils
 
 # Terms
 HUMAN_OBSERVATION = utils.vocabs.Term(
-    labels=("HUMAN OBSERVATION", "HUMANOBSERVATION", "HUMAN_OBSERVATION", "HUMAN-OBSERVATION"),
+    labels=("HUMAN OBSERVATION", ),
     iri=rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157"),
 )
 UNSPECIFIED = utils.vocabs.Term(

--- a/abis_mapping/vocabs/taxon_tank.py
+++ b/abis_mapping/vocabs/taxon_tank.py
@@ -18,7 +18,7 @@ CULTIVAR = utils.vocabs.Term(
     iri=utils.rdf.uri("cultivar", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 CULTIVARGROUP = utils.vocabs.Term(
-    labels=("CULTIVARGROUP", ),
+    labels=("CULTIVAR GROUP", ),
     iri=utils.rdf.uri("cultivargroup", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 FAMILY = utils.vocabs.Term(
@@ -38,7 +38,7 @@ INFORMAL = utils.vocabs.Term(
     iri=utils.rdf.uri("informal", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 INFRAGENERICNAME = utils.vocabs.Term(
-    labels=("INFRAGENERICNAME", ),
+    labels=("INFRAGENERIC NAME", ),
     iri=utils.rdf.uri("infragenericname", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 INFRAORDER = utils.vocabs.Term(
@@ -46,11 +46,11 @@ INFRAORDER = utils.vocabs.Term(
     iri=utils.rdf.uri("infraorder", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 INFRASPECIFICNAME = utils.vocabs.Term(
-    labels=("INFRASPECIFICNAME", ),
+    labels=("INFRASPECIFIC NAME", ),
     iri=utils.rdf.uri("infraspecificname", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 INFRASUBSPECIFICNAME = utils.vocabs.Term(
-    labels=("INFRASUBSPECIFICNAME", ),
+    labels=("INFRASUBSPECIFIC NAME", ),
     iri=utils.rdf.uri("infrasubspecificname", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 KINGDOM = utils.vocabs.Term(
@@ -78,7 +78,7 @@ SPECIES = utils.vocabs.Term(
     iri=utils.rdf.uri("species", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SPECIESAGGREGATE = utils.vocabs.Term(
-    labels=("SPECIESAGGREGATE", ),
+    labels=("SPECIES AGGREGATE", ),
     iri=utils.rdf.uri("speciesaggregate", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SUBFAMILY = utils.vocabs.Term(
@@ -114,7 +114,7 @@ SUBSPECIES = utils.vocabs.Term(
     iri=utils.rdf.uri("subspecies", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SUBSPECIFICAGGREGATE = utils.vocabs.Term(
-    labels=("SUBSPECIFICAGGREGATE", ),
+    labels=("SUBSPECIFIC AGGREGATE", ),
     iri=utils.rdf.uri("subspecificaggregate", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SUBTRIBE = utils.vocabs.Term(
@@ -130,7 +130,7 @@ SUPERFAMILY = utils.vocabs.Term(
     iri=utils.rdf.uri("superfamily", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 SUPRAGENERICNAME = utils.vocabs.Term(
-    labels=("SUPRAGENERICNAME", ),
+    labels=("SUPRAGENERIC NAME", ),
     iri=utils.rdf.uri("supragenericname", utils.namespaces.EXAMPLE),  # TODO -> Need real URI
 )
 TRIBE = utils.vocabs.Term(

--- a/abis_mapping/vocabs/threat_status.py
+++ b/abis_mapping/vocabs/threat_status.py
@@ -10,75 +10,183 @@ from abis_mapping import utils
 
 # Terms
 EPBC_EX = utils.vocabs.Term(
-    labels=("EPBC/EX", ),
+    labels=(
+        "EPBC/EX",
+        "EPBC/EXTINCT",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/EX",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/EXTINCT",
+    ),
     iri=utils.rdf.uri("threatStatus/EPBC/EX", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 EPBC_XW = utils.vocabs.Term(
-    labels=("EPBC/XW", ),
+    labels=(
+        "EPBC/XW",
+        "EPBC/EXTINCT IN THE WILD",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/XW",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/EXTINCT IN THE WILD",
+    ),
     iri=utils.rdf.uri("threatStatus/EPBC/XW", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 EPBC_CE = utils.vocabs.Term(
-    labels=("EPBC/CE", ),
+    labels=(
+        "EPBC/CE",
+        "EPBC/CRITICALLY ENDANGERED",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/CE",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/CRITICALLY ENDANGERED",
+    ),
     iri=utils.rdf.uri("threatStatus/EPBC/CE", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 EPBC_E = utils.vocabs.Term(
-    labels=("EPBC/E", ),
+    labels=(
+        "EPBC/E",
+        "EPBC/ENDANGERED",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/E",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/ENDANGERED",
+    ),
     iri=utils.rdf.uri("threatStatus/EPBC/E", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 EPBC_V = utils.vocabs.Term(
-    labels=("EPBC/V", ),
+    labels=(
+        "EPBC/V",
+        "EPBC/VULNERABLE",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/V",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/VULNERABLE",
+    ),
     iri=utils.rdf.uri("threatStatus/EPBC/V", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 EPBC_CD = utils.vocabs.Term(
-    labels=("EPBC/CD", ),
+    labels=(
+        "EPBC/CD",
+        "EPBC/CONSERVATION DEPENDENT",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/CD",
+        "ENVIRONMENT PROTECTION AND BIODIVERSITY CONSERVATION/CONSERVATION DEPENDENT",
+    ),
     iri=utils.rdf.uri("threatStatus/EPBC/CD", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_CR = utils.vocabs.Term(
-    labels=("WA/CR", ),
+    labels=(
+        "WA/CR",
+        "WA/CRITICALLY ENDANGERED",
+        "WA/CRITICALLY ENDANGERED SPECIES",
+        "WESTERN AUSTRALIA/CR",
+        "WESTERN AUSTRALIA/CRITICALLY ENDANGERED",
+        "WESTERN AUSTRALIA/CRITICALLY ENDANGERED SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/CR", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_EN = utils.vocabs.Term(
-    labels=("WA/EN", ),
+    labels=(
+        "WA/EN",
+        "WA/ENDANGERED",
+        "WA/ENDANGERED SPECIES",
+        "WESTERN AUSTRALIA/EN",
+        "WESTERN AUSTRALIA/ENDANGERED",
+        "WESTERN AUSTRALIA/ENDANGERED SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/EN", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_VU = utils.vocabs.Term(
-    labels=("WA/VU", ),
+    labels=(
+        "WA/VU",
+        "WA/VULNERABLE",
+        "WA/VULNERABLE SPECIES",
+        "WESTERN AUSTRALIA/VU",
+        "WESTERN AUSTRALIA/VULNERABLE",
+        "WESTERN AUSTRALIA/VULNERABLE SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/VU", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_EX = utils.vocabs.Term(
-    labels=("WA/EX", ),
+    labels=(
+        "WA/EX",
+        "WA/EXTINCT",
+        "WA/EXTINCT SPECIES",
+        "WESTERN AUSTRALIA/EX",
+        "WESTERN AUSTRALIA/EXTINCT",
+        "WESTERN AUSTRALIA/EXTINCT SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/EX", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_EW = utils.vocabs.Term(
-    labels=("WA/EW", ),
+    labels=(
+        "WA/EW",
+        "WA/EXTINCT IN THE WILD",
+        "WESTERN AUSTRALIA/EW",
+        "WESTERN AUSTRALIA/EXTINCT IN THE WILD",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/EW", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_MI = utils.vocabs.Term(
-    labels=("WA/MI", ),
+    labels=(
+        "WA/MI",
+        "WA/MIGRATORY SPECIES",
+        "WESTERN AUSTRALIA/MI",
+        "WESTERN AUSTRALIA/MIGRATORY SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/MI", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_CD = utils.vocabs.Term(
-    labels=("WA/CD", ),
+    labels=(
+        "WA/CD",
+        "WA/CONSERVATION DEPENDENT",
+        "WA/CONSERVATION DEPENDENT FAUNA",
+        "WESTERN AUSTRALIA/CD",
+        "WESTERN AUSTRALIA/CONSERVATION DEPENDENT",
+        "WESTERN AUSTRALIA/CONSERVATION DEPENDENT FAUNA",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/CD", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_OS = utils.vocabs.Term(
-    labels=("WA/OS", ),
+    labels=(
+        "WA/OS",
+        "WA/OTHER SPECIFICALLY PROTECTED FAUNA",
+        "WESTERN AUSTRALIA/OS",
+        "WESTERN AUSTRALIA/OTHER SPECIFICALLY PROTECTED FAUNA",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/OS", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_P1 = utils.vocabs.Term(
-    labels=("WA/P1", ),
+    labels=(
+        "WA/P1",
+        "WA/PRIORITY 1",
+        "WA/PRIORITY 1 POORLY KNOWN SPECIES"
+        "WESTERN AUSTRALIA/P1",
+        "WESTERN AUSTRALIA/PRIORITY 1",
+        "WESTERN AUSTRALIA/PRIORITY 1 POORLY KNOWN SPECIES"
+    ),
     iri=utils.rdf.uri("threatStatus/WA/P1", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_P2 = utils.vocabs.Term(
-    labels=("WA/P2", ),
+    labels=(
+        "WA/P2",
+        "WA/PRIORITY 2",
+        "WA/PRIORITY 2 POORLY KNOWN SPECIES",
+        "WESTERN AUSTRALIA/P2",
+        "WESTERN AUSTRALIA/PRIORITY 2",
+        "WESTERN AUSTRALIA/PRIORITY 2 POORLY KNOWN SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/P2", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_P3 = utils.vocabs.Term(
-    labels=("WA/P3", ),
+    labels=(
+        "WA/P3",
+        "WA/PRIORITY 3",
+        "WA/PRIORITY 3 POORLY KNOWN SPECIES",
+        "WESTERN AUSTRALIA/P3",
+        "WESTERN AUSTRALIA/PRIORITY 3",
+        "WESTERN AUSTRALIA/PRIORITY 3 POORLY KNOWN SPECIES",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/P3", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 WA_P4 = utils.vocabs.Term(
-    labels=("WA/P4", ),
+    labels=(
+        "WA/P4",
+        "WA/PRIORITY 4",
+        "WA/PRIORITY 4 RARE NEAR THREATENED AND OTHER SPECIES IN NEED OF MONITORING",
+        "WESTERN AUSTRALIA/P4",
+        "WESTERN AUSTRALIA/PRIORITY 4",
+        "WESTERN AUSTRALIA/PRIORITY 4 RARE NEAR THREATENED AND OTHER SPECIES IN NEED OF MONITORING",
+    ),
     iri=utils.rdf.uri("threatStatus/WA/P4", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
 )
 

--- a/tests/utils/test_strings.py
+++ b/tests/utils/test_strings.py
@@ -1,0 +1,24 @@
+"""Provides Unit Tests for the `abis_mapping.utils.strings` module"""
+
+
+# Local
+from abis_mapping import utils
+
+
+def test_strings_sanitise() -> None:
+    """Tests the sanitise() function"""
+    # Test Capitalisation
+    assert utils.strings.sanitise("test") == "TEST"
+    assert utils.strings.sanitise("Test") == "TEST"
+    assert utils.strings.sanitise("TeSt") == "TEST"
+    assert utils.strings.sanitise("TEST") == "TEST"
+
+    # Test Stripping (Space, Hyphen, Underscore and Slash)
+    assert utils.strings.sanitise("1/a b c") == "1ABC"
+    assert utils.strings.sanitise("2/a-b-c") == "2ABC"
+    assert utils.strings.sanitise("3/a_b_c") == "3ABC"
+    assert utils.strings.sanitise("4/a-b_c") == "4ABC"
+
+    # Test Stripping (Other)
+    assert utils.strings.sanitise("a: b-c,d/e_f=g") == "ABCDEFG"
+    assert utils.strings.sanitise("  p., /' 1 -Q-(2)r[ ] 3  s!*@(&#4  ") == "P1Q2R3S4"


### PR DESCRIPTION
## Summary
* Adds alternate labels to new vocabularies
    * `threatStatus` (`vocabs.threat_status`)
    * `threatStatusCheckProtocol` (`vocabs.check_protocol`)
    * `conservationJurisdiction` (`vocabs.conservation_jurisdiction`)
* Adds functionality to match a wider range of labels to vocabulary terms using label normalisation / sanitation.
    * For example, `basisOfRecord/HumanObservation` will now match with the input values `{"Human Observation", "human-observation", "HUMAN_OBSERVATION", etc...}` in the template _without_ explicitly defining those as alternate labels

## Changes
* Adds the `utils.strings.sanitise()` utility function
    * Capitalises and strips all non-alphanumeric characters from a string
    * This is used to normalize the vocabulary term labels
    * This means vocabulary terms can be matched more broadly by only matching on normalised/sanitised values
* Removes overly-verbose "duplicate" alternate labels from all vocabulary terms
    * Similar labels (e.g., `-` instead of `_`, etc) are now handled by the string sanitation instead of being repeatedly and explicitly defined
* Adds new unit tests