### PR TITLE
Bumped the poetry package version to 3.0.0-a1 (alpha1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abis-mapping"
-version = "2.2.0"
+version = "3.0.0-a1"
 description = "Provides templates and mappings to translate tabular data to ABIS rdf"
 authors = ["Gaia Resources <dev@gaiaresources.com.au>"]
 


### PR DESCRIPTION
Bumping the version to 3.0.0-a1 (alpha1) so that we can visually see if the deployment of partA is using the right version (in the swagger)