### PR TITLE
BDRSPS-177 Extra fields JSON Graph Building

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -171,7 +171,9 @@ class ABISMapper(abc.ABC):
 
         if full_schema:
             # Append the extra fields onto the official schema and return
-            [existing_schema.add_field(field) for field in extra_fields]
+            for field in extra_fields:
+                existing_schema.add_field(field)
+
             return existing_schema
 
         # Create difference schema and return

--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -73,15 +73,20 @@ class ABISMapper(abc.ABC):
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
-        """Adds additional fields data to graph as JSON.
+        """Adds additional fields data to graph as JSON if values exist.
 
         Args:
             subject_uri (rdflib.URIRef): Node for the JSON data to be attached.
             row (frictionless.Row): Row containing all data including extras.
             graph (rdflib.Graph): Graph to be modified.
         """
-        # Extract fields and create json node
-        json_str = json.dumps(cls.extract_extra_fields(row))
+        # Extract fields and determine if any values
+        extra_fields = cls.extract_extra_fields(row)
+        if extra_fields == {}:
+            return
+
+        # Create JSON string literal
+        json_str = json.dumps(extra_fields)
         json_node = rdflib.Literal(json_str, datatype=rdflib.RDF.JSON)
 
         # Add to graph
@@ -111,33 +116,63 @@ class ABISMapper(abc.ABC):
     @classmethod
     def extra_fields_schema(
         cls,
-        row: frictionless.Row
+        data: frictionless.Row | types.ReadableType,
+        full_schema: bool = False
     ) -> frictionless.Schema:
         """Creates a schema with all extra fields found in data.
 
+        The fields of data are expected to be the same or a superset of the template's
+        official schema. It is expected that validation has occurred prior to calling.
+
         Args:
-            row (frictionless.Row): Row expected to contain more columns
-                than included in the template's schema.
+            data (frictionless.Row | types.ReadableType): Row or data expected to
+                contain more columns than included in the template's schema.
+            full_schema (bool): Flag to indicate whether full schema for row or data
+                should be returned or just the difference.
 
         Returns:
             frictionless.Schema: A schema object, the fields of which are only
