### PR TITLE
BDRSPS-335 Made survey metadata template valid for one and only one row

### DIFF
--- a/abis_mapping/templates/survey_metadata/mapping.py
+++ b/abis_mapping/templates/survey_metadata/mapping.py
@@ -8,6 +8,7 @@ from abis_mapping import utils
 
 # Third-party
 import frictionless
+import frictionless.checks
 import rdflib
 
 # Typing
@@ -52,9 +53,11 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         report: frictionless.Report = resource.validate(
             checklist=frictionless.Checklist(
                 checks=[
+                    # Enforces non-empty and maximum row count.
+                    frictionless.checks.table_dimensions(max_rows=1, min_rows=1),
+
                     # Extra Custom Checks
                     plugins.tabular.IsTabular(),
-                    plugins.empty.NotEmpty(),
                     plugins.chronological.ChronologicalOrder(
                         field_names=[
                             "temporalCoverageStartDate",


### PR DESCRIPTION
The previous `NotEmpty()` check was removed and replaced with a `min_rows=1` along with `max_rows=1` arguments to the frictionless `table_dimensions()` check.