### PR TITLE
BDRSPS-399 Made timestamps now allow for no timezone on template inputs

### DIFF
--- a/abis_mapping/utils/types.py
+++ b/abis_mapping/utils/types.py
@@ -390,11 +390,10 @@ def parse_timestamp(raw: str) -> Timestamp:
         assert isinstance(d, Date)
         return d
 
-    # (3) Try Parse as ISO Datetime with Timezone
+    # (3) Try Parse as ISO Datetime
     with contextlib.suppress(Exception):
         assert len(raw) > 10  # Shortcut to disable some formats we don't want
         timestamp = dateutil.parser.isoparse(raw)
-        assert timestamp.tzinfo is not None
         return Datetime.fromtimestamp(timestamp.timestamp(), tz=timestamp.tzinfo)
 
     # Could not parse the string to a Timestamp type

--- a/tests/plugins/test_timestamp.py
+++ b/tests/plugins/test_timestamp.py
@@ -51,7 +51,6 @@ def test_timestamp_type() -> None:
     # Read Invalid Cells
     assert field.read_cell(123)[0] is None
     assert field.read_cell("hello world")[0] is None
-    assert field.read_cell("2022-04-26T22:00:00")[0] is None  # No Timezone
     assert field.read_cell("2022-4-26")[0] is None
     assert field.read_cell("26/04/22")[0] is None
     assert field.read_cell("26/04/10101")[0] is None
@@ -63,6 +62,7 @@ def test_timestamp_type() -> None:
     assert field.read_cell("26/04/2022")[0]  # Date
     assert field.read_cell("26/04/0022")[0]  # Date
     assert field.read_cell("2022-04-26")[0]  # Date
+    assert field.read_cell("2022-04-26T22:00:00")[0]  # No Timezone
     assert field.read_cell("2022-04-26T22:00:00Z")[0]  # Date Time with Timezone
     assert field.read_cell("2022-04-26T22:00:00+08:00")[0]  # Date Time with Timezone
     assert field.read_cell("2022-04-26T22:00+08:00")[0]  # Date Time with Timezone

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -58,7 +58,6 @@ def test_timestamp_parse_valid(raw: str, expected: str) -> None:
     ],
     [
         ("hello world", ),
-        ("2022-04-26T22:00:00", ),
         ("26/04/2022 22:00:00Z", ),
         ("22", ),
         ("2022-4", ),


### PR DESCRIPTION
The mapping functionality was already present for the Timestamp classes just had to allow for no timezone input for the `parse_timestamp` function. 

Please approve and merge PR#105 first then if any conflicts are present please assign this PR back to me to rectify. 