-                the extra fields not a part of a template's official schema.
+                the extra fields not a part of a template's official schema if full_schema = False
+                else the schema will be the concatenation of the official schema fields and the
+                extra fields.
         """
         # Construct official schema
         existing_schema: frictionless.Schema = frictionless.Schema.from_descriptor(cls.schema())
 
-        # Get set of fieldnames of row
-        actual_fieldnames = set(row.field_names)
+        if isinstance(data, frictionless.Row):
+            # Get list of fieldnames of row
+            actual_fieldnames = data.field_names
 
-        # Create schema from row fields
-        actual_schema = frictionless.Schema(fields=row.fields)
+            # Create schema from row fields
+            actual_schema = frictionless.Schema(fields=data.fields)
+        else:
+            # Create resource and infer
+            resource = frictionless.Resource(
+                data=data,
+                format="csv",
+            )
+            resource.infer()
 
-        # Find set of extra fieldnames
-        existing_fieldnames = set(existing_schema.field_names)
-        extra_fieldnames = actual_fieldnames - existing_fieldnames
+            # Get actual schema
+            actual_schema = resource.schema
+
+            # Get list of actual fieldnames
+            actual_fieldnames = resource.schema.field_names
+
+        # Find list of extra fieldnames
+        existing_fieldnames = existing_schema.field_names
+        if len(actual_fieldnames) > len(existing_fieldnames):
+            extra_fieldnames = actual_fieldnames[len(existing_fieldnames):]
+        else:
+            extra_fieldnames = []
 
         # Construct list of extra Fields
         extra_fields = [actual_schema.get_field(fieldname) for fieldname in extra_fieldnames]
+
+        if full_schema:
+            # Append the extra fields onto the official schema and return
+            [existing_schema.add_field(field) for field in extra_fields]
+            return existing_schema
 
         # Create difference schema and return
         return frictionless.Schema(fields=extra_fields)

--- a/abis_mapping/templates/incidental_occurrence_data/examples/margaret_river_flora/margaret_river_flora_extra_cols.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data/examples/margaret_river_flora/margaret_river_flora_extra_cols.ttl
@@ -1,0 +1,2225 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dwc: <http://rs.tdwg.org/dwc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix tern: <https://w3id.org/tern/ontologies/tern/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://createme.org/observation/acceptedNameUsage/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "acceptedNameUsage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/scientificName/15> ;
+    sosa:hasResult <http://createme.org/value/acceptedNameUsage/15> ;
+    sosa:hasSimpleResult "Caladenia excelsa Hopper & A.P.Br." ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://example.com/methods/name-check-method> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ] ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/acceptedNameUsage/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "acceptedNameUsage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/scientificName/16> ;
+    sosa:hasResult <http://createme.org/value/acceptedNameUsage/16> ;
+    sosa:hasSimpleResult "Caladenia excelsa Hopper & A.P.Br." ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://example.com/methods/name-check-method> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ] ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/establishmentMeans/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "establishmentMeans-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/establishmentMeans/15> ;
+    sosa:hasSimpleResult "native" ;
+    sosa:observedProperty <http://example.com/concept/establishmentMeans> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/establishmentMeans/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "establishmentMeans-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/establishmentMeans/16> ;
+    sosa:hasSimpleResult "new establishment means" ;
+    sosa:observedProperty <http://example.com/concept/establishmentMeans> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/individualCount/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "individualCount-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/individualCount/15> ;
+    sosa:hasSimpleResult 2 ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/74c71500-0bae-43c9-8db0-bd6940899af1> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/individualCount/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "individualCount-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/individualCount/16> ;
+    sosa:hasSimpleResult 6 ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/74c71500-0bae-43c9-8db0-bd6940899af1> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/lifeStage/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "lifeStage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/value/lifeStage/15> ;
+    sosa:hasSimpleResult "adult" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/abb0ee19-b2e8-42f3-8a25-d1f39ca3ebc3> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/lifeStage/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "lifeStage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/value/lifeStage/16> ;
+    sosa:hasSimpleResult "new life stage" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/abb0ee19-b2e8-42f3-8a25-d1f39ca3ebc3> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/occurrenceStatus/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "occurrenceStatus-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/occurrenceStatus/15> ;
+    sosa:hasSimpleResult "present" ;
+    sosa:observedProperty <http://example.com/concept/occurrenceStatus> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/occurrenceStatus/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "occurrenceStatus-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/occurrenceStatus/16> ;
+    sosa:hasSimpleResult "new occurrence status" ;
+    sosa:observedProperty <http://example.com/concept/occurrenceStatus> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/organismRemarks/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "organismRemarks-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/organismRemarks/15> ;
+    sosa:hasSimpleResult "Dried out leaf tips" ;
+    sosa:observedProperty <http://example.com/concept/organismRemarks> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/organismRemarks/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "organismRemarks-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/organismRemarks/16> ;
+    sosa:hasSimpleResult "Leaves brown" ;
+    sosa:observedProperty <http://example.com/concept/organismRemarks> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/reproductiveCondition/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "reproductiveCondition-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/value/reproductiveCondition/15> ;
+    sosa:hasSimpleResult "No breeding evident" ;
+    sosa:observedProperty <http://example.com/concept/reproductiveCondition> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/reproductiveCondition/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "reproductiveCondition-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/value/reproductiveCondition/16> ;
+    sosa:hasSimpleResult "new reproductiveCondition" ;
+    sosa:observedProperty <http://example.com/concept/reproductiveCondition> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/scientificName/1> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/1> ;
+    sosa:hasResult <http://createme.org/scientificName/1> ;
+    sosa:hasSimpleResult "Calothamnus lateralis var. crassus" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/1> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/scientificName/10> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/10> ;
+    sosa:hasResult <http://createme.org/scientificName/10> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/10> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
+    sosa:hasResult <http://createme.org/scientificName/11> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/11>,
+        <http://createme.org/attribute/identificationRemarks/11>,
+        <http://createme.org/attribute/kingdom/11> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/12> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/12> ;
+    sosa:hasResult <http://createme.org/scientificName/12> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/12> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/scientificName/13> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/13> ;
+    sosa:hasResult <http://createme.org/scientificName/13> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/13> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/14> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/14> ;
+    sosa:hasResult <http://createme.org/scientificName/14> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/14>,
+        <http://createme.org/attribute/identificationRemarks/14>,
+        <http://createme.org/attribute/kingdom/14> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/scientificName/15> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/15>,
+        <http://createme.org/attribute/identificationRemarks/15>,
+        <http://createme.org/attribute/kingdom/15>,
+        <http://createme.org/attribute/taxonRank/15> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/scientificName/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/scientificName/16> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/16>,
+        <http://createme.org/attribute/identificationRemarks/16>,
+        <http://createme.org/attribute/kingdom/16>,
+        <http://createme.org/attribute/taxonRank/16> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/scientificName/2> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/2> ;
+    sosa:hasResult <http://createme.org/scientificName/2> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/2> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/3> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/3> ;
+    sosa:hasResult <http://createme.org/scientificName/3> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/3> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/4> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/4> ;
+    sosa:hasResult <http://createme.org/scientificName/4> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/4> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/5> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/5> ;
+    sosa:hasResult <http://createme.org/scientificName/5> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/5> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/6> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/6> ;
+    sosa:hasResult <http://createme.org/scientificName/6> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/6> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/7> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/7> ;
+    sosa:hasResult <http://createme.org/scientificName/7> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/7> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/8> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/8> ;
+    sosa:hasResult <http://createme.org/scientificName/8> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/8> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/9> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/9> ;
+    sosa:hasResult <http://createme.org/scientificName/9> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/9> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/sex/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "sex-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/value/sex/15> ;
+    sosa:hasSimpleResult "male" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/05cbf534-c233-4aa8-a08c-00b28976ed36> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/sex/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "sex-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/value/sex/16> ;
+    sosa:hasSimpleResult "new sex" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/05cbf534-c233-4aa8-a08c-00b28976ed36> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/threatStatus/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "threatStatus-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/WA-BIO> ;
+    prov:wasInfluencedBy <http://createme.org/attribute/conservationJurisdiction/15> ;
+    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/15> ;
+    sosa:hasResult <http://createme.org/value/threatStatus/15> ;
+    sosa:hasSimpleResult "VU" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> ;
+    tern:resultDateTime "2022-09-12"^^xsd:date .
+
+<http://createme.org/observation/threatStatus/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "threatStatus-observation" ;
+    prov:wasInfluencedBy <http://createme.org/attribute/conservationJurisdiction/16> ;
+    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/16> ;
+    sosa:hasResult <http://createme.org/value/threatStatus/16> ;
+    sosa:hasSimpleResult "new threat status" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/a-random-selection> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ] ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/verbatimID/1> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/1> ;
+    sosa:hasResult <http://createme.org/verbatimID/1> ;
+    sosa:hasSimpleResult "Calothamnus lateralis var. crassus" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/10> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/10> ;
+    sosa:hasResult <http://createme.org/verbatimID/10> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
+    sosa:hasResult <http://createme.org/verbatimID/11> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/14> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/14> ;
+    sosa:hasResult <http://createme.org/verbatimID/14> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/verbatimID/15> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/verbatimID/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/verbatimID/16> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/verbatimID/2> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/2> ;
+    sosa:hasResult <http://createme.org/verbatimID/2> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/3> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/3> ;
+    sosa:hasResult <http://createme.org/verbatimID/3> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/4> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/4> ;
+    sosa:hasResult <http://createme.org/verbatimID/4> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/5> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/5> ;
+    sosa:hasResult <http://createme.org/verbatimID/5> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/6> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/6> ;
+    sosa:hasResult <http://createme.org/verbatimID/6> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/7> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/7> ;
+    sosa:hasResult <http://createme.org/verbatimID/7> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/8> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/8> ;
+    sosa:hasResult <http://createme.org/verbatimID/8> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/9> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/9> ;
+    sosa:hasResult <http://createme.org/verbatimID/9> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/attribute/basisOfRecord/13> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "PreservedSpecimen" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/13> .
+
+<http://createme.org/attribute/basisOfRecord/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "HumanObservation" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/14> .
+
+<http://createme.org/attribute/basisOfRecord/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "PreservedSpecimen" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/15> .
+
+<http://createme.org/attribute/basisOfRecord/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "new basis of record" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/16> .
+
+<http://createme.org/attribute/conservationJurisdiction/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
+    tern:hasSimpleValue "WA" ;
+    tern:hasValue <http://createme.org/value/conservationJurisdiction/15> .
+
+<http://createme.org/attribute/conservationJurisdiction/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
+    tern:hasSimpleValue "WA" ;
+    tern:hasValue <http://createme.org/value/conservationJurisdiction/16> .
+
+<http://createme.org/attribute/dataGeneralizations/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/14> .
+
+<http://createme.org/attribute/habitat/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
+    tern:hasSimpleValue "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    tern:hasValue <http://createme.org/value/habitat/15> .
+
+<http://createme.org/attribute/habitat/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
+    tern:hasSimpleValue "new habitat" ;
+    tern:hasValue <http://createme.org/value/habitat/16> .
+
+<http://createme.org/attribute/identificationQualifier/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "?" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/11> .
+
+<http://createme.org/attribute/identificationQualifier/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "?" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/14> .
+
+<http://createme.org/attribute/identificationQualifier/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "species incerta" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/15> .
+
+<http://createme.org/attribute/identificationQualifier/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "new identification qualifier" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/16> .
+
+<http://createme.org/attribute/identificationRemarks/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "One unopened flower when recorded and one leaf only. ID not confirmed" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/11> .
+
+<http://createme.org/attribute/identificationRemarks/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "Could not confirm the ID due to damaged flower" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/14> .
+
+<http://createme.org/attribute/identificationRemarks/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "no flowers present" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/15> .
+
+<http://createme.org/attribute/identificationRemarks/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "new remarks" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/16> .
+
+<http://createme.org/attribute/kingdom/1> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/1> .
+
+<http://createme.org/attribute/kingdom/10> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/10> .
+
+<http://createme.org/attribute/kingdom/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/11> .
+
+<http://createme.org/attribute/kingdom/12> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/12> .
+
+<http://createme.org/attribute/kingdom/13> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/13> .
+
+<http://createme.org/attribute/kingdom/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/14> .
+
+<http://createme.org/attribute/kingdom/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/15> .
+
+<http://createme.org/attribute/kingdom/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "new kingdom" ;
+    tern:hasValue <http://createme.org/value/kingdom/16> .
+
+<http://createme.org/attribute/kingdom/2> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/2> .
+
+<http://createme.org/attribute/kingdom/3> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/3> .
+
+<http://createme.org/attribute/kingdom/4> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/4> .
+
+<http://createme.org/attribute/kingdom/5> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/5> .
+
+<http://createme.org/attribute/kingdom/6> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/6> .
+
+<http://createme.org/attribute/kingdom/7> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/7> .
+
+<http://createme.org/attribute/kingdom/8> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/8> .
+
+<http://createme.org/attribute/kingdom/9> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/9> .
+
+<http://createme.org/attribute/preparations/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/preparations> ;
+    tern:hasSimpleValue "Wet (in ethanol or some other preservative)" ;
+    tern:hasValue <http://createme.org/value/preparations/15> .
+
+<http://createme.org/attribute/preparations/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/preparations> ;
+    tern:hasSimpleValue "new preparations" ;
+    tern:hasValue <http://createme.org/value/preparations/16> .
+
+<http://createme.org/attribute/taxonRank/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/taxonRank> ;
+    tern:hasSimpleValue "species" ;
+    tern:hasValue <http://createme.org/value/taxonRank/15> .
+
+<http://createme.org/attribute/taxonRank/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/taxonRank> ;
+    tern:hasSimpleValue "new taxon rank" ;
+    tern:hasValue <http://createme.org/value/taxonRank/16> .
+
+<http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/basisOfRecord> ;
+    skos:definition "A type of basisOfRecord." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new basis of record" .
+
+<http://createme.org/bdr-cv/attribute/identificationQualifier/new-identification-qualifier> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
+    skos:definition "A type of identificationQualifier." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new identification qualifier" .
+
+<http://createme.org/bdr-cv/attribute/kingdom/new-kingdom> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/kingdom> ;
+    skos:definition "A type of kingdom." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new kingdom" .
+
+<http://createme.org/bdr-cv/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/preparations> ;
+    skos:definition "A type of preparations." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "Wet (in ethanol or some other preservative)" .
+
+<http://createme.org/bdr-cv/attribute/preparations/new-preparations> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/preparations> ;
+    skos:definition "A type of preparations." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new preparations" .
+
+<http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/taxonRank> ;
+    skos:definition "A type of taxonRank." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new taxon rank" .
+
+<http://createme.org/bdr-cv/featureType/occurrence/kingdom/new-kingdom> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:definition "The existence of the organism sampled at a particular place at a particular time." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d> ;
+    skos:prefLabel "new kingdom" .
+
+<http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:definition "An organism specimen." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d> ;
+    skos:prefLabel "new kingdom" .
+
+<http://createme.org/bdr-cv/methods/samplingProtocol/new-sampling-protocol> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/samplingProtocol> ;
+    skos:definition "A type of samplingProtocol." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "new sampling protocol" .
+
+<http://createme.org/bdr-cv/methods/sequencingMethod/Sanger-dideoxy-sequencing> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/sequencingMethod> ;
+    skos:definition "A type of sequencingMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "Sanger dideoxy sequencing" .
+
+<http://createme.org/bdr-cv/methods/sequencingMethod/new-sequencing-method> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/sequencingMethod> ;
+    skos:definition "A type of sequencingMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "new sequencing method" .
+
+<http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
+    skos:definition "A type of threatStatusCheckProtocol." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "Check against Threatened and Priority Fauna List WA available from https://www.dpaw.wa.gov.au/plants-and-animals/threatened-species-and-communities/threatened-animals. Last updated 13 June 2022" .
+
+<http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/a-random-selection> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
+    skos:definition "A type of threatStatusCheckProtocol." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "a random selection" .
+
+<http://createme.org/bdr-cv/parameter/establishmentMeans/new-establishment-means> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/establishmentMeans> ;
+    skos:definition "A type of establishmentMeans." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new establishment means" .
+
+<http://createme.org/bdr-cv/parameter/lifeStage/new-life-stage> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/lifeStage> ;
+    skos:definition "A type of lifeStage." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new life stage" .
+
+<http://createme.org/bdr-cv/parameter/occurrenceStatus/new-occurrence-status> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/occurrenceStatus> ;
+    skos:definition "A type of occurrenceStatus." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new occurrence status" .
+
+<http://createme.org/bdr-cv/parameter/reproductiveCondition/No-breeding-evident> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/reproductiveCondition> ;
+    skos:definition "A type of reproductiveCondition." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "No breeding evident" .
+
+<http://createme.org/bdr-cv/parameter/reproductiveCondition/new-reproductiveCondition> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/reproductiveCondition> ;
+    skos:definition "A type of reproductiveCondition." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new reproductiveCondition" .
+
+<http://createme.org/bdr-cv/parameter/sex/new-sex> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/sex> ;
+    skos:definition "A type of sex." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new sex" .
+
+<http://createme.org/bdr-cv/parameter/threatStatus/WA/new-threat-status> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/threatStatus> ;
+    skos:definition "A type of threatStatus." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "WA/new threat status" .
+
+<http://createme.org/provider/WA-BIO> a prov:Agent ;
+    foaf:name "WA-BIO" .
+
+<http://createme.org/sample/sequence/15> a tern:FeatureOfInterest,
+        tern:Sample ;
+    dcterms:identifier "https://www.ncbi.nlm.nih.gov/nuccore/MH040616.1",
+        "https://www.ncbi.nlm.nih.gov/nuccore/MH040669.1" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "sequence-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/sequencing/15> ;
+    sosa:isSampleOf <http://createme.org/sample/specimen/15> ;
+    tern:featureType <http://example.com/concept/sequence> .
+
+<http://createme.org/sample/sequence/16> a tern:FeatureOfInterest,
+        tern:Sample ;
+    dcterms:identifier "https://www.ncbi.nlm.nih.gov/nuccore/MH040616.1",
+        "https://www.ncbi.nlm.nih.gov/nuccore/MH040669.1" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "sequence-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/sequencing/16> ;
+    sosa:isSampleOf <http://createme.org/sample/specimen/16> ;
+    tern:featureType <http://example.com/concept/sequence> .
+
+<http://createme.org/sampling/field/1> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/1> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/field/10> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/10> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/11> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/11> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/12> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/12> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/field/13> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/13> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/14> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 2e+01 ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/14> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/14>,
+        <http://createme.org/attribute/dataGeneralizations/14> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/2> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling",
+        '{"extraInformation1": "Some extra information"}'^^rdf:JSON ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/2> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/3> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/3> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/4> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/4> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/5> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/5> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/6> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling",
+        '{"extraInformation2": "Some more extra information"}'^^rdf:JSON ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/6> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/7> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/7> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/8> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/8> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/9> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/9> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/sequencing/15> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 5e+01 ;
+    rdfs:comment "sequencing-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/sample/sequence/15> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/sequencingMethod/Sanger-dideoxy-sequencing> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/sequencing/16> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 3e+01 ;
+    rdfs:comment "sequencing-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/sample/sequence/16> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/sequencingMethod/new-sequencing-method> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/sampling/specimen/13> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/13> ;
+    sosa:hasResult <http://createme.org/sample/specimen/13> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/13> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/specimen/15> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 5e+01 ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/sample/specimen/15> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/15>,
+        <http://createme.org/attribute/dataGeneralizations/15> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-26"^^xsd:date .
+
+<http://createme.org/sampling/specimen/16> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 3e+01 ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/sample/specimen/16> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/16>,
+        <http://createme.org/attribute/dataGeneralizations/16> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-27"^^xsd:date .
+
+<http://createme.org/scientificName/1> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Calothamnus lateralis var. crassus" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/10> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/11> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/12> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/13> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/14> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/2> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Boronia anceps" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/3> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Boronia anceps" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/4> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Boronia anceps" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/5> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/6> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/7> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/8> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/9> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/value/basisOfRecord/13> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
+
+<http://createme.org/value/basisOfRecord/14> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://example.com/basisOfRecord/HumanObservation> .
+
+<http://createme.org/value/basisOfRecord/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
+
+<http://createme.org/value/basisOfRecord/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> .
+
+<http://createme.org/value/conservationJurisdiction/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation Jurisdiction = WA" ;
+    rdf:value <https://sws.geonames.org/2058645/> .
+
+<http://createme.org/value/conservationJurisdiction/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation Jurisdiction = WA" ;
+    rdf:value <https://sws.geonames.org/2058645/> .
+
+<http://createme.org/value/dataGeneralizations/14> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
+
+<http://createme.org/value/dataGeneralizations/15> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
+
+<http://createme.org/value/dataGeneralizations/16> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates generalised" .
+
+<http://createme.org/value/establishmentMeans/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "establishmentMeans-value" ;
+    rdf:value <http://example.com/establishmentMeans/native> .
+
+<http://createme.org/value/establishmentMeans/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "establishmentMeans-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/establishmentMeans/new-establishment-means> .
+
+<http://createme.org/value/habitat/15> a tern:Text,
+        tern:Value ;
+    rdfs:label "habitat" ;
+    rdf:value "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." .
+
+<http://createme.org/value/habitat/16> a tern:Text,
+        tern:Value ;
+    rdfs:label "habitat" ;
+    rdf:value "new habitat" .
+
+<http://createme.org/value/identificationQualifier/11> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/> .
+
+<http://createme.org/value/identificationQualifier/14> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/> .
+
+<http://createme.org/value/identificationQualifier/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://example.com/identificationQualifier/species-incerta> .
+
+<http://createme.org/value/identificationQualifier/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/new-identification-qualifier> .
+
+<http://createme.org/value/identificationRemarks/11> a tern:Text,
+        tern:Value ;
+    rdf:value "One unopened flower when recorded and one leaf only. ID not confirmed" .
+
+<http://createme.org/value/identificationRemarks/14> a tern:Text,
+        tern:Value ;
+    rdf:value "Could not confirm the ID due to damaged flower" .
+
+<http://createme.org/value/identificationRemarks/15> a tern:Text,
+        tern:Value ;
+    rdf:value "no flowers present" .
+
+<http://createme.org/value/identificationRemarks/16> a tern:Text,
+        tern:Value ;
+    rdf:value "new remarks" .
+
+<http://createme.org/value/individualCount/15> a tern:Integer,
+        tern:Value ;
+    rdfs:label "individual-count" ;
+    rdf:value 2 .
+
+<http://createme.org/value/individualCount/16> a tern:Integer,
+        tern:Value ;
+    rdfs:label "individual-count" ;
+    rdf:value 6 .
+
+<http://createme.org/value/kingdom/1> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/10> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/11> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/12> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/13> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/14> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = new kingdom" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/kingdom/new-kingdom> .
+
+<http://createme.org/value/kingdom/2> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/3> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/4> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/5> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/6> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/7> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/8> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/9> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/lifeStage/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "lifeStage-value" ;
+    rdf:value <http://example.com/lifeStage/adult> .
+
+<http://createme.org/value/lifeStage/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "lifeStage-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/lifeStage/new-life-stage> .
+
+<http://createme.org/value/occurrenceStatus/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "occurrenceStatus = present" ;
+    rdf:value <http://example.com/occurrenceStatus/present> .
+
+<http://createme.org/value/occurrenceStatus/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "occurrenceStatus = new occurrence status" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/occurrenceStatus/new-occurrence-status> .
+
+<http://createme.org/value/organismRemarks/15> a tern:Text,
+        tern:Value ;
+    rdfs:label "organism-remarks" ;
+    rdf:value "Dried out leaf tips" .
+
+<http://createme.org/value/organismRemarks/16> a tern:Text,
+        tern:Value ;
+    rdfs:label "organism-remarks" ;
+    rdf:value "Leaves brown" .
+
+<http://createme.org/value/preparations/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "preparations" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
+
+<http://createme.org/value/preparations/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "preparations" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/preparations/new-preparations> .
+
+<http://createme.org/value/reproductiveCondition/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "reproductiveCondition-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/reproductiveCondition/No-breeding-evident> .
+
+<http://createme.org/value/reproductiveCondition/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "reproductiveCondition-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/reproductiveCondition/new-reproductiveCondition> .
+
+<http://createme.org/value/sex/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "sex-value" ;
+    rdf:value <http://example.com/sex/male> .
+
+<http://createme.org/value/sex/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "sex-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/sex/new-sex> .
+
+<http://createme.org/value/taxonRank/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "taxon rank = species" ;
+    rdf:value <http://example.com/species> .
+
+<http://createme.org/value/taxonRank/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "taxon rank = new taxon rank" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> .
+
+<http://createme.org/value/threatStatus/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation status = VU" ;
+    rdf:value <http://example.com/threatStatus/WA/vulnerable-species> .
+
+<http://createme.org/value/threatStatus/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation status = new threat status" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/threatStatus/WA/new-threat-status> .
+
+<http://createme.org/verbatimID/1> a tern:Text,
+        tern:Value ;
+    rdf:value "Calothamnus lateralis var. crassus" .
+
+<http://createme.org/verbatimID/10> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia excelsa" .
+
+<http://createme.org/verbatimID/11> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/14> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/15> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/16> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/2> a tern:Text,
+        tern:Value ;
+    rdf:value "Boronia anceps" .
+
+<http://createme.org/verbatimID/3> a tern:Text,
+        tern:Value ;
+    rdf:value "Boronia anceps" .
+
+<http://createme.org/verbatimID/4> a tern:Text,
+        tern:Value ;
+    rdf:value "Boronia anceps" .
+
+<http://createme.org/verbatimID/5> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/6> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/7> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/8> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/9> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia excelsa" .
+
+<http://createme.org/attribute/dataGeneralizations/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/15> .
+
+<http://createme.org/attribute/dataGeneralizations/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates generalised" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/16> .
+
+<http://createme.org/bdr-cv/attribute/identificationQualifier/> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
+    skos:definition "A type of identificationQualifier." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "?" .
+
+<http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/identificationMethod> ;
+    skos:definition "A type of identificationMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "Visually identified in the field (sighting)" .
+
+<http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/identificationMethod> ;
+    skos:definition "A type of identificationMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "new identification method" .
+
+<http://createme.org/sample/field/12> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/12> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/specimen/13> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:collectionCode "CC123" ;
+    rdfs:comment "specimen-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WAM> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/13> ;
+    sosa:isSampleOf <http://createme.org/sample/field/13> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
+
+<http://createme.org/sampling/field/15> a tern:Sampling ;
+    dcterms:identifier "8022FSJMJ079c5cf" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 5e+01 ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/15> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/15>,
+        <http://createme.org/attribute/habitat/15> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/field/16> a tern:Sampling ;
+    dcterms:identifier "ABC123" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 3e+01 ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/16> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/samplingProtocol/new-sampling-protocol> ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/16>,
+        <http://createme.org/attribute/habitat/16> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/scientificName/15> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/16> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/value/acceptedNameUsage/15> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "acceptedNameUsage-value" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa Hopper & A.P.Br." ;
+    tern:featureType <http://example.com/concept/acceptedNameUsage> .
+
+<http://createme.org/value/acceptedNameUsage/16> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "acceptedNameUsage-value" ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa Hopper & A.P.Br." ;
+    tern:featureType <http://example.com/concept/acceptedNameUsage> .
+
+<http://createme.org/sample/field/1> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/1> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/10> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/10> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/11> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/11> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/13> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/13> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/14> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:collectionCode "CC456" ;
+    rdfs:comment "field-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WAM> ;
+    sosa:isResultOf <http://createme.org/sampling/field/14> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/2> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/2> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/3> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/3> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/4> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/4> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/5> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/5> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/6> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/6> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/7> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/7> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/8> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/8> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/9> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/9> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/provider/BHP> a prov:Agent ;
+    foaf:name "BHP" .
+
+<http://createme.org/sample/specimen/15> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:catalogNumber "32237" ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/15> ;
+    sosa:isSampleOf <http://createme.org/sample/field/15> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/15> .
+
+<http://createme.org/sample/specimen/16> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:catalogNumber "32238" ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/16> ;
+    sosa:isSampleOf <http://createme.org/sample/field/16> ;
+    tern:featureType <http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/16> .
+
+<http://createme.org/sample/field/15> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:occurrenceID "MR-456" ;
+    dwc:otherCatalogNumbers "BHP2012-7521",
+        "M12378" ;
+    dwc:recordNumber "PE:12:8832" ;
+    rdfs:comment "field-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/BHP> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/BHP> ;
+    sosa:isResultOf <http://createme.org/sampling/field/15> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/16> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:occurrenceID "MR-457" ;
+    dwc:otherCatalogNumbers "BHP2012-7522",
+        "M12379" ;
+    dwc:recordNumber "PE:12:8833" ;
+    rdfs:comment "field-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WAM> ;
+    sosa:isResultOf <http://createme.org/sampling/field/16> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://createme.org/bdr-cv/featureType/occurrence/kingdom/new-kingdom> .
+
+<http://createme.org/provider/WAM> a prov:Agent ;
+    foaf:name "WAM" .
+
+<http://createme.org/location/Australia> a tern:FeatureOfInterest ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:sfWithin <https://sws.geonames.org/2077456/> ] ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> .
+
+<http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> a prov:Agent ;
+    foaf:name "Stream Environment and Water Pty Ltd" .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> a tern:RDFDataset ;
+    dcterms:description "Example Incidental Occurrence Dataset by Gaia Resources" ;
+    dcterms:issued "2023-09-04"^^xsd:date ;
+    dcterms:title "Example Incidental Occurrence Dataset" .
+
+[] a rdf:Statement ;
+    rdf:object "BHP2012-7521" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/BHP> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    rdf:object "MR-457" ;
+    rdf:predicate dwc:occurrenceID ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "occurrenceID source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    rdf:object "PE:12:8832" ;
+    rdf:predicate dwc:recordNumber ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "recordNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/originator> ] .
+
+[] a rdf:Statement ;
+    rdf:object "MR-456" ;
+    rdf:predicate dwc:occurrenceID ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "occurrenceID source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    rdf:object "PE:12:8833" ;
+    rdf:predicate dwc:recordNumber ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "recordNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/originator> ] .
+
+[] a rdf:Statement ;
+    dwc:collectionCode "ARACH" ;
+    rdf:object "32237" ;
+    rdf:predicate dwc:catalogNumber ;
+    rdf:subject <http://createme.org/sample/specimen/15> ;
+    skos:prefLabel "catalogNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    rdf:object "8022FSJMJ079c5cf" ;
+    rdf:predicate dcterms:identifier ;
+    rdf:subject <http://createme.org/sampling/field/15> ;
+    skos:prefLabel "recordID source" .
+
+[] a rdf:Statement ;
+    rdf:object "M12379" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    rdf:object "BHP2012-7522" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    dcterms:source "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI ;
+    rdf:object "ABC123" ;
+    rdf:predicate dcterms:identifier ;
+    rdf:subject <http://createme.org/sampling/field/16> ;
+    skos:prefLabel "recordID source" .
+
+[] a rdf:Statement ;
+    rdf:object "M12378" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/BHP> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    dwc:collectionCode "ARACH" ;
+    rdf:object "32238" ;
+    rdf:predicate dwc:catalogNumber ;
+    rdf:subject <http://createme.org/sample/specimen/16> ;
+    skos:prefLabel "catalogNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+

--- a/abis_mapping/templates/incidental_occurrence_data/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data/mapping.py
@@ -134,7 +134,10 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             chunk_size = None
 
         # Construct Schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.extra_fields_schema(
+            data=data,
+            full_schema=True,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -735,6 +738,13 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Conservation Jurisdiction Value
         self.add_conservation_jurisdiction_value(
             uri=conservation_jurisdiction_value,
+            row=row,
+            graph=graph,
+        )
+
+        # Add extra fields JSON
+        self.add_extra_fields_json(
+            subject_uri=sampling_field,
             row=row,
             graph=graph,
         )

--- a/abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.ttl
+++ b/abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.ttl
@@ -1,0 +1,31 @@
+@prefix bdr: <http://example.com/bdr-schema/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tern: <https://w3id.org/tern/ontologies/tern/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://createme.org/project/SSD-Survey-Project/1> a bdr:Project ;
+    bdr:hasSurvey <http://createme.org/survey/SSD-Survey/1> ;
+    dcterms:description "Native vegetation clearing permit" ;
+    dcterms:identifier "IBSA-2021-0118" ;
+    dcterms:title "Reconnaissance and Targeted survey conducted for Shire of Augusta Margaret River, for the Reconstruction of Cowaramup Bay Road project." ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> .
+
+<http://createme.org/attribute/survey-method-url/1> a tern:Attribute ;
+    tern:hasSimpleValue "https://biocollect.ala.org.au/document/download/2022-01/202201%20CBR%20Flora%20and%20Vegetation%20report_draftv1.pdf" .
+
+<http://createme.org/survey/SSD-Survey/1> a bdr:Survey ;
+    time:hasTime [ a time:TemporalEntity ;
+            time:hasBeginning "2020-09-21"^^xsd:date ;
+            time:hasEnd "2020-09-23"^^xsd:date ] ;
+    rdfs:comment '{"extraInformation1": "some additional info", "extraInformation2": "some more info"}'^^rdf:JSON ;
+    tern:hasAttribute <http://createme.org/attribute/survey-method-url/1> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> a tern:RDFDataset ;
+    dcterms:description "Example Systematic Survey Metadata Dataset by Gaia Resources" ;
+    dcterms:issued "2023-10-09"^^xsd:date ;
+    dcterms:title "Example Systematic Survey Metadata Dataset" .
+

--- a/abis_mapping/templates/survey_metadata/mapping.py
+++ b/abis_mapping/templates/survey_metadata/mapping.py
@@ -90,7 +90,10 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             rdflib.Graph: ABIS conformant RDF sub-graph from raw data chunk.
         """
         # Construct Schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.extra_fields_schema(
