### PR TITLE
BDRSPS-823 Integrate docs TOC into nav section to free up horizontal space for tables

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ theme:
   name: material
   icon:
     repo: fontawesome/brands/github
+  features:
+    - toc.integrate
 docs_dir: docs/pages
 extra:
   version:


### PR DESCRIPTION
Enabling this option: https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-integration

e.g.:

![image](https://github.com/user-attachments/assets/e5a239de-2c9d-4cb8-80a5-99d18027a2b5)
