### PR TITLE
BDRSPS-321 Updated geodetic datum uris to 0 meaning latest version

### DIFF
--- a/abis_mapping/templates/survey_metadata/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata/examples/minimal.ttl
@@ -35,7 +35,7 @@
             time:hasBeginning "2020-09-21"^^xsd:date ;
             time:hasEnd "2020-09-23"^^xsd:date ] ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/9.9.1/7844> POLYGON ((146.363 -33.826, 148.499 -33.826, 148.499 -34.411, 146.363 -33.826))"^^geo:wktLiteral ] ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((146.363 -33.826, 148.499 -33.826, 148.499 -34.411, 146.363 -33.826))"^^geo:wktLiteral ] ;
     bdr:target "Coleoptera | Insecta" ;
     sosa:usedProcedure <http://createme.org/survey/procedure/surveyMethod/1> .
 

--- a/abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.ttl
+++ b/abis_mapping/templates/survey_metadata/examples/minimal_extra_cols.ttl
@@ -36,7 +36,7 @@
             time:hasBeginning "2020-09-21"^^xsd:date ;
             time:hasEnd "2020-09-23"^^xsd:date ] ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/9.9.1/7844> POLYGON ((146.363 -33.826, 148.499 -33.826, 148.499 -34.411, 146.363 -33.826))"^^geo:wktLiteral ] ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((146.363 -33.826, 148.499 -33.826, 148.499 -34.411, 146.363 -33.826))"^^geo:wktLiteral ] ;
     rdfs:comment '{"extraInformation1": "some additional info", "extraInformation2": "some more info"}'^^rdf:JSON ;
     bdr:target "Coleoptera | Insecta" ;
     sosa:usedProcedure <http://createme.org/survey/procedure/surveyMethod/1> .

--- a/abis_mapping/vocabs/geodetic_datum.py
+++ b/abis_mapping/vocabs/geodetic_datum.py
@@ -11,15 +11,15 @@ from abis_mapping import utils
 # Terms
 AGD84 = utils.vocabs.Term(
     labels=("AGD84", "EPSG:4203"),
-    iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/9.9.1/4203"),
+    iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/0/4203"),
 )
 GDA2020 = utils.vocabs.Term(
     labels=("GDA2020", "EPSG:7844"),
-    iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/9.9.1/7844"),
+    iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/0/7844"),
 )
 GDA94 = utils.vocabs.Term(
     labels=("GDA94", "EPSG:4283"),
-    iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/9.9.1/4283"),
+    iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/0/4283"),
 )
 WGS84 = utils.vocabs.Term(
     labels=("WGS84", "EPSG:4326"),


### PR DESCRIPTION
All except the WGS84 were previously set to 9.9.1. Detail found in [BDRSPS-255](https://youtrack.gaiaresources.com.au/youtrack/issue/BDRSPS-255/Double-check-geodetic-datum-URIs)