### PR TITLE
Bdrsps 870 - Incidental v3 template instructions preparations

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/templates/instructions.md
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/templates/instructions.md
@@ -91,7 +91,7 @@ must come from one of five options in this table.</font></ins>
 
 <a name="threatStatus-vocabularies"></a>
 <ins>Table 2b: Suggested values for conditionally mandatory values for the threatStatus and
-conservationAuthority in the template. State and Territory conservationAuthority spelt out
+conservationAuthority in the template. State and Territory Conservation Authorities spelt out
 in words are also valid. For some threatStatus terms, alternative labels are provided that are also
 valid for that conservationAuthority.
 

--- a/docs/contexts/__init__.py
+++ b/docs/contexts/__init__.py
@@ -3,6 +3,7 @@
 # Local
 from . import base
 from . import incidental_occurrence_data_v2
+from . import incidental_occurrence_data_v3
 from . import survey_occurrence_data
 from . import survey_metadata
 from . import survey_site_data

--- a/docs/contexts/incidental_occurrence_data_v3.py
+++ b/docs/contexts/incidental_occurrence_data_v3.py
@@ -1,0 +1,41 @@
+"""Declares and registers the incidental occurrence data instruction rendering context."""
+
+# Local
+from abis_mapping import base
+from abis_mapping import vocabs
+from docs import contexts
+from docs import tables
+
+# Typing
+from typing import Any
+
+# Constants
+mapper_id = "incidental_occurrence_data-v3.0.0.csv"
+
+
+# Create context
+def _ctx() -> dict[str, Any]:
+    """Returns the context for rendering the instructions of the mapper."""
+    # Retrieve mapper
+    mapper = base.mapper.get_mapper(mapper_id)
+
+    # Return
+    return {
+        "tables": {
+            "fields": tables.fields.FieldTabler(template_id=mapper_id, format="markdown").generate_table(),
+            "vocabularies": tables.vocabs.VocabTabler(template_id=mapper_id, format="markdown").generate_table(),
+            "threat_status": tables.threat_status.ThreatStatusTabler(
+                template_id=mapper_id,
+                format="markdown"
+            ).generate_table(),
+        },
+        "values": {
+            "geodetic_datum_count": len(vocabs.geodetic_datum.GeodeticDatum.terms),
+        },
+        "metadata": mapper.metadata() if mapper is not None else None
+    }
+
+
+# Register once the mapper is also registered
+if mapper_id in base.mapper.get_mappers():
+    contexts.base.register(mapper_id, _ctx())

--- a/docs/templates/base.md
+++ b/docs/templates/base.md
@@ -1,5 +1,5 @@
 {% block metadata %}---
-title: {{ metadata.label }}
+title: {{ metadata.label }} - v{{ metadata.version }}
 summary: {{ metadata.description }}
 ---{% endblock %}
 {% block versions %}<small>

--- a/scripts/generate_instructions.sh
+++ b/scripts/generate_instructions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 python docs/instructions.py -i -o docs/pages/incidental_occurrence_data-v2.0.0.csv.md incidental_occurrence_data-v2.0.0.csv
+python docs/instructions.py -o docs/pages/incidental_occurrence_data-v3.0.0.csv.md incidental_occurrence_data-v3.0.0.csv
 python docs/instructions.py -o docs/pages/survey_occurrence_data-v1.0.0.csv.md survey_occurrence_data-v1.0.0.csv
 python docs/instructions.py -o docs/pages/survey_metadata-v1.0.0.csv.md survey_metadata-v1.0.0.csv
 python docs/instructions.py -o docs/pages/survey_site_data-v1.0.0.csv.md survey_site_data-v1.0.0.csv

--- a/scripts/generate_instructions.sh
+++ b/scripts/generate_instructions.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 python docs/instructions.py -i -o docs/pages/incidental_occurrence_data-v2.0.0.csv.md incidental_occurrence_data-v2.0.0.csv
-python docs/instructions.py -o docs/pages/incidental_occurrence_data-v3.0.0.csv.md incidental_occurrence_data-v3.0.0.csv
 python docs/instructions.py -o docs/pages/survey_occurrence_data-v1.0.0.csv.md survey_occurrence_data-v1.0.0.csv
 python docs/instructions.py -o docs/pages/survey_metadata-v1.0.0.csv.md survey_metadata-v1.0.0.csv
 python docs/instructions.py -o docs/pages/survey_site_data-v1.0.0.csv.md survey_site_data-v1.0.0.csv

