### PR TITLE
Setup directory for archiving documentation of removed templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ Dockerfile
 /result.md
 /tests/templates/**/*-result.ttl
 /docs/pages/**/*.md
+!/docs/pages/archived_templates/*.md
 !/docs/pages/index.md
 /docs/pages/index.html
 site/

--- a/docs/pages/archived_templates/index.md
+++ b/docs/pages/archived_templates/index.md
@@ -1,0 +1,5 @@
+# Archived templates
+
+Archived templates are no longer available for use.
+
+Documentation for archived templates is retained here for reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
     repo: fontawesome/brands/github
   features:
     - toc.integrate
+    - navigation.indexes
 docs_dir: docs/pages
 extra:
   version:


### PR DESCRIPTION
What it will look like:

![image](https://github.com/user-attachments/assets/d7db8f05-f68d-40d0-a75a-b7bfe5984bac)
