### PR TITLE
BDRSPS-241 Add spatial coverage to survey metadata mapping

### DIFF
--- a/abis_mapping/plugins/wkt.py
+++ b/abis_mapping/plugins/wkt.py
@@ -1,5 +1,7 @@
 """Provides custom frictionless wkt plugin for the package."""
 
+# Local
+from abis_mapping import settings
 
 # Third-party
 import frictionless
@@ -88,10 +90,10 @@ class WKTField(frictionless.Field):
                 TypeError: if the returned value from the shapely
                     method to_wkt is not string.
             """
-            # Serialize to default format for pyproj
+            # Serialize to wkt format
             wkt_str = shapely.to_wkt(
                 geometry=cell,
-                rounding_precision=8,
+                rounding_precision=settings.DEFAULT_WKT_ROUNDING_PRECISION,
             )
 
             # Type checking due to no types provided by the shapely package

--- a/abis_mapping/settings.py
+++ b/abis_mapping/settings.py
@@ -1,0 +1,4 @@
+"""All non-sensitive configuration parameters"""
+
+# Default precision for rounding WKT coordinates when serializing.
+DEFAULT_WKT_ROUNDING_PRECISION = 8

--- a/abis_mapping/settings.py
+++ b/abis_mapping/settings.py
@@ -1,4 +1,4 @@
-"""All non-sensitive configuration parameters"""
+"""All non-sensitive project-wide configuration parameters"""
 
 # Default precision for rounding WKT coordinates when serializing.
 DEFAULT_WKT_ROUNDING_PRECISION = 8

--- a/abis_mapping/templates/incidental_occurrence_data/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data/mapping.py
@@ -1041,7 +1041,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph (rdflib.Graph): Graph to add to
         """
         # Create WKT from Latitude and Longitude
