### PR TITLE
[BDRSPS-385] Added AGD66 to allowable geodeticData

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data/schema.json
+++ b/abis_mapping/templates/incidental_occurrence_data/schema.json
@@ -58,6 +58,7 @@
       "constraints": {
         "required": true,
         "enum": [
+          "AGD66",
           "AGD84",
           "EPSG:4203",
           "GDA2020",

--- a/abis_mapping/templates/incidental_occurrence_data/schema.json
+++ b/abis_mapping/templates/incidental_occurrence_data/schema.json
@@ -59,6 +59,7 @@
         "required": true,
         "enum": [
           "AGD66",
+          "EPSG:4202",
           "AGD84",
           "EPSG:4203",
           "GDA2020",

--- a/abis_mapping/templates/survey_occurrence_data/schema.json
+++ b/abis_mapping/templates/survey_occurrence_data/schema.json
@@ -58,6 +58,7 @@
       "constraints": {
         "required": true,
         "enum": [
+          "AGD66",
           "AGD84",
           "EPSG:4203",
           "GDA2020",

--- a/abis_mapping/templates/survey_occurrence_data/schema.json
+++ b/abis_mapping/templates/survey_occurrence_data/schema.json
@@ -59,6 +59,7 @@
         "required": true,
         "enum": [
           "AGD66",
+          "EPSG:4202",
           "AGD84",
           "EPSG:4203",
           "GDA2020",

--- a/abis_mapping/templates/survey_site_data/schema.json
+++ b/abis_mapping/templates/survey_site_data/schema.json
@@ -92,6 +92,7 @@
       "constraints": {
         "required": true,
         "enum": [
+          "AGD66",
           "AGD84",
           "EPSG:4203",
           "GDA2020",

--- a/abis_mapping/templates/survey_site_data/schema.json
+++ b/abis_mapping/templates/survey_site_data/schema.json
@@ -93,6 +93,7 @@
         "required": true,
         "enum": [
           "AGD66",
+          "EPSG:4202",
           "AGD84",
           "EPSG:4203",
           "GDA2020",

--- a/abis_mapping/vocabs/geodetic_datum.py
+++ b/abis_mapping/vocabs/geodetic_datum.py
@@ -9,6 +9,10 @@ from abis_mapping import utils
 
 
 # Terms
+AGD66 = utils.vocabs.Term(
+        labels=("AGD66", "EPSG:4202"),
+        iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/0/4202"),
+    )
 AGD84 = utils.vocabs.Term(
     labels=("AGD84", "EPSG:4203"),
     iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/0/4203"),
@@ -25,8 +29,7 @@ WGS84 = utils.vocabs.Term(
     labels=("WGS84", "EPSG:4326"),
     iri=rdflib.URIRef("http://www.opengis.net/def/crs/EPSG/0/4326"),
 )
-
 # Vocabulary
 GEODETIC_DATUM = utils.vocabs.RestrictedVocabulary(
-    terms=(AGD84, GDA2020, GDA94, WGS84),
+    terms=(AGD66, AGD84, GDA2020, GDA94, WGS84),
 )

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -27,6 +27,7 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
             ["site5", "", "10.0", "20.0", ""],
             ["site6", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "", "", ""],
             ["site7", "", "10.0", "20.0", "AGD66"],
+            ["site8", "", "11.0", "21.0", "EPSG:4202"],
             ]
     # Amalgamate into a list of dicts
     all_raw = [{hname: val for hname, val in zip(rawh, ln)} for ln in raws]
@@ -59,6 +60,7 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
         "site2": "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (2.5 2.5)",
         "site3": "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (10 20)",
         "site7": "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (10 20)",
+        "site8": "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (11 21)",
     }
     # Invoke method
     actual = mapper.extract_geometry_defaults(csv_data)

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -25,7 +25,9 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
             ["site3", "", "10.0", "20.0", "WGS84"],
             ["site4", "", "", "", ""],
             ["site5", "", "10.0", "20.0", ""],
-            ["site6", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "", "", ""]]
+            ["site6", "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", "", "", ""],
+            ["site7", "", "10.0", "20.0", "AGD66"],
+            ]
     # Amalgamate into a list of dicts
     all_raw = [{hname: val for hname, val in zip(rawh, ln)} for ln in raws]
 
@@ -56,6 +58,7 @@ def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
         "site1": "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (2.5 2.5)",
         "site2": "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (2.5 2.5)",
         "site3": "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (10 20)",
+        "site7": "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (10 20)",
     }
     # Invoke method
     actual = mapper.extract_geometry_defaults(csv_data)


### PR DESCRIPTION
- Added AGD66 to the vocabulary for Geodetic Datum
- Added unit test to confirm validity of AGD66 
- Added AGD66 to allowable values for `geodeticDatum` column of CSV files for incidental / survey occurance data and survey site data.