### PR TITLE
BDRSPS-494 New site template geometry validation

### DIFF
--- a/abis_mapping/plugins/__init__.py
+++ b/abis_mapping/plugins/__init__.py
@@ -8,6 +8,7 @@ from . import empty
 from . import list
 from . import logical_or
 from . import mutual_inclusion
+from . import sites_geometry
 from . import tabular
 from . import timestamp
 from . import wkt

--- a/abis_mapping/plugins/sites_geometry.py
+++ b/abis_mapping/plugins/sites_geometry.py
@@ -46,7 +46,7 @@ class SitesGeometry(frictionless.Check):
             return
 
         # Create error note
-        note = f"invalid geometry: "
+        note = "invalid geometry: "
         if (wkt or (lat and long)) and not datum:
             note += f"invalid datum {row['geodeticDatum']} provided."
         elif lat ^ long:
@@ -55,7 +55,7 @@ class SitesGeometry(frictionless.Check):
                 f"got ({row['decimalLatitude']}, {row['decimalLongitude']})"
             )
         else:
-            note += f"incorrect combination of geometry fields provided."
+            note += "incorrect combination of geometry fields provided."
 
         # Yield error
         yield frictionless.errors.RowConstraintError.from_row(

--- a/abis_mapping/plugins/sites_geometry.py
+++ b/abis_mapping/plugins/sites_geometry.py
@@ -1,0 +1,64 @@
+"""Provides extra frictionless geometry sites' data template checks for the package."""
+
+
+# Third-party
+import frictionless
+import frictionless.errors
+import attrs
+
+# Typing
+from typing import Iterator
+
+
+@attrs.define(kw_only=True, repr=False)
+class SitesGeometry(frictionless.Check):
+    """Checks whether geometry related fields are provided in a correct combination."""
+
+    # Check attributes
+    type = "sites-geometry"
+    Errors = [frictionless.errors.RowConstraintError]
+
+    # Occurrences site ids to be passed in from occurrence template.
+    occurrence_site_ids: set[str] = set()
+
+    def validate_row(self, row: frictionless.Row) -> Iterator[frictionless.Error]:
+        """Called to validate the given row (on every row).
+
+        Args:
+            row (frictionless.Row): The row to check the site's geometry for
+
+        Yields:
+            frictionless.Error: For when the check condition is violated.
+        """
+        # Extract values as bool
+        lat = row["decimalLatitude"] is not None
+        long = row["decimalLongitude"] is not None
+        datum = row["geodeticDatum"] is not None
+        wkt = row["footprintWKT"] is not None
+        site_id = row["siteID"] in self.occurrence_site_ids
+
+        # Perform check
+        if (
+            (lat and long and datum) or
+            (wkt and datum) or
+            site_id
+        ):
+            return
+
+        # Create error note
+        note = f"invalid geometry: "
+        if (wkt or (lat and long)) and not datum:
+            note += f"invalid datum {row['geodeticDatum']} provided."
+        elif lat ^ long:
+            note += (
+                f"latitude and longitude must be provided together, "
+                f"got ({row['decimalLatitude']}, {row['decimalLongitude']})"
+            )
+        else:
+            note += f"incorrect combination of geometry fields provided."
+
+        # Yield error
+        yield frictionless.errors.RowConstraintError.from_row(
+            row=row,
+            note=note
+        )

--- a/abis_mapping/templates/survey_site_data/mapping.py
+++ b/abis_mapping/templates/survey_site_data/mapping.py
@@ -72,20 +72,8 @@ class SurveySiteMapper(base.mapper.ABISMapper):
                     # Extra custom checks
                     plugins.tabular.IsTabular(),
                     plugins.empty.NotEmpty(),
-                    plugins.mutual_inclusion.MutuallyInclusive(
-                        field_names=[
-                            "decimalLatitude",
-                            "decimalLongitude",
-                        ]
-                    ),
-                    plugins.logical_or.LogicalOr(
-                        field_names=[
-                            "footprintWKT",
-                            "decimalLatitude",
-                        ],
-                        foreign_keys={
-                            "siteID": set(site_id_map.keys())
-                        },
+                    plugins.sites_geometry.SitesGeometry(
+                        occurrence_site_ids=set(site_id_map)
                     ),
                     plugins.chronological.ChronologicalOrder(
                         field_names=[
@@ -174,7 +162,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         base_iri: Optional[rdflib.Namespace] = None,
         **kwargs: Any,
     ) -> Iterator[rdflib.Graph]:
-        """Applies Mapping for the `survey_site_data.csv` Template
+        """Applies Mapping for the `survey_site_data.csv` Template.
 
         Args:
             data (base.types.ReadableType): Valid raw data to be mapped.
@@ -427,7 +415,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         geodetic_datum = row["geodeticDatum"]
         footprint_wkt = row["footprintWKT"]
 
-        if not footprint_wkt:
+        if footprint_wkt is None or geodetic_datum is None:
             return
 
         # Construct geometry
@@ -460,7 +448,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         decimal_longitude = row["decimalLongitude"]
         geodetic_datum = row["geodeticDatum"]
 
-        if not decimal_latitude or not decimal_longitude:
+        if decimal_latitude is None or decimal_longitude is None or geodetic_datum is None:
             return
 
         # Construct geometry

--- a/abis_mapping/templates/survey_site_data/schema.json
+++ b/abis_mapping/templates/survey_site_data/schema.json
@@ -90,7 +90,7 @@
       "type": "string",
       "format": "default",
       "constraints": {
-        "required": true,
+        "required": false,
         "enum": [
           "AGD66",
           "EPSG:4202",

--- a/tests/plugins/test_site_geometry.py
+++ b/tests/plugins/test_site_geometry.py
@@ -1,0 +1,133 @@
+"""Provides unit tests for the abis_mapping.plugins.site_geometry module."""
+
+
+# Third-party
+import frictionless
+import pytest
+import attrs
+
+# Local
+from abis_mapping import plugins
+
+# Typing
+from typing import NamedTuple, Any, Iterator
+
+
+class Case(NamedTuple):
+    """Tuple for all the test cases."""
+    lat: float | None
+    long: float | None
+    wkt: str | None
+    datum: str | None
+    site_ids: set[str]
+    valid: bool
+
+
+@attrs.define(kw_only=True)
+class Parameters:
+    """Parameters for the test cases"""
+    header: list[str]
+    cases: list[Case]
+
+    def compiled(self) -> Iterator[tuple]:
+        for case in self.cases:
+            source = {key: val for key, val in zip(self.header, case)}
+            source["siteID"] = "site1"
+            yield source, case[-2], case[-1]
+
+
+class TestSiteGeometry:
+    """Test the site_geometry check"""
+
+    params = Parameters(
+        header=["decimalLatitude", "decimalLongitude", "footprintWKT", "geodeticDatum"],
+        cases=[
+            ("", "", "", "", set(), False),
+            ("", "", "", "", {"site1"}, True),
+            ("", "", "", "WGS84", set(), False),
+            ("", "", "", "WGS84", {"site1"}, True),
+            ("", "", "POINT (0 0)", "", set(), False),
+            ("", "", "POINT (0 0)", "", {"site1"}, True),
+            ("", "", "POINT (0 0)", "WGS84", set(), True),
+            ("", "", "POINT (0 0)", "WGS84", {"site1"}, True),
+            ("", "0", "", "", set(), False),
+            ("", "0", "", "", {"site1"}, True),
+            ("", "0", "", "WGS84", set(), False),
+            ("", "0", "", "WGS84", {"site1"}, True),
+            ("", "0", "POINT(0 0)", "", set(), False),
+            ("", "0", "POINT(0 0)", "", {"site1"}, True),
+            ("", "0", "POINT(0 0)", "WGS84", set(), True),
+            ("", "0", "POINT(0 0)", "WGS84", {"site1"}, True),
+            ("0", "", "", "", set(), False),
+            ("0", "", "", "", {"site1"}, True),
+            ("0", "", "", "WGS84", set(), False),
+            ("0", "", "", "WGS84", {"site1"}, True),
+            ("0", "", "POINT (0 0)", "", set(), False),
+            ("0", "", "POINT (0 0)", "", {"site1"}, True),
+            ("0", "", "POINT (0 0)", "WGS84", set(), True),
+            ("0", "", "POINT (0 0)", "WGS84", {"site1"}, True),
+            ("0", "0", "", "", set(), False),
+            ("0", "0", "", "", {"site1"}, True),
+            ("0", "0", "", "WGS84", set(), True),
+            ("0", "0", "", "WGS84", {"site1"}, True),
+            ("0", "0", "POINT(0 0)", "", set(), False),
+            ("0", "0", "POINT(0 0)", "", {"site1"}, True),
+            ("0", "0", "POINT(0 0)", "WGS84", set(), True),
+            ("0", "0", "POINT(0 0)", "WGS84", {"site1"}, True),
+        ],
+    )
+
+    @pytest.mark.parametrize(
+        "source,site_ids,valid",
+        list(params.compiled())
+    )
+    def test_check_site_geometry_valid(self, source: dict[str, Any], site_ids: set[str], valid: bool) -> None:
+        """Tests the site goemetry checker.
+
+        Args:
+            source (dict[str, Any]): Source for creating resource.
+            site_ids (set[str]): Site ids sent from occurrence template.
+            valid (bool): Whether the case is valid.
+        """
+        # Construct schema
+        descriptor = {
+            "fields": [
+                {
+                    "name": "decimalLatitude",
+                    "type": "number",
+                },
+                {
+                    "name": "decimalLongitude",
+                    "type": "number",
+                },
+                {
+                    "name": "footprintWKT",
+                    "type": "string",
+                },
+                {
+                    "name": "geodeticDatum",
+                    "type": "string",
+                },
+                {
+                    "name": "siteID",
+                    "type": "string",
+                },
+            ],
+        }
+        schema = frictionless.Schema.from_descriptor(descriptor)
+
+        # Construct fake resource
+        resource = frictionless.Resource(
+            source=[source],
+            schema=schema,
+        )
+
+        # Validate
+        report = resource.validate(
+            checklist=frictionless.Checklist(
+                checks=[plugins.sites_geometry.SitesGeometry(occurrence_site_ids=site_ids)]
+            )
+        )
+
+        # Assert
+        assert report.valid == valid

--- a/tests/plugins/test_site_geometry.py
+++ b/tests/plugins/test_site_geometry.py
@@ -20,9 +20,18 @@ class Parameters:
     cases: list[tuple]
 
     def compiled(self) -> Iterator[tuple]:
+        """Compiles all the parameters for the test cases.
+
+        Yields:
+            tuple: The parameters for each test case.
+        """
+        # Iterate through each of the cases.
         for case in self.cases:
+            # Construct data row
             source = {key: val for key, val in zip(self.header, case)}
+            # Add siteID column
             source["siteID"] = "site1"
+            # Yield result
             yield source, case[-2], case[-1]
 
 

--- a/tests/plugins/test_site_geometry.py
+++ b/tests/plugins/test_site_geometry.py
@@ -10,24 +10,14 @@ import attrs
 from abis_mapping import plugins
 
 # Typing
-from typing import NamedTuple, Any, Iterator
-
-
-class Case(NamedTuple):
-    """Tuple for all the test cases."""
-    lat: float | None
-    long: float | None
-    wkt: str | None
-    datum: str | None
-    site_ids: set[str]
-    valid: bool
+from typing import Any, Iterator
 
 
 @attrs.define(kw_only=True)
 class Parameters:
     """Parameters for the test cases"""
     header: list[str]
-    cases: list[Case]
+    cases: list[tuple]
 
     def compiled(self) -> Iterator[tuple]:
         for case in self.cases:
@@ -79,7 +69,7 @@ class TestSiteGeometry:
 
     @pytest.mark.parametrize(
         "source,site_ids,valid",
-        list(params.compiled())
+        params.compiled()
     )
     def test_check_site_geometry_valid(self, source: dict[str, Any], site_ids: set[str], valid: bool) -> None:
         """Tests the site goemetry checker.

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -171,7 +171,11 @@ class TestSiteIDForeignKeys:
     ]
 )
 def test_add_footprint_geometry_no_geometry(row_dict: dict[str, Any]) -> None:
-    """Tests that add_footprint_geometry won't add to graph without valid WKT geometry."""
+    """Tests that add_footprint_geometry won't add to graph without valid WKT geometry.
+
+    Args:
+        row_dict (dict[str, Any]): Raw data row to use for test case.
+    """
     # Create graph
     graph = rdflib.Graph()
 
@@ -214,7 +218,11 @@ def test_add_footprint_geometry_no_geometry(row_dict: dict[str, Any]) -> None:
     ]
 )
 def test_add_point_geometry_no_geometry(row_dict: dict[str, Any]) -> None:
-    """Tests that add_point_geometry method doesn't add to graph for no point geometries."""
+    """Tests that add_point_geometry method doesn't add to graph for no point geometries.
+
+    Args:
+        row_dict (dict[str, Any]): Raw data row to use for test case.
+    """
     # Create graph
     graph = rdflib.Graph()
 

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -4,14 +4,19 @@
 import csv
 import io
 
+# Third-party
+import attrs
+import frictionless
+import pytest
+import pytest_mock
+import rdflib
+
 # Local
 from abis_mapping import base
 import abis_mapping.templates.survey_site_data.mapping
 
-# Third-party
-import pytest_mock
-import attrs
-import pytest
+# Typing
+from typing import Any
 
 
 def test_extract_geometry_defaults(mocker: pytest_mock.MockerFixture) -> None:
@@ -84,10 +89,10 @@ class TestSiteIDForeignKeys:
         Scenario(
             name="valid_with_site_id_map",
             raws=[
-                ["site1", "-38.94", "115.21", "POINT(30 10)"],
-                ["site2", "-38.94", "115.21", ""],
-                ["site3", "", "", "LINESTRING(30 10, 10 30, 40 40)"],
-                ["site4", "", "", ""],
+                ["site1", "-38.94", "115.21", "POINT(30 10)", "WGS84"],
+                ["site2", "-38.94", "115.21", "", "GDA2020"],
+                ["site3", "", "", "LINESTRING(30 10, 10 30, 40 40)", "GDA94"],
+                ["site4", "", "", "", ""],
             ],
             site_id_map={
                 "site4": True,
@@ -97,7 +102,7 @@ class TestSiteIDForeignKeys:
         Scenario(
             name="invalid_missing_geometry_and_not_in_map",
             raws=[
-                ["site1", "", "", ""],
+                ["site1", "", "", "", ""],
             ],
             site_id_map={
                 "site2": True
@@ -119,7 +124,7 @@ class TestSiteIDForeignKeys:
             mocker (pytest_mock.MockerFixture): The mocker fixture.
         """
         # Construct fake data
-        rawh = ["siteID", "decimalLatitude", "decimalLongitude", "footprintWKT"]
+        rawh = ["siteID", "decimalLatitude", "decimalLongitude", "footprintWKT", "geodeticDatum"]
         all_raw = [{hname: val for hname, val in zip(rawh, ln)} for ln in scenario.raws]
 
         # Get mapper
@@ -155,3 +160,85 @@ class TestSiteIDForeignKeys:
         if not report.valid:
             error_codes = [code for codes in report.flatten(['type']) for code in codes]
             assert set(error_codes) == scenario.expected_error_codes
+
+
+@pytest.mark.parametrize(
+    "row_dict",
+    [
+        {"footprintWKT": None, "geodeticDatum": None},
+        {"footprintWKT": None, "geodeticDatum": "WGS84"},
+        {"footprintWKT": "POINT (0 0)", "geodeticDatum": None},
+    ]
+)
+def test_add_footprint_geometry_no_geometry(row_dict: dict[str, Any]) -> None:
+    """Tests that add_footprint_geometry won't add to graph without valid WKT geometry."""
+    # Create graph
+    graph = rdflib.Graph()
+
+    # Create resource
+    resource = frictionless.Resource(
+        source=[row_dict]
+    )
+
+    # Extract row
+    with resource.open() as r:
+        row = next(r.row_stream)
+
+    # Create URI
+    uri = rdflib.URIRef("http://example.com/abis-mapping/test")
+
+    # Get mapper
+    mapper = abis_mapping.templates.survey_site_data.mapping.SurveySiteMapper()
+
+    # Call method
+    mapper.add_footprint_geometry(
+        uri=uri,
+        row=row,
+        graph=graph,
+    )
+
+    # Validate no triples added to graph
+    assert len(graph) == 0
+
+
+@pytest.mark.parametrize(
+    "row_dict",
+    [
+        {"decimalLatitude": None, "decimalLongitude": None, "geodeticDatum": None},
+        {"decimalLatitude": None, "decimalLongitude": None, "geodeticDatum": "WGS84"},
+        {"decimalLatitude": None, "decimalLongitude": 0, "geodeticDatum": None},
+        {"decimalLatitude": None, "decimalLongitude": 0, "geodeticDatum": "WGS84"},
+        {"decimalLatitude": 0, "decimalLongitude": None, "geodeticDatum": None},
+        {"decimalLatitude": 0, "decimalLongitude": None, "geodeticDatum": "WGS84"},
+        {"decimalLatitude": 0, "decimalLongitude": 0, "geodeticDatum": None},
+    ]
+)
+def test_add_point_geometry_no_geometry(row_dict: dict[str, Any]) -> None:
+    """Tests that add_point_geometry method doesn't add to graph for no point geometries."""
+    # Create graph
+    graph = rdflib.Graph()
+
+    # Create resource
+    resource = frictionless.Resource(
+        source=[row_dict]
+    )
+
+    # Extract row
+    with resource.open() as r:
+        row = next(r.row_stream)
+
+    # Create URI
+    uri = rdflib.URIRef("http://example.com/abis-mapping/test")
+
+    # Get mapper
+    mapper = abis_mapping.templates.survey_site_data.mapping.SurveySiteMapper()
+
+    # Call method
+    mapper.add_point_geometry(
+        uri=uri,
+        row=row,
+        graph=graph,
+    )
+
+    # Validate no triples added to graph
+    assert len(graph) == 0


### PR DESCRIPTION
This implements the agreed validation rules for the site template, incorporating whether the geodetic datum is included or not. A new custom frictionless check was created for this purpose specifically, hence the hard-coding of field names within the check's `validate_row` method. 