+            data=data,
+            full_schema=True,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -197,6 +200,13 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             row=row,
             graph=graph,
             base_iri=base_iri,
+        )
+
+        # Add extra columns JSON
+        self.add_extra_fields_json(
+            subject_uri=bdr_survey,
+            row=row,
+            graph=graph,
         )
 
     def add_bdr_project(

--- a/abis_mapping/templates/survey_occurrence_data/examples/margaret_river_flora/margaret_river_flora_extra_cols.ttl
+++ b/abis_mapping/templates/survey_occurrence_data/examples/margaret_river_flora/margaret_river_flora_extra_cols.ttl
@@ -1,0 +1,2225 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dwc: <http://rs.tdwg.org/dwc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix tern: <https://w3id.org/tern/ontologies/tern/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://createme.org/observation/acceptedNameUsage/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "acceptedNameUsage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/scientificName/15> ;
+    sosa:hasResult <http://createme.org/value/acceptedNameUsage/15> ;
+    sosa:hasSimpleResult "Caladenia excelsa Hopper & A.P.Br." ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://example.com/methods/name-check-method> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ] ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/acceptedNameUsage/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "acceptedNameUsage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/scientificName/16> ;
+    sosa:hasResult <http://createme.org/value/acceptedNameUsage/16> ;
+    sosa:hasSimpleResult "Caladenia excelsa Hopper & A.P.Br." ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://example.com/methods/name-check-method> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ] ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/establishmentMeans/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "establishmentMeans-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/establishmentMeans/15> ;
+    sosa:hasSimpleResult "native" ;
+    sosa:observedProperty <http://example.com/concept/establishmentMeans> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/establishmentMeans/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "establishmentMeans-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/establishmentMeans/16> ;
+    sosa:hasSimpleResult "new establishment means" ;
+    sosa:observedProperty <http://example.com/concept/establishmentMeans> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/individualCount/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "individualCount-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/individualCount/15> ;
+    sosa:hasSimpleResult 2 ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/74c71500-0bae-43c9-8db0-bd6940899af1> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/individualCount/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "individualCount-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/individualCount/16> ;
+    sosa:hasSimpleResult 6 ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/74c71500-0bae-43c9-8db0-bd6940899af1> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/lifeStage/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "lifeStage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/value/lifeStage/15> ;
+    sosa:hasSimpleResult "adult" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/abb0ee19-b2e8-42f3-8a25-d1f39ca3ebc3> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/lifeStage/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "lifeStage-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/value/lifeStage/16> ;
+    sosa:hasSimpleResult "new life stage" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/abb0ee19-b2e8-42f3-8a25-d1f39ca3ebc3> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/occurrenceStatus/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "occurrenceStatus-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/occurrenceStatus/15> ;
+    sosa:hasSimpleResult "present" ;
+    sosa:observedProperty <http://example.com/concept/occurrenceStatus> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/occurrenceStatus/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "occurrenceStatus-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/occurrenceStatus/16> ;
+    sosa:hasSimpleResult "new occurrence status" ;
+    sosa:observedProperty <http://example.com/concept/occurrenceStatus> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/organismRemarks/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "organismRemarks-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/value/organismRemarks/15> ;
+    sosa:hasSimpleResult "Dried out leaf tips" ;
+    sosa:observedProperty <http://example.com/concept/organismRemarks> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/organismRemarks/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "organismRemarks-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/value/organismRemarks/16> ;
+    sosa:hasSimpleResult "Leaves brown" ;
+    sosa:observedProperty <http://example.com/concept/organismRemarks> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/reproductiveCondition/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "reproductiveCondition-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/value/reproductiveCondition/15> ;
+    sosa:hasSimpleResult "No breeding evident" ;
+    sosa:observedProperty <http://example.com/concept/reproductiveCondition> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/reproductiveCondition/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "reproductiveCondition-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/value/reproductiveCondition/16> ;
+    sosa:hasSimpleResult "new reproductiveCondition" ;
+    sosa:observedProperty <http://example.com/concept/reproductiveCondition> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/scientificName/1> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/1> ;
+    sosa:hasResult <http://createme.org/scientificName/1> ;
+    sosa:hasSimpleResult "Calothamnus lateralis var. crassus" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/1> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/scientificName/10> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/10> ;
+    sosa:hasResult <http://createme.org/scientificName/10> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/10> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
+    sosa:hasResult <http://createme.org/scientificName/11> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/11>,
+        <http://createme.org/attribute/identificationRemarks/11>,
+        <http://createme.org/attribute/kingdom/11> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/12> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/12> ;
+    sosa:hasResult <http://createme.org/scientificName/12> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/12> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/scientificName/13> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/13> ;
+    sosa:hasResult <http://createme.org/scientificName/13> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/13> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/14> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/14> ;
+    sosa:hasResult <http://createme.org/scientificName/14> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/14>,
+        <http://createme.org/attribute/identificationRemarks/14>,
+        <http://createme.org/attribute/kingdom/14> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/observation/scientificName/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/scientificName/15> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/15>,
+        <http://createme.org/attribute/identificationRemarks/15>,
+        <http://createme.org/attribute/kingdom/15>,
+        <http://createme.org/attribute/taxonRank/15> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/scientificName/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/scientificName/16> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/16>,
+        <http://createme.org/attribute/identificationRemarks/16>,
+        <http://createme.org/attribute/kingdom/16>,
+        <http://createme.org/attribute/taxonRank/16> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/scientificName/2> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/2> ;
+    sosa:hasResult <http://createme.org/scientificName/2> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/2> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/3> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/3> ;
+    sosa:hasResult <http://createme.org/scientificName/3> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/3> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/4> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/4> ;
+    sosa:hasResult <http://createme.org/scientificName/4> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/4> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/5> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/5> ;
+    sosa:hasResult <http://createme.org/scientificName/5> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/5> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/6> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/6> ;
+    sosa:hasResult <http://createme.org/scientificName/6> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/6> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/7> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/7> ;
+    sosa:hasResult <http://createme.org/scientificName/7> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/7> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/8> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/8> ;
+    sosa:hasResult <http://createme.org/scientificName/8> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/8> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/scientificName/9> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/9> ;
+    sosa:hasResult <http://createme.org/scientificName/9> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:hasAttribute <http://createme.org/attribute/kingdom/9> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/sex/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "sex-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/value/sex/15> ;
+    sosa:hasSimpleResult "male" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/05cbf534-c233-4aa8-a08c-00b28976ed36> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/sex/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "sex-observation" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/value/sex/16> ;
+    sosa:hasSimpleResult "new sex" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/05cbf534-c233-4aa8-a08c-00b28976ed36> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value sosa:usedProcedure ;
+            rdfs:comment "Observation method unknown, 'human observation' used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/observation/threatStatus/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "threatStatus-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/WA-BIO> ;
+    prov:wasInfluencedBy <http://createme.org/attribute/conservationJurisdiction/15> ;
+    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/15> ;
+    sosa:hasResult <http://createme.org/value/threatStatus/15> ;
+    sosa:hasSimpleResult "VU" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> ;
+    tern:resultDateTime "2022-09-12"^^xsd:date .
+
+<http://createme.org/observation/threatStatus/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "threatStatus-observation" ;
+    prov:wasInfluencedBy <http://createme.org/attribute/conservationJurisdiction/16> ;
+    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/16> ;
+    sosa:hasResult <http://createme.org/value/threatStatus/16> ;
+    sosa:hasSimpleResult "new threat status" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/a-random-selection> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ] ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/verbatimID/1> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/1> ;
+    sosa:hasResult <http://createme.org/verbatimID/1> ;
+    sosa:hasSimpleResult "Calothamnus lateralis var. crassus" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/10> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/10> ;
+    sosa:hasResult <http://createme.org/verbatimID/10> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
+    sosa:hasResult <http://createme.org/verbatimID/11> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/14> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/14> ;
+    sosa:hasResult <http://createme.org/verbatimID/14> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/verbatimID/15> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-24"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/verbatimID/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/verbatimID/16> ;
+    sosa:hasSimpleResult "Caladenia ?excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2019-09-25"^^xsd:date ] ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> ;
+    tern:resultDateTime "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp .
+
+<http://createme.org/observation/verbatimID/2> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/2> ;
+    sosa:hasResult <http://createme.org/verbatimID/2> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/3> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/3> ;
+    sosa:hasResult <http://createme.org/verbatimID/3> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/4> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/4> ;
+    sosa:hasResult <http://createme.org/verbatimID/4> ;
+    sosa:hasSimpleResult "Boronia anceps" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/5> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/5> ;
+    sosa:hasResult <http://createme.org/verbatimID/5> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/6> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/6> ;
+    sosa:hasResult <http://createme.org/verbatimID/6> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/7> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/7> ;
+    sosa:hasResult <http://createme.org/verbatimID/7> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/8> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/8> ;
+    sosa:hasResult <http://createme.org/verbatimID/8> ;
+    sosa:hasSimpleResult "Banksia sessilis var. cordata" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-21"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-21"^^xsd:date .
+
+<http://createme.org/observation/verbatimID/9> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "verbatimID-observation" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/9> ;
+    sosa:hasResult <http://createme.org/verbatimID/9> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:phenomenonTime [ a time:Instant ;
+            time:inXSDDate "2020-09-23"^^xsd:date ] ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
+    tern:resultDateTime "2019-09-23"^^xsd:date .
+
+<http://createme.org/attribute/basisOfRecord/13> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "PreservedSpecimen" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/13> .
+
+<http://createme.org/attribute/basisOfRecord/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "HumanObservation" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/14> .
+
+<http://createme.org/attribute/basisOfRecord/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "PreservedSpecimen" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/15> .
+
+<http://createme.org/attribute/basisOfRecord/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/basisOfRecord> ;
+    tern:hasSimpleValue "new basis of record" ;
+    tern:hasValue <http://createme.org/value/basisOfRecord/16> .
+
+<http://createme.org/attribute/conservationJurisdiction/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
+    tern:hasSimpleValue "WA" ;
+    tern:hasValue <http://createme.org/value/conservationJurisdiction/15> .
+
+<http://createme.org/attribute/conservationJurisdiction/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
+    tern:hasSimpleValue "WA" ;
+    tern:hasValue <http://createme.org/value/conservationJurisdiction/16> .
+
+<http://createme.org/attribute/dataGeneralizations/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/14> .
+
+<http://createme.org/attribute/habitat/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
+    tern:hasSimpleValue "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    tern:hasValue <http://createme.org/value/habitat/15> .
+
+<http://createme.org/attribute/habitat/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
+    tern:hasSimpleValue "new habitat" ;
+    tern:hasValue <http://createme.org/value/habitat/16> .
+
+<http://createme.org/attribute/identificationQualifier/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "?" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/11> .
+
+<http://createme.org/attribute/identificationQualifier/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "?" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/14> .
+
+<http://createme.org/attribute/identificationQualifier/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "species incerta" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/15> .
+
+<http://createme.org/attribute/identificationQualifier/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "new identification qualifier" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/16> .
+
+<http://createme.org/attribute/identificationRemarks/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "One unopened flower when recorded and one leaf only. ID not confirmed" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/11> .
+
+<http://createme.org/attribute/identificationRemarks/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "Could not confirm the ID due to damaged flower" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/14> .
+
+<http://createme.org/attribute/identificationRemarks/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "no flowers present" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/15> .
+
+<http://createme.org/attribute/identificationRemarks/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "new remarks" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/16> .
+
+<http://createme.org/attribute/kingdom/1> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/1> .
+
+<http://createme.org/attribute/kingdom/10> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/10> .
+
+<http://createme.org/attribute/kingdom/11> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/11> .
+
+<http://createme.org/attribute/kingdom/12> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/12> .
+
+<http://createme.org/attribute/kingdom/13> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/13> .
+
+<http://createme.org/attribute/kingdom/14> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/14> .
+
+<http://createme.org/attribute/kingdom/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/15> .
+
+<http://createme.org/attribute/kingdom/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "new kingdom" ;
+    tern:hasValue <http://createme.org/value/kingdom/16> .
+
+<http://createme.org/attribute/kingdom/2> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/2> .
+
+<http://createme.org/attribute/kingdom/3> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/3> .
+
+<http://createme.org/attribute/kingdom/4> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/4> .
+
+<http://createme.org/attribute/kingdom/5> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/5> .
+
+<http://createme.org/attribute/kingdom/6> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/6> .
+
+<http://createme.org/attribute/kingdom/7> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/7> .
+
+<http://createme.org/attribute/kingdom/8> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/8> .
+
+<http://createme.org/attribute/kingdom/9> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/kingdom> ;
+    tern:hasSimpleValue "Plantae" ;
+    tern:hasValue <http://createme.org/value/kingdom/9> .
+
+<http://createme.org/attribute/preparations/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/preparations> ;
+    tern:hasSimpleValue "Wet (in ethanol or some other preservative)" ;
+    tern:hasValue <http://createme.org/value/preparations/15> .
+
+<http://createme.org/attribute/preparations/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/preparations> ;
+    tern:hasSimpleValue "new preparations" ;
+    tern:hasValue <http://createme.org/value/preparations/16> .
+
+<http://createme.org/attribute/taxonRank/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/taxonRank> ;
+    tern:hasSimpleValue "species" ;
+    tern:hasValue <http://createme.org/value/taxonRank/15> .
+
+<http://createme.org/attribute/taxonRank/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/taxonRank> ;
+    tern:hasSimpleValue "new taxon rank" ;
+    tern:hasValue <http://createme.org/value/taxonRank/16> .
+
+<http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/basisOfRecord> ;
+    skos:definition "A type of basisOfRecord." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new basis of record" .
+
+<http://createme.org/bdr-cv/attribute/identificationQualifier/new-identification-qualifier> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
+    skos:definition "A type of identificationQualifier." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new identification qualifier" .
+
+<http://createme.org/bdr-cv/attribute/kingdom/new-kingdom> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/kingdom> ;
+    skos:definition "A type of kingdom." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new kingdom" .
+
+<http://createme.org/bdr-cv/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/preparations> ;
+    skos:definition "A type of preparations." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "Wet (in ethanol or some other preservative)" .
+
+<http://createme.org/bdr-cv/attribute/preparations/new-preparations> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/preparations> ;
+    skos:definition "A type of preparations." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new preparations" .
+
+<http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/taxonRank> ;
+    skos:definition "A type of taxonRank." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new taxon rank" .
+
+<http://createme.org/bdr-cv/featureType/occurrence/kingdom/new-kingdom> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:definition "The existence of the organism sampled at a particular place at a particular time." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d> ;
+    skos:prefLabel "new kingdom" .
+
+<http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:definition "An organism specimen." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d> ;
+    skos:prefLabel "new kingdom" .
+
+<http://createme.org/bdr-cv/methods/samplingProtocol/new-sampling-protocol> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/samplingProtocol> ;
+    skos:definition "A type of samplingProtocol." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "new sampling protocol" .
+
+<http://createme.org/bdr-cv/methods/sequencingMethod/Sanger-dideoxy-sequencing> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/sequencingMethod> ;
+    skos:definition "A type of sequencingMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "Sanger dideoxy sequencing" .
+
+<http://createme.org/bdr-cv/methods/sequencingMethod/new-sequencing-method> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/sequencingMethod> ;
+    skos:definition "A type of sequencingMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "new sequencing method" .
+
+<http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
+    skos:definition "A type of threatStatusCheckProtocol." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "Check against Threatened and Priority Fauna List WA available from https://www.dpaw.wa.gov.au/plants-and-animals/threatened-species-and-communities/threatened-animals. Last updated 13 June 2022" .
+
+<http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/a-random-selection> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
+    skos:definition "A type of threatStatusCheckProtocol." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "a random selection" .
+
+<http://createme.org/bdr-cv/parameter/establishmentMeans/new-establishment-means> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/establishmentMeans> ;
+    skos:definition "A type of establishmentMeans." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new establishment means" .
+
+<http://createme.org/bdr-cv/parameter/lifeStage/new-life-stage> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/lifeStage> ;
+    skos:definition "A type of lifeStage." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new life stage" .
+
+<http://createme.org/bdr-cv/parameter/occurrenceStatus/new-occurrence-status> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/occurrenceStatus> ;
+    skos:definition "A type of occurrenceStatus." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new occurrence status" .
+
+<http://createme.org/bdr-cv/parameter/reproductiveCondition/No-breeding-evident> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/reproductiveCondition> ;
+    skos:definition "A type of reproductiveCondition." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "No breeding evident" .
+
+<http://createme.org/bdr-cv/parameter/reproductiveCondition/new-reproductiveCondition> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/reproductiveCondition> ;
+    skos:definition "A type of reproductiveCondition." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new reproductiveCondition" .
+
+<http://createme.org/bdr-cv/parameter/sex/new-sex> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/sex> ;
+    skos:definition "A type of sex." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "new sex" .
+
+<http://createme.org/bdr-cv/parameter/threatStatus/WA/new-threat-status> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/parameter/threatStatus> ;
+    skos:definition "A type of threatStatus." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
+    skos:prefLabel "WA/new threat status" .
+
+<http://createme.org/provider/WA-BIO> a prov:Agent ;
+    foaf:name "WA-BIO" .
+
+<http://createme.org/sample/sequence/15> a tern:FeatureOfInterest,
+        tern:Sample ;
+    dcterms:identifier "https://www.ncbi.nlm.nih.gov/nuccore/MH040616.1",
+        "https://www.ncbi.nlm.nih.gov/nuccore/MH040669.1" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "sequence-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/sequencing/15> ;
+    sosa:isSampleOf <http://createme.org/sample/specimen/15> ;
+    tern:featureType <http://example.com/concept/sequence> .
+
+<http://createme.org/sample/sequence/16> a tern:FeatureOfInterest,
+        tern:Sample ;
+    dcterms:identifier "https://www.ncbi.nlm.nih.gov/nuccore/MH040616.1",
+        "https://www.ncbi.nlm.nih.gov/nuccore/MH040669.1" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "sequence-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/sequencing/16> ;
+    sosa:isSampleOf <http://createme.org/sample/specimen/16> ;
+    tern:featureType <http://example.com/concept/sequence> .
+
+<http://createme.org/sampling/field/1> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/1> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/field/10> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/10> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/11> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/11> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/12> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/12> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/field/13> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/13> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/14> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 2e+01 ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/14> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/14>,
+        <http://createme.org/attribute/dataGeneralizations/14> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/field/2> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    rdfs:comment '{"extraInformation1": "Some extra information"}'^^rdf:JSON ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/2> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/3> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/3> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/4> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/4> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/5> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/5> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/6> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    rdfs:comment '{"extraInformation2": "Some more extra information"}'^^rdf:JSON ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/6> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/7> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/7> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/8> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/8> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-21"^^xsd:date .
+
+<http://createme.org/sampling/field/9> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/9> ;
+    sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/sequencing/15> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 5e+01 ;
+    rdfs:comment "sequencing-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/sample/sequence/15> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/sequencingMethod/Sanger-dideoxy-sequencing> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/sequencing/16> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 3e+01 ;
+    rdfs:comment "sequencing-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/sample/sequence/16> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/sequencingMethod/new-sequencing-method> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/sampling/specimen/13> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/13> ;
+    sosa:hasResult <http://createme.org/sample/specimen/13> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/13> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ],
+        [ a rdf:Statement ;
+            rdf:value tern:resultDateTime ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ] ;
+    tern:resultDateTime "2020-09-23"^^xsd:date .
+
+<http://createme.org/sampling/specimen/15> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 5e+01 ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
+    sosa:hasResult <http://createme.org/sample/specimen/15> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/15>,
+        <http://createme.org/attribute/dataGeneralizations/15> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-26"^^xsd:date .
+
+<http://createme.org/sampling/specimen/16> a tern:Sampling ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 3e+01 ;
+    rdfs:comment "specimen-sampling" ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
+    sosa:hasResult <http://createme.org/sample/specimen/16> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/16>,
+        <http://createme.org/attribute/dataGeneralizations/16> ;
+    tern:qualifiedValue [ a rdf:Statement ;
+            rdf:value geo:hasGeometry ;
+            rdfs:comment "Location unknown, location of field sampling used as proxy" ] ;
+    tern:resultDateTime "2019-09-27"^^xsd:date .
+
+<http://createme.org/scientificName/1> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Calothamnus lateralis var. crassus" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/10> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/11> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/12> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/13> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/14> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/2> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Boronia anceps" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/3> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Boronia anceps" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/4> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Boronia anceps" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/5> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/6> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/7> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/8> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Banksia sessilis var. cordata" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/9> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/value/basisOfRecord/13> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
+
+<http://createme.org/value/basisOfRecord/14> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://example.com/basisOfRecord/HumanObservation> .
+
+<http://createme.org/value/basisOfRecord/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
+
+<http://createme.org/value/basisOfRecord/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "basisOfRecord" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> .
+
+<http://createme.org/value/conservationJurisdiction/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation Jurisdiction = WA" ;
+    rdf:value <https://sws.geonames.org/2058645/> .
+
+<http://createme.org/value/conservationJurisdiction/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation Jurisdiction = WA" ;
+    rdf:value <https://sws.geonames.org/2058645/> .
+
+<http://createme.org/value/dataGeneralizations/14> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
+
+<http://createme.org/value/dataGeneralizations/15> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
+
+<http://createme.org/value/dataGeneralizations/16> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates generalised" .
+
+<http://createme.org/value/establishmentMeans/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "establishmentMeans-value" ;
+    rdf:value <http://example.com/establishmentMeans/native> .
+
+<http://createme.org/value/establishmentMeans/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "establishmentMeans-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/establishmentMeans/new-establishment-means> .
+
+<http://createme.org/value/habitat/15> a tern:Text,
+        tern:Value ;
+    rdfs:label "habitat" ;
+    rdf:value "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." .
+
+<http://createme.org/value/habitat/16> a tern:Text,
+        tern:Value ;
+    rdfs:label "habitat" ;
+    rdf:value "new habitat" .
+
+<http://createme.org/value/identificationQualifier/11> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/> .
+
+<http://createme.org/value/identificationQualifier/14> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/> .
+
+<http://createme.org/value/identificationQualifier/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://example.com/identificationQualifier/species-incerta> .
+
+<http://createme.org/value/identificationQualifier/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "identificationQualifier" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/new-identification-qualifier> .
+
+<http://createme.org/value/identificationRemarks/11> a tern:Text,
+        tern:Value ;
+    rdf:value "One unopened flower when recorded and one leaf only. ID not confirmed" .
+
+<http://createme.org/value/identificationRemarks/14> a tern:Text,
+        tern:Value ;
+    rdf:value "Could not confirm the ID due to damaged flower" .
+
+<http://createme.org/value/identificationRemarks/15> a tern:Text,
+        tern:Value ;
+    rdf:value "no flowers present" .
+
+<http://createme.org/value/identificationRemarks/16> a tern:Text,
+        tern:Value ;
+    rdf:value "new remarks" .
+
+<http://createme.org/value/individualCount/15> a tern:Integer,
+        tern:Value ;
+    rdfs:label "individual-count" ;
+    rdf:value 2 .
+
+<http://createme.org/value/individualCount/16> a tern:Integer,
+        tern:Value ;
+    rdfs:label "individual-count" ;
+    rdf:value 6 .
+
+<http://createme.org/value/kingdom/1> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/10> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/11> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/12> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/13> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/14> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = new kingdom" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/kingdom/new-kingdom> .
+
+<http://createme.org/value/kingdom/2> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/3> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/4> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/5> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/6> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/7> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/8> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/kingdom/9> a tern:IRI,
+        tern:Value ;
+    rdfs:label "kingdom = Plantae" ;
+    rdf:value <http://example.com/kingdom/plantae> .
+
+<http://createme.org/value/lifeStage/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "lifeStage-value" ;
+    rdf:value <http://example.com/lifeStage/adult> .
+
+<http://createme.org/value/lifeStage/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "lifeStage-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/lifeStage/new-life-stage> .
+
+<http://createme.org/value/occurrenceStatus/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "occurrenceStatus = present" ;
+    rdf:value <http://example.com/occurrenceStatus/present> .
+
+<http://createme.org/value/occurrenceStatus/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "occurrenceStatus = new occurrence status" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/occurrenceStatus/new-occurrence-status> .
+
+<http://createme.org/value/organismRemarks/15> a tern:Text,
+        tern:Value ;
+    rdfs:label "organism-remarks" ;
+    rdf:value "Dried out leaf tips" .
+
+<http://createme.org/value/organismRemarks/16> a tern:Text,
+        tern:Value ;
+    rdfs:label "organism-remarks" ;
+    rdf:value "Leaves brown" .
+
+<http://createme.org/value/preparations/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "preparations" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
+
+<http://createme.org/value/preparations/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "preparations" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/preparations/new-preparations> .
+
+<http://createme.org/value/reproductiveCondition/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "reproductiveCondition-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/reproductiveCondition/No-breeding-evident> .
+
+<http://createme.org/value/reproductiveCondition/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "reproductiveCondition-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/reproductiveCondition/new-reproductiveCondition> .
+
+<http://createme.org/value/sex/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "sex-value" ;
+    rdf:value <http://example.com/sex/male> .
+
+<http://createme.org/value/sex/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "sex-value" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/sex/new-sex> .
+
+<http://createme.org/value/taxonRank/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "taxon rank = species" ;
+    rdf:value <http://example.com/species> .
+
+<http://createme.org/value/taxonRank/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "taxon rank = new taxon rank" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> .
+
+<http://createme.org/value/threatStatus/15> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation status = VU" ;
+    rdf:value <http://example.com/threatStatus/WA/vulnerable-species> .
+
+<http://createme.org/value/threatStatus/16> a tern:IRI,
+        tern:Value ;
+    rdfs:label "Conservation status = new threat status" ;
+    rdf:value <http://createme.org/bdr-cv/parameter/threatStatus/WA/new-threat-status> .
+
+<http://createme.org/verbatimID/1> a tern:Text,
+        tern:Value ;
+    rdf:value "Calothamnus lateralis var. crassus" .
+
+<http://createme.org/verbatimID/10> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia excelsa" .
+
+<http://createme.org/verbatimID/11> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/14> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/15> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/16> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia ?excelsa" .
+
+<http://createme.org/verbatimID/2> a tern:Text,
+        tern:Value ;
+    rdf:value "Boronia anceps" .
+
+<http://createme.org/verbatimID/3> a tern:Text,
+        tern:Value ;
+    rdf:value "Boronia anceps" .
+
+<http://createme.org/verbatimID/4> a tern:Text,
+        tern:Value ;
+    rdf:value "Boronia anceps" .
+
+<http://createme.org/verbatimID/5> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/6> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/7> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/8> a tern:Text,
+        tern:Value ;
+    rdf:value "Banksia sessilis var. cordata" .
+
+<http://createme.org/verbatimID/9> a tern:Text,
+        tern:Value ;
+    rdf:value "Caladenia excelsa" .
+
+<http://createme.org/attribute/dataGeneralizations/15> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/15> .
+
+<http://createme.org/attribute/dataGeneralizations/16> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates generalised" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/16> .
+
+<http://createme.org/bdr-cv/attribute/identificationQualifier/> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
+    skos:definition "A type of identificationQualifier." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "?" .
+
+<http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/identificationMethod> ;
+    skos:definition "A type of identificationMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "Visually identified in the field (sighting)" .
+
+<http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> a skos:Concept ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    skos:broader <http://example.com/bdr-cv/methods/identificationMethod> ;
+    skos:definition "A type of identificationMethod." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
+    skos:prefLabel "new identification method" .
+
+<http://createme.org/sample/field/12> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/12> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/specimen/13> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:collectionCode "CC123" ;
+    rdfs:comment "specimen-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WAM> ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/13> ;
+    sosa:isSampleOf <http://createme.org/sample/field/13> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
+
+<http://createme.org/sampling/field/15> a tern:Sampling ;
+    dcterms:identifier "8022FSJMJ079c5cf" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 5e+01 ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/15> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/15>,
+        <http://createme.org/attribute/habitat/15> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2019-09-24"^^xsd:date .
+
+<http://createme.org/sampling/field/16> a tern:Sampling ;
+    dcterms:identifier "ABC123" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    geo:hasMetricSpatialAccuracy 3e+01 ;
+    rdfs:comment "field-sampling" ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/location/Australia> ;
+    sosa:hasResult <http://createme.org/sample/field/16> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/samplingProtocol/new-sampling-protocol> ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/16>,
+        <http://createme.org/attribute/habitat/16> ;
+    tern:locationDescription "Cowaramup Bay Road" ;
+    tern:resultDateTime "2019-09-25"^^xsd:date .
+
+<http://createme.org/scientificName/15> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/scientificName/16> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "scientificName" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa" ;
+    tern:featureType <http://example.com/concept/scientificName> .
+
+<http://createme.org/value/acceptedNameUsage/15> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "acceptedNameUsage-value" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa Hopper & A.P.Br." ;
+    tern:featureType <http://example.com/concept/acceptedNameUsage> .
+
+<http://createme.org/value/acceptedNameUsage/16> a tern:FeatureOfInterest,
+        tern:Text,
+        tern:Value ;
+    rdfs:label "acceptedNameUsage-value" ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdf:value "Caladenia excelsa Hopper & A.P.Br." ;
+    tern:featureType <http://example.com/concept/acceptedNameUsage> .
+
+<http://createme.org/sample/field/1> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/1> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/10> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/10> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/11> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/11> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/13> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/13> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/14> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:collectionCode "CC456" ;
+    rdfs:comment "field-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WAM> ;
+    sosa:isResultOf <http://createme.org/sampling/field/14> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/2> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/2> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/3> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/3> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/4> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/4> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/5> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/5> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/6> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/6> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/7> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/7> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/8> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/8> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/9> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/9> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/provider/BHP> a prov:Agent ;
+    foaf:name "BHP" .
+
+<http://createme.org/sample/specimen/15> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:catalogNumber "32237" ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/15> ;
+    sosa:isSampleOf <http://createme.org/sample/field/15> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/15> .
+
+<http://createme.org/sample/specimen/16> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:catalogNumber "32238" ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/16> ;
+    sosa:isSampleOf <http://createme.org/sample/field/16> ;
+    tern:featureType <http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/16> .
+
+<http://createme.org/sample/field/15> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:occurrenceID "MR-456" ;
+    dwc:otherCatalogNumbers "BHP2012-7521",
+        "M12378" ;
+    dwc:recordNumber "PE:12:8832" ;
+    rdfs:comment "field-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/BHP> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/BHP> ;
+    sosa:isResultOf <http://createme.org/sampling/field/15> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
+<http://createme.org/sample/field/16> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:occurrenceID "MR-457" ;
+    dwc:otherCatalogNumbers "BHP2012-7522",
+        "M12379" ;
+    dwc:recordNumber "PE:12:8833" ;
+    rdfs:comment "field-sample" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WAM> ;
+    sosa:isResultOf <http://createme.org/sampling/field/16> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://createme.org/bdr-cv/featureType/occurrence/kingdom/new-kingdom> .
+
+<http://createme.org/provider/WAM> a prov:Agent ;
+    foaf:name "WAM" .
+
+<http://createme.org/location/Australia> a tern:FeatureOfInterest ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:sfWithin <https://sws.geonames.org/2077456/> ] ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> .
+
+<http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> a prov:Agent ;
+    foaf:name "Stream Environment and Water Pty Ltd" .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> a tern:RDFDataset ;
+    dcterms:description "Example Systematic Survey Occurrence Dataset by Gaia Resources" ;
+    dcterms:issued "2023-09-05"^^xsd:date ;
+    dcterms:title "Example Systematic Survey Occurrence Dataset" .
+
+[] a rdf:Statement ;
+    rdf:object "MR-456" ;
+    rdf:predicate dwc:occurrenceID ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "occurrenceID source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    rdf:object "ABC123" ;
+    rdf:predicate dcterms:identifier ;
+    rdf:subject <http://createme.org/sampling/field/16> ;
+    skos:prefLabel "recordID source" .
+
+[] a rdf:Statement ;
+    dcterms:source "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI ;
+    rdf:object "8022FSJMJ079c5cf" ;
+    rdf:predicate dcterms:identifier ;
+    rdf:subject <http://createme.org/sampling/field/15> ;
+    skos:prefLabel "recordID source" .
+
+[] a rdf:Statement ;
+    rdf:object "PE:12:8833" ;
+    rdf:predicate dwc:recordNumber ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "recordNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/originator> ] .
+
+[] a rdf:Statement ;
+    rdf:object "PE:12:8832" ;
+    rdf:predicate dwc:recordNumber ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "recordNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/originator> ] .
+
+[] a rdf:Statement ;
+    rdf:object "BHP2012-7522" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    rdf:object "MR-457" ;
+    rdf:predicate dwc:occurrenceID ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "occurrenceID source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    dwc:collectionCode "ARACH" ;
+    rdf:object "32238" ;
+    rdf:predicate dwc:catalogNumber ;
+    rdf:subject <http://createme.org/sample/specimen/16> ;
+    skos:prefLabel "catalogNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    rdf:object "M12379" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/16> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    rdf:object "BHP2012-7521" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/BHP> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+
+[] a rdf:Statement ;
+    dwc:collectionCode "ARACH" ;
+    rdf:object "32237" ;
+    rdf:predicate dwc:catalogNumber ;
+    rdf:subject <http://createme.org/sample/specimen/15> ;
+    skos:prefLabel "catalogNumber source" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/WAM> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/custodian> ] .
+
+[] a rdf:Statement ;
+    rdf:object "M12378" ;
+    rdf:predicate dwc:otherCatalogNumbers ;
+    rdf:subject <http://createme.org/sample/field/15> ;
+    skos:prefLabel "otherCatalogNumbers stakeholder" ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            prov:agent <http://createme.org/provider/BHP> ;
+            prov:hadRole <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/stakeholder> ] .
+

