### PR TITLE
BDRSPS-374 Implemented site template centroid mapping method

### DIFF
--- a/abis_mapping/templates/survey_site_data/mapping.py
+++ b/abis_mapping/templates/survey_site_data/mapping.py
@@ -90,7 +90,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
     def extract_geometry_defaults(
         self,
         data: base.types.ReadableType,
-    ) -> dict[str, str | None]:
+    ) -> dict[str, str]:
         """Constructs a dictionary mapping site id to default WKT.
 
         The resulting string WKT returned can then be used as the missing
@@ -100,9 +100,9 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             data (base.types.ReadableType): Raw data to be mapped.
 
         Returns:
-            dict[str, str | None]: Keys are the site id; values are the
-                appropriate point WKT serialized string or None if no valid
-                found.
+            dict[str, str]: Keys are the site id; values are the
+                appropriate point WKT serialized string. If none then
+                there is no siteID key created.
 
         """
         # Construct schema
@@ -131,9 +131,6 @@ class SurveySiteMapper(base.mapper.ABISMapper):
                 # If not footprint then we revert to using supplied longitude & latitude
                 if longitude is not None and latitude is not None:
                     result[site_id] = shapely.Point([longitude, latitude]).wkt
-                    continue
-                # If all these are missing return None for the site ID entry
-                result[site_id] = None
 
             return result
 

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -8,16 +8,23 @@ import abis_mapping.templates.survey_site_data.mapping
 
 
 def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
-    """Test the extract_geometry_defaults method."""
+    """Test the extract_geometry_defaults method.
+
+    Args:
+        mocker (pytest_mock.MockerFixture): The mocker fixture.
+    """
     # Construct a dummy raw data set using only the fields that matter to the method.
     rawh = ["siteID", "footprintWKT", "decimalLongitude", "decimalLatitude"]
     raws = [["site1", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "", ""],
             ["site2", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "10.0", "20.0"],
             ["site3", "", "10.0", "20.0"],
             ["site4", "", "", ""]]
+    # Amalgamate into a list of dicts
     all_raw = [{hname: val for hname, val in zip(rawh, ln)} for ln in raws]
 
+    # Get the specific mapper
     mapper = abis_mapping.templates.survey_site_data.mapping.SurveySiteMapper()
+
     # Modify schema to only include the necessary fields for test
     descriptor = {"fields": [
         {"name": "siteID", "type": "string"},
@@ -27,6 +34,7 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
     ]}
     mocker.patch.object(base.mapper.ABISMapper, "schema").return_value = descriptor
 
+    # Create raw data csv string
     with io.StringIO() as output:
         csv_writer = csv.DictWriter(output, fieldnames=rawh)
         csv_writer.writeheader()
@@ -42,5 +50,8 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
         "site3": "POINT (10 20)",
         "site4": None
     }
+    # Invoke method
     actual = mapper.extract_geometry_defaults(csv_data)
+
+    # Validate
     assert actual == expected

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -1,0 +1,46 @@
+"""Tests for the survey_site_data template not common to other templates."""
+import csv
+import io
+from abis_mapping import base
+import pytest_mock
+
+import abis_mapping.templates.survey_site_data.mapping
+
+
+def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
+    """Test the extract_geometry_defaults method."""
+    # Construct a dummy raw data set using only the fields that matter to the method.
+    rawh = ["siteID", "footprintWKT", "decimalLongitude", "decimalLatitude"]
+    raws = [["site1", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "", ""],
+            ["site2", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "10.0", "20.0"],
+            ["site3", "", "10.0", "20.0"],
+            ["site4", "", "", ""]]
+    all_raw = [{hname: val for hname, val in zip(rawh, ln)} for ln in raws]
+
+    mapper = abis_mapping.templates.survey_site_data.mapping.SurveySiteMapper()
+    # Modify schema to only include the necessary fields for test
+    descriptor = {"fields": [
+        {"name": "siteID", "type": "string"},
+        {"name": "footprintWKT", "type": "wkt"},
+        {"name": "decimalLongitude", "type": "number"},
+        {"name": "decimalLatitude", "type": "number"},
+    ]}
+    mocker.patch.object(base.mapper.ABISMapper, "schema").return_value = descriptor
+
+    with io.StringIO() as output:
+        csv_writer = csv.DictWriter(output, fieldnames=rawh)
+        csv_writer.writeheader()
+
+        for row in all_raw:
+            csv_writer.writerow(row)
+
+        csv_data = output.getvalue().encode("utf-8")
+
+    expected = {
+        "site1": "POINT (2.5 2.5)",
+        "site2": "POINT (2.5 2.5)",
+        "site3": "POINT (10 20)",
+        "site4": None
+    }
+    actual = mapper.extract_geometry_defaults(csv_data)
+    assert actual == expected

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -48,7 +48,6 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
         "site1": "POINT (2.5 2.5)",
         "site2": "POINT (2.5 2.5)",
         "site3": "POINT (10 20)",
-        "site4": None
     }
     # Invoke method
     actual = mapper.extract_geometry_defaults(csv_data)


### PR DESCRIPTION
The method returns a dictionary which maps `siteID` to its corresponding centroid as a point type WKT string or None of no valid point can be obtained. 