### PR TITLE
BDRSPS-396 Implement common timestamp field formats across all fields

### DIFF
--- a/abis_mapping/plugins/timestamp.py
+++ b/abis_mapping/plugins/timestamp.py
@@ -49,10 +49,6 @@ class TimestampField(frictionless.Field):
         "enum"
     ]
 
-    # Flags to allow for year and yearMonth types
-    allow_year: bool = False
-    allow_year_month: bool = False
-
     def create_value_reader(self) -> frictionless.schema.types.IValueReader:
         """Creates value reader callable."""
 
@@ -63,7 +59,7 @@ class TimestampField(frictionless.Field):
                 cell (Any): Cell to convert
 
             Returns:
-                Optional[types.DateOrDatetime]: Converted cell, or none if invalid.
+                Optional[types.Timestamp]: Converted cell, or none if invalid.
             """
             # Check cell not already timestamp value
             if isinstance(cell, types.Timestamp):
@@ -77,14 +73,8 @@ class TimestampField(frictionless.Field):
             # Catch Parsing Errors
             try:
                 # Parse and return
-                result = types.parse_timestamp(cell)
-                # If Year returned and not allowed, then it's invalid
-                if isinstance(result, types.Year) and not self.allow_year:
-                    return None
-                # If YearMonth returned and not allowed, then it's invalid
-                if isinstance(result, types.YearMonth) and not self.allow_year_month:
-                    return None
-                return result
+                return types.parse_timestamp(cell)
+
             except ValueError:
                 # Invalid
                 return None
@@ -107,14 +97,6 @@ class TimestampField(frictionless.Field):
 
         # Return value writer callable
         return value_writer
-
-    # Add the extra params to the metadata profile
-    metadata_profile_patch = {
-        "properties": {
-            "allowYear": {"type": "boolean"},
-            "allowYearMonth": {"type": "boolean"}
-        }
-    }
 
 
 # Register Timestamp Plugin

--- a/abis_mapping/templates/survey_metadata/schema.json
+++ b/abis_mapping/templates/survey_metadata/schema.json
@@ -40,8 +40,6 @@
       "example": "21/09/2020",
       "type": "timestamp",
       "format": "default",
-      "allowYear": true,
-      "allowYearMonth": true,
       "constraints": {
         "required": true
       }
@@ -53,8 +51,6 @@
       "example": "23/09/2020",
       "type": "timestamp",
       "format": "default",
-      "allowYear": true,
-      "allowYearMonth": true,
       "constraints": {
         "required": false
       }

--- a/tests/plugins/test_timestamp.py
+++ b/tests/plugins/test_timestamp.py
@@ -42,7 +42,7 @@ def test_timestamp_registered() -> None:
 
 
 def test_timestamp_type() -> None:
-    """Tests the Timestamp Type"""
+    """Tests the Timestamp Type Date and Datetime types specifically."""
     # Instantiate the field
     field = plugins.timestamp.TimestampField(
         name="testField",
@@ -55,9 +55,6 @@ def test_timestamp_type() -> None:
     assert field.read_cell("2022-4-26")[0] is None
     assert field.read_cell("26/04/22")[0] is None
     assert field.read_cell("26/04/10101")[0] is None
-    assert field.read_cell("2022")[0] is None
-    assert field.read_cell("2022-04")[0] is None
-    assert field.read_cell("04/2022")[0] is None
 
     # Read Valid Cells
     assert field.read_cell("26/04/2022")[0]  # Date
@@ -75,15 +72,13 @@ def test_timestamp_type() -> None:
 
 
 def test_timestamp_type_year_month() -> None:
-    """Tests the Timestamp type with year and month allowed."""
+    """Tests the Timestamp type with year and month specifically."""
     # Instantiate the field
     field = plugins.timestamp.TimestampField(
         name="testField",
-        allow_year_month=True
     )
 
     # Read invalid cells
-    assert field.read_cell("2022")[0] is None
     assert field.read_cell("04/22")[0] is None
     assert field.read_cell("2022-4")[0] is None
     assert field.read_cell("22-04")[0] is None
@@ -93,10 +88,6 @@ def test_timestamp_type_year_month() -> None:
     assert field.read_cell("13/2022")[0] is None
 
     # Read valid cells
-    assert field.read_cell("26/04/2022")[0]  # Date
-    assert field.read_cell("2022-04-26")[0]  # Date
-    assert field.read_cell("2022-04-26T22:00:00Z")[0]  # Date Time with Timezone
-    assert field.read_cell("2022-04-26T22:00:00+08:00")[0]  # Date Time with Timezone
     assert field.read_cell("2022-04")[0] == types.YearMonth(year=2022, month=4)  # Year month
     assert field.read_cell("04/2022")[0] == types.YearMonth(year=2022, month=4)  # Year month
     assert field.read_cell("4/2022")[0] == types.YearMonth(year=2022, month=4)  # Year month
@@ -105,7 +96,6 @@ def test_timestamp_type_year_month() -> None:
 
     # Write cell
     assert field.write_cell(types.YearMonth(year=2022, month=4))[0] == "2022-04"
-    assert field.write_cell(types.Datetime.now())[0]
 
 
 def test_ym_equality() -> None:
@@ -119,25 +109,18 @@ def test_year_equality() -> None:
 
 
 def test_timestamp_type_year() -> None:
-    """Tests the Timestamp type with year allowed."""
+    """Tests the Timestamp type year specifically."""
     # Instantiate the field
     field = plugins.timestamp.TimestampField(
         name="testField",
-        allow_year=True
     )
 
     # Read invalid cells
-    assert field.read_cell("2022-04")[0] is None
-    assert field.read_cell("04/2022")[0] is None
     assert field.read_cell("22")[0] is None
     assert field.read_cell("10101")[0] is None
     assert field.read_cell(10101)[0] is None
 
     # Read valid cells
-    assert field.read_cell("26/04/2022")[0]  # Date
-    assert field.read_cell("2022-04-26")[0]  # Date
-    assert field.read_cell("2022-04-26T22:00:00Z")[0]  # Date Time with Timezone
-    assert field.read_cell("2022-04-26T22:00:00+08:00")[0]  # Date Time with Timezone
     assert field.read_cell("2022")[0] == types.Year(2022)
     assert field.read_cell(types.Year(2022))[0] == types.Year(2022)
     assert field.read_cell("0022")[0] == types.Year(22)
@@ -145,70 +128,3 @@ def test_timestamp_type_year() -> None:
     # Write cell
     assert field.write_cell(types.Year(2022))[0] == "2022"
     assert field.write_cell(types.Datetime.now())[0]
-
-
-def test_timestamp_type_year_and_year_month() -> None:
-    """Tests the Timestamp type with both year and year month allowed."""
-    # Instantiate the field
-    field = plugins.timestamp.TimestampField(
-        name="testField",
-        allow_year=True,
-        allow_year_month=True,
-    )
-
-    # Read valid cells
-    assert field.read_cell("26/04/2022")[0]  # Date
-    assert field.read_cell("2022-04-26")[0]  # Date
-    assert field.read_cell("2022-04-26T22:00:00Z")[0]  # Date Time with Timezone
-    assert field.read_cell("2022-04-26T22:00:00+08:00")[0]  # Date Time with Timezone
-    assert field.read_cell("2022")[0] == types.Year(2022)  # Year only
-    assert field.read_cell("2022-04")[0] == types.YearMonth(year=2022, month=4)  # Year month
-    assert field.read_cell("04/2022")[0] == types.YearMonth(year=2022, month=4)  # Year month
-
-    # Write cell
-    assert field.write_cell(2022)[0] == "2022"
-    assert field.write_cell(types.YearMonth(year=2022, month=4))[0] == "2022-04"
-    assert field.write_cell(datetime.datetime.now())[0]
-
-
-def test_year_month_params_on_schema() -> None:
-    """Tests the allow year and yearmonth schema parameters."""
-    # Construct a descriptor
-    desc = {
-        "fields": [
-            {
-                "name": "testField",
-                "type": "timestamp",
-                "allowYear": True,
-                "allowYearMonth": True,
-            }
-        ]
-    }
-
-    # Validate descriptor
-    schema_report = frictionless.Schema.validate_descriptor(desc)
-    assert schema_report.valid
-
-    # Construct schema, test data and resource
-    schema = frictionless.Schema.from_descriptor(desc)
-    valid_data = [
-        "26/04/2022",
-        "2022-04-26",
-        "2022-04-26T22:00:00Z",
-        "2022-04-26T22:00:00+08:00",
-        "2022",
-        "2022-04",
-        "04/2022",
-    ]
-    resource = frictionless.Resource(
-        schema=schema,
-        source=[{"testField": s} for s in valid_data]
-    )
-
-    # Ensure resource constructed properly
-    resource.infer(stats=True)
-    assert resource.rows == len(valid_data)
-
-    # Validate resource
-    resource_report = resource.validate()
-    assert resource_report.valid


### PR DESCRIPTION
To achieve this the `allowYear` and `allowYearMonth` field properties were removed, with tests updated accordingly.