--- a/abis_mapping/templates/survey_occurrence_data/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data/mapping.py
@@ -134,7 +134,10 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             chunk_size = None
 
         # Construct Schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.extra_fields_schema(
+            data=data,
+            full_schema=True,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -735,6 +738,13 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Conservation Jurisdiction Value
         self.add_conservation_jurisdiction_value(
             uri=conservation_jurisdiction_value,
+            row=row,
+            graph=graph,
+        )
+
+        # Add extra fields JSON
+        self.add_extra_fields_json(
+            subject_uri=sampling_field,
             row=row,
             graph=graph,
         )

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -189,7 +189,7 @@ def test_extra_fields_schema_row_data(template_id: str, file_path: str) -> None:
     existing_schema = frictionless.Schema.from_descriptor(mapper().schema())
 
     # Open resource for row streaming
-    with (resource.open() as r):
+    with resource.open() as r:
         for row in r.row_stream:
             # Extract extra columns schema
             diff_schema = mapper.extra_fields_schema(row)

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -175,6 +175,9 @@ def test_apply_validation_extra_columns_middle(template_id: str, file_path: str)
 )
 def test_extra_fields_schema_row_data(template_id: str, file_path: str) -> None:
     """Tests extra fields schema gets extracted from row data."""
+    # Expected extra field names
+    expected_extra_fieldnames = {"extraInformation1", "extraInformation2"}
+
     # Get mapper
     mapper = base.mapper.get_mapper(template_id)
     assert mapper is not None
