### PR TITLE
Documentation CI changes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,10 +7,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - 'main'
 permissions:
   contents: write
 jobs:
-  publish_documentation:
+  documentation:
     env:
       DOCS_BRANCH: docs-site
     runs-on: ubuntu-latest
@@ -36,16 +39,19 @@ jobs:
           poetry env info
       - name: Generate markdown
         run: poetry run bash scripts/generate_instructions.sh
-      - name: Build and deploy documentation
+      - name: "Build/Deploy/Delete documentation"
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.event.ref }}" == "refs/heads/main" ]]; then
             echo "Updating 'dev' documentation" 
             poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} dev 
-          elif [ "${{ github.event.action }}" == "published" ]; then
+          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.action }}" == "published" ]]; then
             echo "Creating documentation version ${{ github.ref_name }}"
             poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} --update-aliases ${{ github.ref_name }} latest 
             poetry run mike set-default --push --branch=${{ env.DOCS_BRANCH }} latest
-          elif [ "${{ github.event.action }}" == "deleted" ]; then
+          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.action }}" == "deleted" ]]; then
             echo "Deleting documentation version ${{ github.ref_name }}"
             poetry run mike delete --push --branch=${{ env.DOCS_BRANCH }} ${{ github.ref_name }}
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Building documentation for pull request, not publishing."
+            poetry run mkdocs build
           fi

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,21 +24,18 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Install Poetry
+        run: pipx install poetry==1.8.3
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install project and generate markdown
+          cache: "poetry"
+      - name: Install project and dependencies
         run: |
-          pipx install poetry==1.6.1
-          poetry install
-          poetry run bash scripts/generate_instructions.sh
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
+          poetry install --sync
+          poetry env info
+      - name: Generate markdown
+        run: poetry run bash scripts/generate_instructions.sh
       - name: Build and deploy documentation
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.11"
       - name: Install project and generate markdown
         run: |
           pipx install poetry==1.6.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,21 +37,27 @@ jobs:
         run: |
           poetry install --sync
           poetry env info
+
       - name: Generate markdown
         run: poetry run bash scripts/generate_instructions.sh
-      - name: Build/Deploy/Delete documentation
+
+      - name: Build and deploy dev documentation
+        if: ${{ github.event_name == 'push' }}
+        run: poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} dev
+
+      - name: Build and deploy published tag documentation
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.event.ref }}" == "refs/heads/main" ]]; then
-            echo "Updating 'dev' documentation" 
-            poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} dev 
-          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.action }}" == "published" ]]; then
-            echo "Creating documentation version ${{ github.ref_name }}"
-            poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} --update-aliases ${{ github.ref_name }} latest 
-            poetry run mike set-default --push --branch=${{ env.DOCS_BRANCH }} latest
-          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.action }}" == "deleted" ]]; then
-            echo "Deleting documentation version ${{ github.ref_name }}"
-            poetry run mike delete --push --branch=${{ env.DOCS_BRANCH }} ${{ github.ref_name }}
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Building documentation for pull request, not publishing."
-            poetry run mkdocs build
-          fi
+          echo "Creating documentation version ${{ github.ref_name }}"
+          poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} --update-aliases ${{ github.ref_name }} latest
+          poetry run mike set-default --push --branch=${{ env.DOCS_BRANCH }} latest
+
+      - name: Remove deleted tag documentation
+        if: ${{ github.event_name == 'release' && github.event.action == 'deleted' }}
+        run: |
+          echo "Deleting documentation version ${{ github.ref_name }}"
+          poetry run mike delete --push --branch=${{ env.DOCS_BRANCH }} ${{ github.ref_name }}
+
+      - name: Build documentation for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        run: poetry run mkdocs build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,7 @@ on:
       - main
   pull_request:
     branches:
-      - 'main'
+      - main
 permissions:
   contents: write
 jobs:
@@ -32,14 +32,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "poetry"
+          cache: poetry
       - name: Install project and dependencies
         run: |
           poetry install --sync
           poetry env info
       - name: Generate markdown
         run: poetry run bash scripts/generate_instructions.sh
-      - name: "Build/Deploy/Delete documentation"
+      - name: Build/Deploy/Delete documentation
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.event.ref }}" == "refs/heads/main" ]]; then
             echo "Updating 'dev' documentation" 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Documentation
 on:
   release:
     types:


### PR DESCRIPTION
* Install poetry before actions/setup-python - this makes actions/setup-python configure poetry to use the python version setup.
* cache poetry virtual env with cache: "poetry" option, also use --sync option to remove no-longer used packages from the cache.
* Generate markdown in own step.
* Remove cache action that did nothing.
* Build docs on PRs