### PR TITLE
BDRSPS-435 Template IDs now include version number.

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -31,7 +31,6 @@ class ABISMapper(abc.ABC):
     registry: dict[str, type["ABISMapper"]] = {}
 
     # ABIS Mapper Template ID and Instructions File
-    template_id: str = NotImplemented  # Must be implemented
     instructions_file: str = NotImplemented  # Must be implemented
 
     # List of frictionless errors to be skipped by default
@@ -216,15 +215,27 @@ class ABISMapper(abc.ABC):
         """
         # Retrieve Template Filepath
         directory = pathlib.Path(inspect.getfile(cls)).parent
-        template_file = directory / cls.template_id  # Template File is the Template ID
+
+        # Template File is the name and filetype as extension from metadata
+        md = cls.metadata()
+        template_file = directory / f"{md['name']}.{md['file_type'].lower()}"
 
         # Return
         return template_file
 
+    @property
+    def template_id(self) -> str:
+        """Getter for the template id.
+
+        Returns:
+            str: template id from metadata
+        """
+        return self.metadata()["id"]
+
     @final
     @classmethod
     @functools.lru_cache
-    def metadata(cls) -> dict[str, Any]:
+    def metadata(cls) -> dict[str, str]:
         """Retrieves and Caches the Template Metadata for this Template
 
         Returns:
@@ -235,7 +246,9 @@ class ABISMapper(abc.ABC):
         metadata_file = directory / "metadata.json"
 
         # Read Metadata and Return
-        return json.loads(metadata_file.read_text())  # type: ignore[no-any-return]
+        md: dict[str, str] = json.loads(metadata_file.read_text())
+        md["id"] = f"{md['name']}-v{md['version']}.{md['file_type'].lower()}"
+        return md
 
     @final
     @classmethod