@@ -182,16 +185,62 @@ def test_extra_fields_schema_row_data(template_id: str, file_path: str) -> None:
     # Create resource from raw data
     resource = frictionless.Resource(source=file_path)
 
+    # Construct official schema
+    existing_schema = frictionless.Schema.from_descriptor(mapper().schema())
+
     # Open resource for row streaming
-    with resource.open() as r:
+    with (resource.open() as r):
         for row in r.row_stream:
             # Extract extra columns schema
-            schema = mapper().extra_fields_schema(row)
+            diff_schema = mapper.extra_fields_schema(row)
+            full_schema = mapper.extra_fields_schema(data=row, full_schema=True)
 
             # Assert
-            assert set(schema.field_names) == {"extraInformation1", "extraInformation2"}
-            for field in schema.fields:
+            assert set(diff_schema.field_names) == expected_extra_fieldnames
+            for field in diff_schema.fields:
                 assert field.type == "string"
+            assert set(full_schema.field_names) == \
+                   set(existing_schema.field_names) | expected_extra_fieldnames  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "template_id,file_path",
+    [
+        ("incidental_occurrence_data.csv",
+         ("abis_mapping/templates/incidental_occurrence_data/examples/"
+          "margaret_river_flora/margaret_river_flora_extra_cols.csv")),
+        ("survey_occurrence_data.csv",
+         ("abis_mapping/templates/survey_occurrence_data/examples/"
+          "margaret_river_flora/margaret_river_flora_extra_cols.csv")),
+        ("survey_metadata.csv",
+         "abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.csv"),
+    ]
+)
+def test_extra_fields_schema_raw_data(template_id: str, file_path: str) -> None:
+    """Tests extra fields schema gets extracted from row data."""
+    # Expected extra field names
+    expected_extra_fieldnames = {"extraInformation1", "extraInformation2"}
+
+    # Get mapper
+    mapper = base.mapper.get_mapper(template_id)
+    assert mapper is not None
+
+    # Get data
+    data = pathlib.Path(file_path).read_bytes()
+
+    # Construct official schema
+    existing_schema = frictionless.Schema.from_descriptor(mapper().schema())
+
+    # Extract extra columns schemas
+    diff_schema = mapper.extra_fields_schema(data)
+    full_schema = mapper.extra_fields_schema(data=data, full_schema=True)
+
+    # Assert
+    assert set(diff_schema.field_names) == expected_extra_fieldnames
+    for field in diff_schema.fields:
+        assert field.type == "string"
+    assert set(full_schema.field_names) == \
+           set(existing_schema.field_names) | expected_extra_fieldnames  # type: ignore[attr-defined]
 
 
 def test_extract_extra_fields() -> None:
