### PR TITLE
BDRSPS-785 Hide  new templates during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ Dockerfile
 !/docs/pages/index.md
 /docs/pages/index.html
 site/
+
+# YAPF
+.style.yapf

--- a/abis_mapping/settings.py
+++ b/abis_mapping/settings.py
@@ -1,11 +1,14 @@
 """All non-sensitive project-wide configuration parameters"""
 
+# Standard
+import importlib.metadata
+
 # Third-party
 import pydantic_settings
 
 
 class Settings(pydantic_settings.BaseSettings):
-    """Class for defining default project-wide settings."""
+    """Model for defining default project-wide settings."""
     # Default precision for rounding WKT coordinates when serializing.
     DEFAULT_WKT_ROUNDING_PRECISION: int = 8
 
@@ -18,5 +21,11 @@ class Settings(pydantic_settings.BaseSettings):
     # The version of the documents to be selected
     INSTRUCTIONS_VERSION: str = 'dev'
 
+    # Version parts
+    MAJOR_VERSION: int = int(importlib.metadata.version("abis-mapping").split(".", 1)[0])
+
     # If changing via environment variable prefix name with 'ABIS_MAPPING_'
     model_config = pydantic_settings.SettingsConfigDict(env_prefix="ABIS_MAPPING_")
+
+
+SETTINGS = Settings()

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -1,4 +1,7 @@
-import os
+"""Mapper implementation for the incidental occurrence data v3 template."""
+
+# Standard
+import importlib.metadata
 
 # Third-Party
 import frictionless
@@ -3143,6 +3146,6 @@ def has_specimen(row: frictionless.Row) -> bool:
 
 
 # Register Mapper
-if os.getenv("PYTEST_VERSION"):
-    # incidental v3 is still in development, only register for unit tests.
+if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+    # incidental v3 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(IncidentalOccurrenceMapper)

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -1,7 +1,5 @@
 """Mapper implementation for the incidental occurrence data v3 template."""
 
-# Standard
-import importlib.metadata
 
 # Third-Party
 import frictionless
@@ -11,6 +9,7 @@ import rdflib
 from abis_mapping import base
 from abis_mapping import utils
 from abis_mapping import plugins
+from abis_mapping import settings
 from abis_mapping import types
 from abis_mapping import vocabs
 
@@ -3146,6 +3145,6 @@ def has_specimen(row: frictionless.Row) -> bool:
 
 
 # Register Mapper
-if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+if settings.SETTINGS.MAJOR_VERSION >= 5:
     # incidental v3 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(IncidentalOccurrenceMapper)

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -2,7 +2,6 @@
 
 # Standard
 import dataclasses
-import importlib.metadata
 
 # Third-party
 import frictionless
@@ -12,6 +11,7 @@ import rdflib
 # Local
 from abis_mapping import base
 from abis_mapping import plugins
+from abis_mapping import settings
 from abis_mapping import types
 from abis_mapping import utils
 
@@ -1011,6 +1011,6 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+if settings.SETTINGS.MAJOR_VERSION >= 5:
     # SSD v2 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(SurveyMetadataMapper)

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -2,7 +2,7 @@
 
 # Standard
 import dataclasses
-import os
+import importlib.metadata
 
 # Third-party
 import frictionless
@@ -1011,6 +1011,6 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-if os.getenv("PYTEST_VERSION"):
-    # survey v2 is still in development, only register for unit tests.
+if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+    # SSD v2 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(SurveyMetadataMapper)

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -1,7 +1,7 @@
 """Provides ABIS Mapper for `survey_occurrence_data.csv` Template v2"""
 
 # Standard
-import os
+import importlib.metadata
 import urllib.parse
 
 # Third-Party
@@ -3478,6 +3478,6 @@ def has_specimen(row: frictionless.Row) -> bool:
 
 
 # Register Mapper
-if os.getenv("PYTEST_VERSION"):
-    # survey v3 is still in development, only register for unit tests.
+if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+    # SSD v2 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(SurveyOccurrenceMapper)

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -1,7 +1,6 @@
 """Provides ABIS Mapper for `survey_occurrence_data.csv` Template v2"""
 
 # Standard