--- a/tests/docs/tables/test_threat_status.py
+++ b/tests/docs/tables/test_threat_status.py
@@ -25,31 +25,95 @@ class TestThreatStatusTabler:
             unittest.mock.MagicMock: mocked mapper.
         """
         # Modify the mocked mapper schema
+        fields = [
+            {
+                "name": "someName",
+                "title": "Some Title",
+                "description": "Some description",
+                "example": "SOME EXAMPLE",
+                "type": "string",
+                "format": "default",
+                "constraints": {
+                    "required": True,
+                    "enum": [
+                        "SOME EXAMPLE",
+                        "Option 2",
+                        "plan C",
+                    ]
+                },
+                "vocabularies": [
+                    # Threat status required for tabler to work
+                    "THREAT_STATUS",
+                ],
+            },
+            {
+                "name": "conservationAuthority",
+                "title": "Conservation Authority",
+                "description": "The authority of the conservation.",
+                "example": "ConsAuth Inc.",
+                "type": "string",
+                "format": "default",
+                "constraints": {
+                    "required": False,
+                },
+            },
+        ]
         mocked_mapper.return_value.schema.return_value = {
-            "fields": [
-                {
-                    "name": "someName",
-                    "title": "Some Title",
-                    "description": "Some description",
-                    "example": "SOME EXAMPLE",
-                    "type": "string",
-                    "format": "default",
-                    "constraints": {
-                        "required": True,
-                        "enum": [
-                            "SOME EXAMPLE",
-                            "Option 2",
-                            "plan C",
-                        ]
-                    },
-                    "vocabularies": [
-                        # Threat status required for tabler to work
-                        "THREAT_STATUS",
-                    ],
-                }
-            ]
+            "fields": fields
         }
+        mocked_mapper.return_value.fields.return_value = {f["name"]: f for f in fields}
 
+        return mocked_mapper
+
+    @pytest.fixture
+    def mocked_deprecated_mapper(self, mocked_mapper: unittest.mock.MagicMock) -> unittest.mock.MagicMock:
+        """Modifies and returns a mocked mapper.
+
+        Args:
+            mocked_mapper (unittest.mock.MagicMock): mocked mapper.
+
+        Returns:
+            unittest.mock.MagicMock: mocked mapper.
+        """
+        fields = [
+            {
+                "name": "someName",
+                "title": "Some Title",
+                "description": "Some description",
+                "example": "SOME EXAMPLE",
+                "type": "string",
+                "format": "default",
+                "constraints": {
+                    "required": True,
+                    "enum": [
+                        "SOME EXAMPLE",
+                        "Option 2",
+                        "plan C",
+                    ]
+                },
+                "vocabularies": [
+                    # Threat status required for tabler to work
+                    "THREAT_STATUS",
+                ],
+            },
+            {
+                "name": "conservationJurisdiction",
+                "title": "Conservation Jurisdiction",
+                "description": "The jurisdiction of the conservation.",
+                "example": "ConsJur Inc.",
+                "type": "string",
+                "format": "default",
+                "constraints": {
+                    "required": False,
+                },
+            },
+        ]
+
+        # Modify the mocked mapper schema
+        mocked_mapper.return_value.schema.return_value = {
+            "fields": fields
+        }
+        mocked_mapper.return_value.fields.return_value = {f["name"]: f for f in fields}
         return mocked_mapper
 
     @pytest.fixture
@@ -120,6 +184,30 @@ class TestThreatStatusTabler:
         # Assert
         assert actual == (
             "|conservationAuthority|threatStatus|threatStatus alternative labels|\n"
+            "|:---:|:---|:---|\n"
+            "|SOME AUTHORITY|SOME STATUS|SSTAT|\n"
+        )
+
+    def test_deprecated_table_generates(
+        self,
+        mocked_deprecated_mapper: unittest.mock.MagicMock,
+        mocked_vocab: unittest.mock.MagicMock,
+    ) -> None:
+        """Tests generation of a table that has no conservationAuthority field.
+
+        Args:
+            mocked_deprecated_mapper (unittest.mock.MagicMock): The mocked deprecated mapper object.
+            mocked_vocab (unittest.mock.MagicMock): The mocked vocab object.
+        """
+        # Create tabler
+        tabler = tables.threat_status.ThreatStatusTabler("some id", format="markdown")
+
+        # Generate table
+        actual = tabler.generate_table()
+
+        # Assert
+        assert actual == (
+            "|conservationJurisdiction|threatStatus|threatStatus alternative labels|\n"
             "|:---:|:---|:---|\n"
             "|SOME AUTHORITY|SOME STATUS|SSTAT|\n"
         )


### PR DESCRIPTION
- Modified incidental occurrence v3 instructions to match changes in template.
- Altered the threatstatus tabler to correctly display correct naming of conservationJurisdiction vs conservationAuthority field. 
- Created context for v3 incidental template instructions. 
- Added version numbering to generated mkdocs page titles to avoid confusion with duplicated titles. 