@@ -251,9 +300,39 @@ def test_add_extra_fields_json() -> None:
 
     # Assert
     assert len(graph) == 1
-    for triple in graph:
-        assert triple[0] == base_uri
-        assert triple[1] == rdflib.RDFS.comment
-        assert isinstance(triple[2], rdflib.Literal)
-        assert json.loads(str(triple[2])) == expected_json
-        assert triple[2].datatype == rdflib.RDF.JSON
+    for (s, p, o) in graph:
+        assert s == base_uri
+        assert p == rdflib.RDFS.comment
+        assert isinstance(o, rdflib.Literal)
+        assert json.loads(str(o)) == expected_json
+        assert o.datatype == rdflib.RDF.JSON
+
+
+def test_add_extra_fields_json_no_data() -> None:
+    """Tests functionality of json extra fields when none exists."""
+    # Create graph and base URI
+    graph = rdflib.Graph()
+    base_uri = utils.namespaces.EXAMPLE.someBaseUri
+
+    # Create resource from raw data
+    file_path = "abis_mapping/templates/survey_metadata/examples/minimal.csv"
+    resource = frictionless.Resource(source=file_path)
+
+    # Open resource for row streaming
+    with resource.open() as r:
+        # Only one row in the file
+        row = next(r.row_stream)
+
+    # Get mapper
+    mapper = base.mapper.get_mapper("survey_metadata.csv")
+    assert mapper is not None
+
+    # Attach extra fields json to graph (should have none).
+    mapper.add_extra_fields_json(
+        subject_uri=base_uri,
+        row=row,
+        graph=graph,
+    )
+
+    # Should have no triples
+    assert len(graph) == 0