-import importlib.metadata
 import urllib.parse
 
 # Third-Party
@@ -12,6 +11,7 @@ import rdflib
 from abis_mapping import base
 from abis_mapping import utils
 from abis_mapping import plugins
+from abis_mapping import settings
 from abis_mapping import types
 from abis_mapping import vocabs
 
@@ -3478,6 +3478,6 @@ def has_specimen(row: frictionless.Row) -> bool:
 
 
 # Register Mapper
-if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+if settings.SETTINGS.MAJOR_VERSION >= 5:
     # SSD v2 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(SurveyOccurrenceMapper)

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -3,7 +3,6 @@
 # Standard
 import dataclasses
 import decimal
-import importlib.metadata
 import urllib.parse
 
 # Third-party
@@ -15,6 +14,7 @@ import shapely.geometry
 # Local
 from abis_mapping import base
 from abis_mapping import plugins
+from abis_mapping import settings
 from abis_mapping import types
 from abis_mapping import utils
 from abis_mapping import vocabs
@@ -970,6 +970,6 @@ class SurveySiteMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+if settings.SETTINGS.MAJOR_VERSION >= 5:
     # SSD v2 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(SurveySiteMapper)

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -1,10 +1,10 @@
 """Provides ABIS Mapper for `survey_site_data.csv` Template v2"""
 
 # Standard
-import decimal
-import os
-import urllib.parse
 import dataclasses
+import decimal
+import importlib.metadata
+import urllib.parse
 
 # Third-party
 import rdflib
@@ -970,6 +970,6 @@ class SurveySiteMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-if os.getenv("PYTEST_VERSION"):
-    # survey v3 is still in development, only register for unit tests.
+if int(importlib.metadata.version("abis-mapping").split(".", 1)[0]) >= 5:
+    # SSD v2 is still in development, keep hidden until v5 release candidates are created
     base.mapper.ABISMapper.register_mapper(SurveySiteMapper)

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -6,6 +6,9 @@ import pathlib
 # Third-party
 import attrs
 
+# Local
+from abis_mapping import settings
+
 # Typing
 from typing import Optional, Iterable
 
@@ -151,94 +154,99 @@ TEST_CASES: list[TemplateTestParameters] = [
         metadata_sampling_type="systematic survey",
         allows_extra_cols=True,
     ),
+]
 
