### PR TITLE
BDRSPS-509 URL Encoding for SiteID URIRefs

### DIFF
--- a/abis_mapping/templates/survey_occurrence_data/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data/mapping.py
@@ -1,5 +1,7 @@
 """Provides ABIS Mapper for `survey_occurrence_data.csv` Template"""
 
+# Standard
+import urllib.parse
 
 # Third-Party
 import frictionless
@@ -346,7 +348,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_determined_by = utils.rdf.uri(f"provider/{row['threatStatusDeterminedBy']}", base_iri)
         organism_quantity_observation = utils.rdf.uri(f"observation/organismQuantity/{row_num}", base_iri)
         organism_quantity_value = utils.rdf.uri(f"value/organismQuantity/{row_num}", base_iri)
-        site = dataset + f"/Site/{row['siteID']}" if row['siteID'] else None
+        site = dataset + f"/Site/{urllib.parse.quote(row['siteID'], safe='')}" if row['siteID'] else None
 
         # Add Provider Identified By
         self.add_provider_identified(

--- a/abis_mapping/templates/survey_site_data/mapping.py
+++ b/abis_mapping/templates/survey_site_data/mapping.py
@@ -1,5 +1,14 @@
 """Provides ABIS Mapper for `survey_site_data.csv` Template"""
+
+# Standard
 import decimal
+import urllib.parse
+
+# Third-party
+import rdflib
+import frictionless
+import shapely
+import shapely.geometry
 
 # Local
 from abis_mapping import base
@@ -7,12 +16,6 @@ from abis_mapping import plugins
 from abis_mapping import types
 from abis_mapping import utils
 from abis_mapping import vocabs
-
-# Third-party
-import rdflib
-import frictionless
-import shapely
-import shapely.geometry
 
 # Typing
 from typing import Any, Optional, Iterator
@@ -237,7 +240,8 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         row_num = row.row_number - 1
 
         site_visit = utils.rdf.uri(f"visit/site/{row_num}", base_iri)
-        site = dataset + f"/Site/{row['siteID']}"
+        site_id = urllib.parse.quote(row['siteID'], safe='')
+        site = dataset + f"/Site/{site_id}"
 
         # Add site
         self.add_site(

--- a/tests/templates/test_survey_occurrence_data.py
+++ b/tests/templates/test_survey_occurrence_data.py
@@ -71,6 +71,10 @@ class TestDefaultMap:
                 ["site1", "-38.94", "115.21", "WGS84", "", "", "", ""],
                 ["", "-38.94", "115.21", "WGS84", "", "", "VU", "VIC"],
                 ["site2", "-38.94", "115.21", "WGS84", "", "", "", ""],
+                # The following show that non-url safe characters get encoded during mapping.
+                ["site a", "-38.94", "115.21", "WGS84", "", "", "", ""],
+                ["site/b", "-38.94", "115.21", "WGS84", "", "", "", ""],
+                ["site%20c", "-38.94", "115.21", "WGS84", "", "", "", ""],
             ],
             default_map={},
         ),

--- a/tests/templates/test_survey_site_data.py
+++ b/tests/templates/test_survey_site_data.py
@@ -93,6 +93,11 @@ class TestSiteIDForeignKeys:
                 ["site2", "-38.94", "115.21", "", "GDA2020"],
                 ["site3", "", "", "LINESTRING(30 10, 10 30, 40 40)", "GDA94"],
                 ["site4", "", "", "", ""],
+                # Following shows that non-url safe siteIDs get endcoded when mapping.
+                ["site a", "-38.94", "115.21", "", "GDA2020"],
+                ["site/b", "-38.94", "115.21", "", "GDA2020"],
+                [r"site\c", "-38.94", "115.21", "", "GDA2020"],
+                ["site\nd", "-38.94", "115.21", "", "GDA2020"],
             ],
             site_id_map={
                 "site4": True,


### PR DESCRIPTION
altered siteID url creation to be url encoded for survey site and survey occurrence mappings. Added some site ids with spaces and slashes etc to show that no error raised now.