-        wkt = utils.rdf.toWKT(
+        wkt = utils.rdf.to_wkt_point_literal(
             latitude=row["decimalLatitude"],
             longitude=row["decimalLongitude"],
             datum=vocabs.geodetic_datum.GEODETIC_DATUM.get(row["geodeticDatum"]),
@@ -1279,7 +1279,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Create WKT from Latitude and Longitude
-        wkt = utils.rdf.toWKT(
+        wkt = utils.rdf.to_wkt_point_literal(
             latitude=row["decimalLatitude"],
             longitude=row["decimalLongitude"],
             datum=vocabs.geodetic_datum.GEODETIC_DATUM.get(row["geodeticDatum"]),
@@ -2767,7 +2767,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Create WKT from Latitude and Longitude
-        wkt = utils.rdf.toWKT(
+        wkt = utils.rdf.to_wkt_point_literal(
             latitude=row["decimalLatitude"],
             longitude=row["decimalLongitude"],
             datum=vocabs.geodetic_datum.GEODETIC_DATUM.get(row["geodeticDatum"]),

--- a/abis_mapping/templates/survey_metadata/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata/examples/minimal.ttl
@@ -1,5 +1,6 @@
 @prefix bdr: <http://example.com/bdr-schema/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -37,6 +38,8 @@
     time:hasTime [ a time:TemporalEntity ;
             time:hasBeginning "2020-09-21"^^xsd:date ;
             time:hasEnd "2020-09-23"^^xsd:date ] ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/9.9.1/7844> POLYGON ((146.363 -33.826, 148.499 -33.826, 148.499 -34.411, 146.363 -33.826))"^^geo:wktLiteral ] ;
     schema:rangeIncludes <http://createme.org/survey/taxonomicCoverage/1> ;
     sosa:usedProcedure <http://createme.org/survey/procedure/surveyMethod/1> .
 

--- a/abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.ttl
+++ b/abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.ttl
@@ -1,5 +1,6 @@
 @prefix bdr: <http://example.com/bdr-schema/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
@@ -38,6 +39,8 @@
     time:hasTime [ a time:TemporalEntity ;
             time:hasBeginning "2020-09-21"^^xsd:date ;
             time:hasEnd "2020-09-23"^^xsd:date ] ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/9.9.1/7844> POLYGON ((146.363 -33.826, 148.499 -33.826, 148.499 -34.411, 146.363 -33.826))"^^geo:wktLiteral ] ;
     rdfs:comment '{"extraInformation1": "some additional info", "extraInformation2": "some more info"}'^^rdf:JSON ;
     schema:rangeIncludes <http://createme.org/survey/taxonomicCoverage/1> ;
     sosa:usedProcedure <http://createme.org/survey/procedure/surveyMethod/1> .

--- a/abis_mapping/templates/survey_metadata/mapping.py
+++ b/abis_mapping/templates/survey_metadata/mapping.py
@@ -198,7 +198,6 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         self.add_bdr_survey(
             uri=bdr_survey,
             survey_method=survey_method_procedure,
-            row=row,
             graph=graph,
         )
 
@@ -284,7 +283,6 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         self,
         uri: rdflib.URIRef,
         survey_method: rdflib.URIRef,
-        row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds the BDR survey to the graph.
@@ -293,7 +291,6 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI of the survey.
             survey_method (rdflib.URIRef): URI of node associated with
                 survey method data.
-            row (frictionless.Row): The data row being mapped.
             graph (rdflib.Graph): The graph to be modified.
         """
         # Add type and dataset

--- a/abis_mapping/templates/survey_occurrence_data/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data/mapping.py
@@ -1041,7 +1041,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph (rdflib.Graph): Graph to add to
         """
         # Create WKT from Latitude and Longitude
-        wkt = utils.rdf.toWKT(
+        wkt = utils.rdf.to_wkt_point_literal(
             latitude=row["decimalLatitude"],
             longitude=row["decimalLongitude"],
             datum=vocabs.geodetic_datum.GEODETIC_DATUM.get(row["geodeticDatum"]),
@@ -1279,7 +1279,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Create WKT from Latitude and Longitude
-        wkt = utils.rdf.toWKT(
+        wkt = utils.rdf.to_wkt_point_literal(
             latitude=row["decimalLatitude"],
             longitude=row["decimalLongitude"],
             datum=vocabs.geodetic_datum.GEODETIC_DATUM.get(row["geodeticDatum"]),
@@ -2767,7 +2767,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Create WKT from Latitude and Longitude
-        wkt = utils.rdf.toWKT(
+        wkt = utils.rdf.to_wkt_point_literal(
             latitude=row["decimalLatitude"],
             longitude=row["decimalLongitude"],
             datum=vocabs.geodetic_datum.GEODETIC_DATUM.get(row["geodeticDatum"]),

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -6,6 +6,7 @@ import datetime
 
 # Third-Party
 import rdflib
+import shapely
 
 # Local
 from abis_mapping import utils
@@ -80,10 +81,10 @@ def test_rdf_toTimestamp() -> None:
     assert literal == rdflib.Literal(date, datatype=rdflib.XSD.date)
 
 
-def test_rdf_toWKT() -> None:
-    """Tests the toWKT() Function"""
+def test_rdf_to_wkt_point_literal() -> None:
+    """Tests the to_wkt_point_literal() Function"""
     # Test Lat and Long
-    wkt = utils.rdf.toWKT(
+    wkt = utils.rdf.to_wkt_point_literal(
         latitude=-31.953512,
         longitude=115.857048,
     )
@@ -93,7 +94,7 @@ def test_rdf_toWKT() -> None:
     )
 
     # Test Lat and Long with Datum
-    wkt = utils.rdf.toWKT(
+    wkt = utils.rdf.to_wkt_point_literal(
         latitude=-31.953512,
         longitude=115.857048,
         datum=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/9.9.1/4283"),
@@ -102,3 +103,36 @@ def test_rdf_toWKT() -> None:
         "<http://www.opengis.net/def/crs/EPSG/9.9.1/4283> POINT (115.857048 -31.953512)",
         datatype=utils.namespaces.GEO.wktLiteral,
     )
+
+def test_rdf_to_wkt_literal() -> None:
+    """Tests the to_wkt_literal() Function"""
+    # Create shapely geometry
+    point = shapely.Point(115.857048, -31.953512)
+
+    # Test only geometry
+    wkt = utils.rdf.to_wkt_literal(point)
+    assert wkt == rdflib.Literal(
+        "POINT (115.857048 -31.953512)",
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+
+    # Test with Datum
+    wkt = utils.rdf.to_wkt_literal(
+        geometry=point,
+        datum=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/9.9.1/4283"),
+    )
+    assert wkt == rdflib.Literal(
+        "<http://www.opengis.net/def/crs/EPSG/9.9.1/4283> POINT (115.857048 -31.953512)",
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+
+    # Check rounding
+    point = shapely.Point(115.8570481111111, -31.95351254545)
+
+    # Test only geometry rounds correctly
+    wkt = utils.rdf.to_wkt_literal(point)
+    assert wkt == rdflib.Literal(
+        "POINT (115.85704811 -31.95351255)",
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -104,6 +104,7 @@ def test_rdf_to_wkt_point_literal() -> None:
         datatype=utils.namespaces.GEO.wktLiteral,
     )
 
+
 def test_rdf_to_wkt_literal() -> None:
     """Tests the to_wkt_literal() Function"""
     # Create shapely geometry
@@ -135,4 +136,3 @@ def test_rdf_to_wkt_literal() -> None:
         "POINT (115.85704811 -31.95351255)",
         datatype=utils.namespaces.GEO.wktLiteral,
     )
-


### PR DESCRIPTION
Added spatial coverage to metadata mapping as per [BDRSPS-235](https://youtrack.gaiaresources.com.au/youtrack/issue/BDRSPS-235/ABIS-model-for-spatial-coverage-WKT).
This introduces a settings.py file to manage the shared rounding precision constant used in both the wkt plugin and rdf wkt literal utility function. 