-    # Survey templates v2
-    TemplateTestParameters(
-        template_id="survey_occurrence_data-v2.0.0.csv",
-        empty_template=pathlib.Path(
-            "abis_mapping/templates/survey_occurrence_data_v2/survey_occurrence_data.csv"
-        ),
-        mapping_cases=[
-            MappingParameters(
-                data=pathlib.Path(
-                    ("abis_mapping/templates/survey_occurrence_data_v2/examples"
-                     "/margaret_river_flora/margaret_river_flora.csv")
-                ),
-                expected=pathlib.Path(
-                    ("abis_mapping/templates/survey_occurrence_data_v2/examples"
-                     "/margaret_river_flora/margaret_river_flora.ttl")
-                ),
+if settings.SETTINGS.MAJOR_VERSION >= 5:
+    TEST_CASES += [
+        # Survey templates v2
+        TemplateTestParameters(
+            template_id="survey_occurrence_data-v2.0.0.csv",
+            empty_template=pathlib.Path(
+                "abis_mapping/templates/survey_occurrence_data_v2/survey_occurrence_data.csv"
             ),
-            MappingParameters(
-                scenario_name="organism_qty",
-                should_validate=True,
-                data=pathlib.Path(
-                    "abis_mapping/templates/survey_occurrence_data_v2/examples/organism_qty.csv",
+            mapping_cases=[
+                MappingParameters(
+                    data=pathlib.Path(
+                        ("abis_mapping/templates/survey_occurrence_data_v2/examples"
+                         "/margaret_river_flora/margaret_river_flora.csv")
+                    ),
+                    expected=pathlib.Path(
+                        ("abis_mapping/templates/survey_occurrence_data_v2/examples"
+                         "/margaret_river_flora/margaret_river_flora.ttl")
+                    ),
                 ),
-                expected=pathlib.Path(
-                    "abis_mapping/templates/survey_occurrence_data_v2/examples/organism_qty.ttl",
+                MappingParameters(
+                    scenario_name="organism_qty",
+                    should_validate=True,
+                    data=pathlib.Path(
+                        "abis_mapping/templates/survey_occurrence_data_v2/examples/organism_qty.csv",
+                    ),
+                    expected=pathlib.Path(
+                        "abis_mapping/templates/survey_occurrence_data_v2/examples/organism_qty.ttl",
+                    )
+                ),
+            ],
+            metadata_sampling_type="systematic survey",
+            allows_extra_cols=True,
+            chunking_parameters=[
+                ChunkingParameters(
+                    data=pathlib.Path(
+                        ("abis_mapping/templates/survey_occurrence_data_v2/examples/"
+                         "margaret_river_flora/margaret_river_flora.csv")
+                    ),
+                    chunk_size=7,
+                    yield_count=3,
+                ),
+            ],
+        ),
+        TemplateTestParameters(
+            template_id="survey_site_data-v2.0.0.csv",
+            empty_template=pathlib.Path(
+                "abis_mapping/templates/survey_site_data_v2/survey_site_data.csv",
+            ),
+            mapping_cases=[
+                MappingParameters(
+                    data=pathlib.Path(
+                        "abis_mapping/templates/survey_site_data_v2/examples/minimal.csv"
+                    ),
+                    expected=pathlib.Path(
+                        "abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl"
+                    ),
+                ),
+            ],
+            metadata_sampling_type="systematic survey",
+            allows_extra_cols=True
+        ),
+        TemplateTestParameters(
+            template_id="survey_metadata-v2.0.0.csv",
+            empty_template=pathlib.Path(
+                "abis_mapping/templates/survey_metadata_v2/survey_metadata.csv"
+            ),
+            mapping_cases=[
+                MappingParameters(
+                    data=pathlib.Path(
+                        "abis_mapping/templates/survey_metadata_v2/examples/minimal.csv"
+                    ),
+                    expected=pathlib.Path(
+                        "abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl"
+                    ),
+                ),
+                MappingParameters(
+                    scenario_name="invalid_chrono_order",
+                    should_validate=False,
+                    expected_error_codes={'row-constraint'},
+                    data=pathlib.Path(
+                        "abis_mapping/templates/survey_metadata_v2/examples/minimal_error_chronological_order.csv"
+                    ),
+                    expected=None,
                 )
-            ),
-        ],
-        metadata_sampling_type="systematic survey",
-        allows_extra_cols=True,
-        chunking_parameters=[
-            ChunkingParameters(
-                data=pathlib.Path(
-                    ("abis_mapping/templates/survey_occurrence_data_v2/examples/"
-                     "margaret_river_flora/margaret_river_flora.csv")
-                ),
-                chunk_size=7,
-                yield_count=3,
-            ),
-        ],
-    ),
-    TemplateTestParameters(
-        template_id="survey_site_data-v2.0.0.csv",
-        empty_template=pathlib.Path(
-            "abis_mapping/templates/survey_site_data_v2/survey_site_data.csv",
+            ],
+            metadata_sampling_type="systematic survey",
+            allows_extra_cols=True,
         ),
-        mapping_cases=[
-            MappingParameters(
-                data=pathlib.Path(
-                    "abis_mapping/templates/survey_site_data_v2/examples/minimal.csv"
-                ),
-                expected=pathlib.Path(
-                    "abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl"
-                ),
-            ),
-        ],
-        metadata_sampling_type="systematic survey",
-        allows_extra_cols=True
-    ),
-    TemplateTestParameters(
-        template_id="survey_metadata-v2.0.0.csv",
-        empty_template=pathlib.Path(
-            "abis_mapping/templates/survey_metadata_v2/survey_metadata.csv"
-        ),
-        mapping_cases=[
-            MappingParameters(
-                data=pathlib.Path(
-                    "abis_mapping/templates/survey_metadata_v2/examples/minimal.csv"
-                ),
-                expected=pathlib.Path(
-                    "abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl"
-                ),
-            ),
-            MappingParameters(
-                scenario_name="invalid_chrono_order",
-                should_validate=False,
-                expected_error_codes={'row-constraint'},
-                data=pathlib.Path(
-                    "abis_mapping/templates/survey_metadata_v2/examples/minimal_error_chronological_order.csv"
-                ),
-                expected=None,
-            )
-        ],
-        metadata_sampling_type="systematic survey",
-        allows_extra_cols=True,
-    ),
+    ]
 
+TEST_CASES += [
     # Incidental templates
     TemplateTestParameters(
         template_id="incidental_occurrence_data-v1.0.0.csv",
@@ -299,38 +307,41 @@ TEST_CASES: list[TemplateTestParameters] = [
                 yield_count=3,
             ),
         ],
-    ),
-    TemplateTestParameters(
-        template_id="incidental_occurrence_data-v3.0.0.csv",
-        empty_template=pathlib.Path(
-            "abis_mapping/templates/incidental_occurrence_data_v3/incidental_occurrence_data.csv"
-        ),
-        mapping_cases=[
-            MappingParameters(
-                data=pathlib.Path(
-                    ("abis_mapping/templates/incidental_occurrence_data_v3/examples/"
-                     "margaret_river_flora/margaret_river_flora.csv")
-                ),
-                expected=pathlib.Path(
-                    ("abis_mapping/templates/incidental_occurrence_data_v3/examples/"
-                     "margaret_river_flora/margaret_river_flora.ttl")
-                ),
-            ),
-        ],
-        metadata_sampling_type="incidental",
-        allows_extra_cols=True,
-        chunking_parameters=[
-            ChunkingParameters(
-                data=pathlib.Path(
-                    ("abis_mapping/templates/incidental_occurrence_data_v3/examples/"
-                     "margaret_river_flora/margaret_river_flora.csv")
-                ),
-                chunk_size=7,
-                yield_count=3,
-            ),
-        ],
-    ),
+    )
 ]
+if settings.SETTINGS.MAJOR_VERSION >= 5:
+    TEST_CASES.append(
+        TemplateTestParameters(
+            template_id="incidental_occurrence_data-v3.0.0.csv",
+            empty_template=pathlib.Path(
+                "abis_mapping/templates/incidental_occurrence_data_v3/incidental_occurrence_data.csv"
+            ),
+            mapping_cases=[
+                MappingParameters(
+                    data=pathlib.Path(
+                        ("abis_mapping/templates/incidental_occurrence_data_v3/examples/"
+                         "margaret_river_flora/margaret_river_flora.csv")
+                    ),
+                    expected=pathlib.Path(
+                        ("abis_mapping/templates/incidental_occurrence_data_v3/examples/"
+                         "margaret_river_flora/margaret_river_flora.ttl")
+                    ),
+                ),
+            ],
+            metadata_sampling_type="incidental",
+            allows_extra_cols=True,
+            chunking_parameters=[
+                ChunkingParameters(
+                    data=pathlib.Path(
+                        ("abis_mapping/templates/incidental_occurrence_data_v3/examples/"
+                         "margaret_river_flora/margaret_river_flora.csv")
+                    ),
+                    chunk_size=7,
+                    yield_count=3,
+                ),
+            ],
+        )
+    )
 
 
 def mapping_test_args() -> Iterable[tuple[str, str, MappingParameters]]:


### PR DESCRIPTION
altered condition allowing the registering of templates to be only when abis-mapping version is bumped to v5.x.x or higher.
The rationale is that it was causing unit tests to fail on BDR-partA since the returned template lists didn't match what was expected. I added a rule to exclude a yapf config i use locally since my switch back to vim. 