--- a/tests/templates/test_incidental_occurrence_data.py
+++ b/tests/templates/test_incidental_occurrence_data.py
@@ -5,6 +5,7 @@ import pathlib
 
 # Third-party
 import frictionless
+import pytest
 
 # Local
 import abis_mapping
@@ -34,11 +35,22 @@ def test_validation() -> None:
     assert report.valid
 
 
-def test_mapping() -> None:
+@pytest.mark.parametrize(
+    "data_path,expected_path",
+    [
+        ("abis_mapping/templates/incidental_occurrence_data/examples/margaret_river_flora/margaret_river_flora.csv",
+         "abis_mapping/templates/incidental_occurrence_data/examples/margaret_river_flora/margaret_river_flora.ttl"),
+        (("abis_mapping/templates/incidental_occurrence_data/examples"
+          "/margaret_river_flora/margaret_river_flora_extra_cols.csv"),
+         ("abis_mapping/templates/incidental_occurrence_data/examples"
+          "/margaret_river_flora/margaret_river_flora_extra_cols.ttl")),
+    ]
+)
+def test_mapping(data_path: str, expected_path: str) -> None:
     """Tests the mapping for the template"""
     # Load Data and Expected Output
-    data = DATA.read_bytes()
-    expected = EXPECTED.read_text()
+    data = pathlib.Path(data_path).read_bytes()
+    expected = pathlib.Path(expected_path).read_text()
 
     # Get Mapper
     mapper = abis_mapping.get_mapper(TEMPLATE_ID)