@@ -281,7 +294,8 @@ class ABISMapper(abc.ABC):
             mapper (type[ABISMapper]): Mapper to be registered.
         """
         # Register the mapper with its template id
-        cls.registry[mapper.template_id] = mapper
+        template_id = mapper.metadata()["id"]
+        cls.registry[template_id] = mapper
 
 
 def get_mapper(template_id: str) -> Optional[type[ABISMapper]]:

--- a/abis_mapping/templates/incidental_occurrence_data/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data/mapping.py
@@ -56,8 +56,7 @@ ROLE_STAKEHOLDER = rdflib.URIRef("http://def.isotc211.org/iso19115/-1/2018/Citat
 class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
     """ABIS Mapper for `incidental_occurrence_data.csv`"""
 
-    # Template ID and Instructions File
-    template_id = "incidental_occurrence_data.csv"
+    # Instructions File
     instructions_file = "instructions.pdf"
 
     # Default Dataset Metadata

--- a/abis_mapping/templates/incidental_occurrence_data/metadata.json
+++ b/abis_mapping/templates/incidental_occurrence_data/metadata.json
@@ -1,5 +1,5 @@
 {
-    "id": "incidental_occurrence_data.csv",
+    "name": "incidental_occurrence_data",
     "label": "Incidental Occurrence Data Template",
     "version": "1.0.0",
     "description": "A template to translate some Darwin Core fields",

--- a/abis_mapping/templates/survey_metadata/mapping.py
+++ b/abis_mapping/templates/survey_metadata/mapping.py
@@ -20,7 +20,9 @@ a = rdflib.RDF.type
 
 
 class SurveyMetadataMapper(base.mapper.ABISMapper):
-    template_id = "survey_metadata.csv"
+    """ABIS mapper for `survey_metadata"""
+
+    # Instructions filename
     instructions_file = "instructions.pdf"
 
     # Default Dataset Metadata

--- a/abis_mapping/templates/survey_metadata/metadata.json
+++ b/abis_mapping/templates/survey_metadata/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "survey_metadata.csv",
+  "name": "survey_metadata",
   "label": "Systematic Survey Metadata Template",
   "version": "0.3.1",
   "description": "A template for systematic survey metadata",

--- a/abis_mapping/templates/survey_occurrence_data/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data/mapping.py
@@ -56,8 +56,7 @@ ROLE_STAKEHOLDER = rdflib.URIRef("http://def.isotc211.org/iso19115/-1/2018/Citat
 class SurveyOccurrenceMapper(base.mapper.ABISMapper):
     """ABIS Mapper for `survey_occurrence_data.csv`"""
 
-    # Template ID and Instructions File
-    template_id = "survey_occurrence_data.csv"
+    # Instructions File
     instructions_file = "instructions.pdf"
 
     # Default Dataset Metadata

--- a/abis_mapping/templates/survey_occurrence_data/metadata.json
+++ b/abis_mapping/templates/survey_occurrence_data/metadata.json
@@ -1,5 +1,5 @@
 {
-    "id": "survey_occurrence_data.csv",
+    "name": "survey_occurrence_data",
     "label": "Systematic Survey Occurrence Data Template",
     "version": "2.1.0",
     "description": "A template to translate some Darwin Core fields",

--- a/abis_mapping/templates/survey_site_data/mapping.py
+++ b/abis_mapping/templates/survey_site_data/mapping.py
@@ -24,8 +24,7 @@ a = rdflib.RDF.type
 class SurveySiteMapper(base.mapper.ABISMapper):
     """ABIS Mapper for `survey_site_data.csv`"""
 
-    # Template ID and Instructions File
-    template_id = "survey_site_data.csv"
+    # Instructions File
     instructions_file = "instructions.pdf"
 
     # Default Dataset Metadata

--- a/abis_mapping/templates/survey_site_data/metadata.json
+++ b/abis_mapping/templates/survey_site_data/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "survey_site_data.csv",
+  "name": "survey_site_data",
   "label": "Systematic Survey Site Data Template",
   "version": "0.1.0",
   "description": "A template for systematic survey site data",

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -66,7 +66,7 @@ class TemplateTestParameters:
 
 TEST_CASES: list[TemplateTestParameters] = [
     TemplateTestParameters(
-        template_id="survey_occurrence_data.csv",
+        template_id="survey_occurrence_data-v2.1.0.csv",
         empty_template=pathlib.Path(
             "abis_mapping/templates/survey_occurrence_data/survey_occurrence_data.csv"
         ),
@@ -106,7 +106,7 @@ TEST_CASES: list[TemplateTestParameters] = [
         ],
     ),
     TemplateTestParameters(
-        template_id="survey_site_data.csv",
+        template_id="survey_site_data-v0.1.0.csv",
         empty_template=pathlib.Path(
             "abis_mapping/templates/survey_site_data/survey_site_data.csv",
         ),
@@ -124,7 +124,7 @@ TEST_CASES: list[TemplateTestParameters] = [
         allows_extra_cols=True
     ),
     TemplateTestParameters(
-        template_id="survey_metadata.csv",
+        template_id="survey_metadata-v0.3.1.csv",
         empty_template=pathlib.Path(
             "abis_mapping/templates/survey_metadata/survey_metadata.csv"
         ),
@@ -169,7 +169,7 @@ TEST_CASES: list[TemplateTestParameters] = [
         allows_extra_cols=True,
     ),
     TemplateTestParameters(
-        template_id="incidental_occurrence_data.csv",
+        template_id="incidental_occurrence_data-v1.0.0.csv",
         empty_template=pathlib.Path(
             "abis_mapping/templates/incidental_occurrence_data/incidental_occurrence_data.csv"
         ),

--- a/tests/templates/test_common.py
+++ b/tests/templates/test_common.py
@@ -85,7 +85,7 @@ class TestTemplateBasicSuite:
 
         # Retrieve metadata
         metadata = real_mapper.metadata()
-        assert metadata.get("id") == real_mapper.template_id
+        assert metadata.get("id") == real_mapper().template_id
 
     def test_get_schema(self, test_params: conftest.TemplateTestParameters) -> None:
         """Tests able to retrieve template schema."""

--- a/tests/templates/test_survey_occurrence_data.py
+++ b/tests/templates/test_survey_occurrence_data.py
@@ -15,6 +15,7 @@ import pathlib
 from abis_mapping import base
 from abis_mapping import utils
 from abis_mapping import vocabs
+from abis_mapping import templates
 from tests import conftest
 
 
@@ -168,7 +169,7 @@ class TestDefaultMap:
         all_raw = [{hname: val for hname, val in zip(rawh, ln)} for ln in scenario.raws]
 
         # Get mapper
-        mapper = base.mapper.get_mapper("survey_occurrence_data.csv")
+        mapper = templates.survey_occurrence_data.mapping.SurveyOccurrenceMapper
         assert mapper is not None
 
         # Modify schema to only fields required for test
@@ -226,7 +227,7 @@ class TestDefaultMap:
             csv_data = output.getvalue().encode("utf-8")
 
         # Get mapper
-        mapper = base.mapper.get_mapper("survey_occurrence_data.csv")
+        mapper = templates.survey_occurrence_data.mapping.SurveyOccurrenceMapper
         assert mapper is not None
 
         expected = pathlib.Path("abis_mapping/templates/survey_occurrence_data/examples/organism_qty.ttl").read_text()


### PR DESCRIPTION
revised template id to now be generated from metadata json. Version number now included in template id.
This is in preparation to allow for running multiple versions of templates at the same time. 