### PR TITLE
BDRSPS-732 Add versions to generated instructions 

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v2/templates/instructions.md
+++ b/abis_mapping/templates/incidental_occurrence_data_v2/templates/instructions.md
@@ -1,3 +1,5 @@
+{% extends "BASE_TEMPLATE base.md" %}
+{% block body %}
 # INCIDENTAL OCCURRENCE DATA TEMPLATE INSTRUCTIONS
 
 ## OVERVIEW
@@ -147,3 +149,4 @@ diverse set of characters and languages.
 
 For assistance, please contact: <bdr-support@gaiaresources.com.au>
 
+{% endblock %}

--- a/abis_mapping/templates/survey_metadata/templates/instructions.md
+++ b/abis_mapping/templates/survey_metadata/templates/instructions.md
@@ -1,3 +1,5 @@
+{% extends "BASE_TEMPLATE base.md" %}
+{% block body %}
 # SYSTEMATIC SURVEY METADATA TEMPLATE INSTRUCTIONS
 
 ## OVERVIEW
@@ -145,3 +147,4 @@ issues related to character representation and ensure that your software can han
 diverse set of characters and languages.
 
 For assistance, please contact: <bdr-support@gaiaresources.com.au>
+{% endblock %}

--- a/abis_mapping/templates/survey_occurrence_data/templates/instructions.md
+++ b/abis_mapping/templates/survey_occurrence_data/templates/instructions.md
@@ -1,3 +1,5 @@
+{% extends "BASE_TEMPLATE base.md" %}
+{% block body %}
 # SYSTEMATIC SURVEY OCCURRENCES DATA TEMPLATE INSTRUCTIONS
 
 ## OVERVIEW
@@ -150,4 +152,4 @@ issues related to character representation and ensure that your software can han
 diverse set of characters and languages.
 
 For assistance, please contact: <bdr-support@gaiaresources.com.au>
-
+{% endblock %}

--- a/abis_mapping/templates/survey_site_data/templates/instructions.md
+++ b/abis_mapping/templates/survey_site_data/templates/instructions.md
@@ -1,3 +1,5 @@
+{% extends "BASE_TEMPLATE base.md" %}
+{% block body %}
 # SYSTEMATIC SURVEY SITE DATA TEMPLATE INSTRUCTIONS
 
 ## OVERVIEW
@@ -141,3 +143,4 @@ issues related to character representation and ensure that your software can han
 diverse set of characters and languages.
 
 For assistance, please contact: <bdr-support@gaiaresources.com.au>
+{% endblock %}

--- a/docs/contexts/incidental_occurrence_data_v2.py
+++ b/docs/contexts/incidental_occurrence_data_v2.py
@@ -1,6 +1,7 @@
 """Declares and registers the incidental occurrence data instruction rendering context."""
 
 # Local
+from abis_mapping import base
 from abis_mapping import vocabs
 from docs import contexts
 from docs import tables
@@ -8,6 +9,9 @@ from docs import tables
 
 # Constants
 mapper_id = "incidental_occurrence_data-v2.0.0.csv"
