### PR TITLE
BDRSPS-426 Allowing no geometry on sites

### DIFF
--- a/abis_mapping/plugins/logical_or.py
+++ b/abis_mapping/plugins/logical_or.py
@@ -52,10 +52,13 @@ class LogicalOr(frictionless.Check):
         if len(row_fk_map) > 0:
             return
 
+        # Create error note base on values provided to the check
+        note = f"the fields {self.field_names}"
+        note += f" and foreign key fields {self.foreign_keys.keys()}" if len(self.foreign_keys) > 0 else ""
+        note += " are constrained by logical OR, one or more value must be provided"
+
         # Yield Error
         yield frictionless.errors.RowConstraintError.from_row(
             row=row,
-            note=(
-                f"the columns {self.field_names} are constrained by logical OR, one or more value must be provided"
-            )
+            note=note,
         )

--- a/abis_mapping/templates/survey_occurrence_data/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data/mapping.py
@@ -141,6 +141,34 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Return Validation Report
         return report
 
+    def extract_site_id_keys(
+        self,
+        data: base.types.ReadableType,
+    ) -> dict[str, bool]:
+        """Extract site id key values from the data.
+
+        Args:
+            data (base.types.ReadableType): Raw data to be mapped.
+
+        Returns:
+            dict[str, bool]: Keys are the site id values encountered
+                in the data, values are all 'True',
+        """
+        # Construct schema
+        schema = frictionless.Schema.from_descriptor(self.schema())
+
+        # Construct resource
+        resource = frictionless.Resource(
+            data=data,
+            format="csv",
+            schema=schema,
+        )
+
+        # Iterate over rows to extract values
+        with resource.open() as r:
+            # Construct dictionary and return
+            return {row["siteID"]: True for row in r.row_stream if row["siteID"] is not None}
+
     def apply_mapping(
         self,
         data: base.types.ReadableType,

--- a/tests/plugins/test_logical_or.py
+++ b/tests/plugins/test_logical_or.py
@@ -3,6 +3,7 @@
 
 # Third-Party
 import frictionless
+import pytest
 
 # Local
 from abis_mapping import plugins
@@ -41,3 +42,46 @@ def test_check_logical_or() -> None:
     # Check
     assert not report.valid
     assert len(report.flatten()) == 1
+
+
+@pytest.mark.parametrize(
+    "fk_set,n_err",
+    [
+        ({"d": {"D", "DD", "DDD"}}, 0),
+        ({"e": {"E"}, "d": {"D"}}, 0),
+        ({"e": {"D"}, "d": {"E"}}, 1),
+    ]
+)
+def test_check_logical_or_with_foreign_keys(fk_set: dict[str, set[str]], n_err: int) -> None:
+    """Tests the logical or checker with foreign keys provided."""
+    # Construct fake resource
+    resource = frictionless.Resource(
+        source=[
+            # Valid
+            {"a": "A", "b": None, "c": None, "d": "D", "e": "E"},
+            {"a": None, "b": "B", "c": None, "d": "D", "e": "E"},
+            {"a": None, "b": None, "c": "C", "d": "D", "e": "E"},
+            {"a": "A", "b": "B", "c": None, "d": "D", "e": "E"},
+            {"a": "A", "b": None, "c": "C", "d": "D", "e": "E"},
+            {"a": None, "b": "B", "c": "C", "d": "D", "e": "E"},
+            {"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+
+            # Invalid
+            {"a": None, "b": None, "c": None, "d": "D", "e": "E"},
+        ]
+    )
+
+    report = resource.validate(
+        checklist=frictionless.Checklist(
+            checks=[
+                plugins.logical_or.LogicalOr(
+                    field_names=["a", "b", "c"],
+                    foreign_keys=fk_set,
+                )
+            ]
+        )
+    )
+
+    # Check
+    assert report.valid == (n_err == 0)
+    assert len(report.flatten()) == n_err


### PR DESCRIPTION
In the case that lat/long has been provided for all corresponding occurrences in the occurrence template of a systematic survey 3 template system. Achieved by:
- Modifying the logical OR custom check to allow for an optional input of values corresponding to a foreign key field
- Means that the validation will pass on the site template if there is at least an occurrence with the corresponding site id.
- However if the occurrence is missing lat/long AND the site is missing default geometry then it will get picked up at the occurrence template validation stage.