--- a/tests/templates/test_survey_occurrence_data.py
+++ b/tests/templates/test_survey_occurrence_data.py
@@ -6,6 +6,7 @@ import pathlib
 
 # Third-party
 import frictionless
+import pytest
 
 # Local
 import abis_mapping
@@ -36,11 +37,22 @@ def test_validation() -> None:
     assert report.valid
 
 
-def test_mapping() -> None:
+@pytest.mark.parametrize(
+    "data_path,expected_path",
+    [
+        ("abis_mapping/templates/survey_occurrence_data/examples/margaret_river_flora/margaret_river_flora.csv",
+         "abis_mapping/templates/survey_occurrence_data/examples/margaret_river_flora/margaret_river_flora.ttl"),
+        (("abis_mapping/templates/survey_occurrence_data/examples"
+          "/margaret_river_flora/margaret_river_flora_extra_cols.csv"),
+         ("abis_mapping/templates/survey_occurrence_data/examples"
+          "/margaret_river_flora/margaret_river_flora_extra_cols.ttl")),
+    ]
+)
+def test_mapping(data_path: str, expected_path: str) -> None:
     """Tests the mapping for the template"""
     # Load Data and Expected Output
-    data = DATA.read_bytes()
-    expected = EXPECTED.read_text()
+    data = pathlib.Path(data_path).read_bytes()
+    expected = pathlib.Path(expected_path).read_text()
 
     # Get Mapper
     mapper = abis_mapping.get_mapper(TEMPLATE_ID)


### PR DESCRIPTION
It now adds extra fields as a json string literal to the graph for each of the three existing templates.
Some changes to note:

- Had to go back to accepting raw data into the extra schema method, as it is required in setting up the resource before iterating over its rows.
- The extra fields are now found by slicing the field_names list rather than using the difference of sets approach, to preserve field ordering
-  The extra schema method now either returns the full schema or just the difference, controlled via the full_schema flag (default: False).