### PR TITLE
BDRNS-68: Remove Australia boundaries check in validation but restrict a latitude and longitude min/max values

### DIFF
--- a/abis_mapping/templates/occurrence_data/mapping.py
+++ b/abis_mapping/templates/occurrence_data/mapping.py
@@ -84,10 +84,6 @@ class OccurrenceDataMapper(base.mapper.ABISMapper):
                 # Extra Custom Checks
                 plugins.tabular.IsTabular(),
                 plugins.empty.NotEmpty(),
-                plugins.coordinates.ValidCoordinates(
-                    latitude_name="decimalLatitude",
-                    longitude_name="decimalLongitude",
-                ),
             ],
             limit_memory=base.FRICTIONLESS_LIMIT_MEMORY
         )

--- a/abis_mapping/templates/occurrence_data/schema.json
+++ b/abis_mapping/templates/occurrence_data/schema.json
@@ -32,7 +32,7 @@
       "constraints": {
         "required": true,
         "minimum": -90.0,
-        "maximum": 90.0
+        "maximum": 0
       }
     },
     {
@@ -44,7 +44,7 @@
       "format": "default",
       "constraints": {
         "required": true,
-        "minimum": -180.0,
+        "minimum": 0,
         "maximum": 180.0
       }
     },

--- a/abis_mapping/templates/occurrence_extended/mapping.py
+++ b/abis_mapping/templates/occurrence_extended/mapping.py
@@ -93,10 +93,6 @@ class OccurrenceExtendedMapper(base.mapper.ABISMapper):
                 # Extra Custom Checks
                 plugins.tabular.IsTabular(),
                 plugins.empty.NotEmpty(),
-                plugins.coordinates.ValidCoordinates(
-                    latitude_name="decimalLatitude",
-                    longitude_name="decimalLongitude",
-                ),
                 plugins.mutual_inclusion.MutuallyInclusive(
                     field_names=["threatStatus", "conservationJurisdiction"],
                 )

--- a/abis_mapping/templates/occurrence_extended/schema.json
+++ b/abis_mapping/templates/occurrence_extended/schema.json
@@ -32,7 +32,7 @@
       "constraints": {
         "required": true,
         "minimum": -90.0,
-        "maximum": 90.0
+        "maximum": 0
       }
     },
     {
@@ -44,7 +44,7 @@
       "format": "default",
       "constraints": {
         "required": true,
-        "minimum": -180.0,
+        "minimum": 0,
         "maximum": 180.0
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abis-mapping"
-version = "2.1.0"
+version = "2.2.0"
 description = "Provides templates and mappings to translate tabular data to ABIS rdf"
 authors = ["Gaia Resources <dev@gaiaresources.com.au>"]
 


### PR DESCRIPTION
* Removed the ValidCoordinates check (check Australia mainland boundaries).
* schema.json: set latitude maximum = 0 instead -90 and longitude minimum = 0 instead of -180 in order to catch sign mistakes.
* bumped version to 2.2.0