+
+# Retrieve mapper
+mapper = base.mapper.get_mapper(mapper_id)
 
 # Create context
 _ctx = {
@@ -19,6 +23,7 @@ _ctx = {
     "values": {
         "geodetic_datum_count": len(vocabs.geodetic_datum.GeodeticDatum.terms),
     },
+    "metadata": mapper.metadata() if mapper is not None else None
 }
 
 # Register

--- a/docs/contexts/survey_metadata.py
+++ b/docs/contexts/survey_metadata.py
@@ -1,6 +1,7 @@
 """Declares and registers the survey metadata instruction rendering context."""
 
 # Local
+from abis_mapping import base
 from abis_mapping import vocabs
 from docs import contexts
 from docs import tables
@@ -8,6 +9,9 @@ from docs import tables
 
 # Constants
 mapper_id = "survey_metadata-v1.0.0.csv"
+
+# Retrieve mapper
+mapper = base.mapper.get_mapper(mapper_id)
 
 # Create context
 _ctx = {
@@ -18,6 +22,7 @@ _ctx = {
     "values": {
         "geodetic_datum_count": len(vocabs.geodetic_datum.GeodeticDatum.terms),
     },
+    "metadata": mapper.metadata() if mapper is not None else None,
 }
 
 # Register

--- a/docs/contexts/survey_occurrence_data.py
+++ b/docs/contexts/survey_occurrence_data.py
@@ -1,6 +1,7 @@
 """Declares and registers the survey occurrence data instruction rendering context."""
 
 # Local
+from abis_mapping import base
 from abis_mapping import vocabs
 from docs import contexts
 from docs import tables
@@ -8,6 +9,9 @@ from docs import tables
 
 # Constants
 mapper_id = "survey_occurrence_data-v1.0.0.csv"
+
+# Retrieve mapper
+mapper = base.mapper.get_mapper(mapper_id)
 
 # Create context
 _ctx = {
@@ -19,6 +23,7 @@ _ctx = {
     "values": {
         "geodetic_datum_count": len(vocabs.geodetic_datum.GeodeticDatum.terms),
     },
+    "metadata": mapper.metadata() if mapper is not None else None,
 }
 
 # Register

--- a/docs/contexts/survey_site_data.py
+++ b/docs/contexts/survey_site_data.py
@@ -1,12 +1,16 @@
 """Declares and registers the survey site data instruction rendering context."""
 
 # Local
+from abis_mapping import base
 from docs import contexts
 from docs import tables
 
 
 # Constants
 mapper_id = "survey_site_data-v1.0.0.csv"
+
+# Retrieve mapper
+mapper = base.mapper.get_mapper(mapper_id)
 
 
 # Declare context
@@ -15,6 +19,7 @@ _ctx = {
         "vocabularies": tables.vocabs.VocabTabler(mapper_id).generate_table(as_markdown=True),
         "fields": tables.fields.FieldTabler(mapper_id).generate_table(as_markdown=True),
     },
+    "metadata": mapper.metadata() if mapper is not None else None,
 }
 
 

--- a/docs/templates/base.md
+++ b/docs/templates/base.md
@@ -1,0 +1,9 @@
+{% block metadata %}---
+title: {{ metadata.label }}
+summary: {{ metadata.description }}
+---{% endblock %}
+{% block versions %}<small>
+**abis-mapping** v{{ project_version }} &emsp; **{{metadata.name}}** v{{ metadata.version }}
+</small>{% endblock %}
+
+{% block body %}{% endblock %}

--- a/tests/docs/test_instructions.py
+++ b/tests/docs/test_instructions.py
@@ -6,6 +6,7 @@ import unittest.mock
 # Third-party
 import jinja2
 import pytest
+import pytest_mock
 
 # Local
 from docs import instructions
@@ -30,6 +31,37 @@ class TestMapperLoader:
         # Assert
         assert isinstance(pth, str)
         assert pth.split("/")[-2:] == ["templates", "blank_template.md"]
+        assert rld is not None
+        assert rld() is True
+
+    def test_get_source_base_template(
+        self,
+        mocked_mapper: unittest.mock.MagicMock,
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
+        """Tests get_source using BASE_TEMPLATE keyword.
+
+        Args:
+            mocked_mapper (unittest.mock.MagicMock): Mocked mapper.
+            mocker (pytest_mock.MockerFixture): The pytest MockerFixture.
+        """
+        # Patch and get mock for the Filesystem loader get_source method
+        mocked_fs_get_source = mocker.patch.object(jinja2.FileSystemLoader, "get_source")
+        mocked_fs_get_source.return_value = ("some src", "some_file.md", lambda: True)
+
+        # Create jinja env
+        env = jinja2.Environment(loader=instructions.MapperLoader("some id"))
+
+        # Invoke
+        src, pth, rld = instructions.MapperLoader("some_id").get_source(
+            environment=env,
+            template="BASE_TEMPLATE blank_template.md"
+        )
+
+        # Should call mock with the BASE_TEMPLATE keyword stripped.
+        mocked_fs_get_source.assert_called_with(env, "blank_template.md")
+        assert src == "some src"
+        assert pth == "some_file.md"
         assert rld is not None
         assert rld() is True
 


### PR DESCRIPTION
created base jinja markdown template to add version numbering to generated instruction documents and have the existing templates inherit from it.