### PR TITLE
BDRSPS-925 Add SampleCollections for certain attributes in the incidental v3 mapping

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -17,6 +17,62 @@
     tern:hasSimpleValue "Category 1 - The Department of Biodiversity and Conservation" ;
     tern:hasValue <http://createme.org/value/sensitivityCategory/16> .
 
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/HumanObservation> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/14> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - HumanObservation" ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/HumanObservation> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/PreservedSpecimen> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/13>,
+        <http://createme.org/sample/specimen/15> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/PreservedSpecimen> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/new-basis-of-record> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/16> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - new basis of record" ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/new-basis-of-record> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/dataGeneralizations/Coordinates-generalised> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/16> ;
+    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/14>,
+        <http://createme.org/sample/field/15> ;
+    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/15> ;
+    schema:identifier "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/habitat/new-habitat> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/16> ;
+    schema:identifier "Occurrence Collection - Habitat - new habitat" ;
+    tern:hasAttribute <http://createme.org/attribute/habitat/new-habitat> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/15> ;
+    schema:identifier "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/preparations/new-preparations> a tern:SampleCollection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/16> ;
+    schema:identifier "Occurrence Collection - Preparations - new preparations" ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/new-preparations> .
+
 <http://createme.org/datatype/catalogNumber/BHP> a rdfs:Datatype ;
     skos:definition "A catalog number for the sample" ;
     skos:prefLabel "BHP catalogNumber" ;
@@ -676,29 +732,23 @@
 <http://createme.org/agent/WAM> a prov:Agent ;
     schema:name "WAM" .
 
-<http://createme.org/attribute/basisOfRecord/13> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/basisOfRecord> ;
-    tern:hasSimpleValue "PreservedSpecimen" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/13> .
-
-<http://createme.org/attribute/basisOfRecord/14> a tern:Attribute ;
+<http://createme.org/attribute/basisOfRecord/HumanObservation> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;
     tern:hasSimpleValue "HumanObservation" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/14> .
+    tern:hasValue <http://createme.org/value/basisOfRecord/HumanObservation> .
 
-<http://createme.org/attribute/basisOfRecord/15> a tern:Attribute ;
+<http://createme.org/attribute/basisOfRecord/PreservedSpecimen> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;
     tern:hasSimpleValue "PreservedSpecimen" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/15> .
+    tern:hasValue <http://createme.org/value/basisOfRecord/PreservedSpecimen> .
 
-<http://createme.org/attribute/basisOfRecord/16> a tern:Attribute ;
+<http://createme.org/attribute/basisOfRecord/new-basis-of-record> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;
     tern:hasSimpleValue "new basis of record" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/16> .
+    tern:hasValue <http://createme.org/value/basisOfRecord/new-basis-of-record> .
 
 <http://createme.org/attribute/conservationAuthority/15> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -712,17 +762,29 @@
     tern:hasSimpleValue "WA" ;
     tern:hasValue <http://createme.org/value/conservationAuthority/16> .
 
-<http://createme.org/attribute/habitat/15> a tern:Attribute ;
+<http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates generalised" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/Coordinates-generalised> .
+
+<http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
+
+<http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
     tern:hasSimpleValue "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
-    tern:hasValue <http://createme.org/value/habitat/15> .
+    tern:hasValue <http://createme.org/value/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
-<http://createme.org/attribute/habitat/16> a tern:Attribute ;
+<http://createme.org/attribute/habitat/new-habitat> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
     tern:hasSimpleValue "new habitat" ;
-    tern:hasValue <http://createme.org/value/habitat/16> .
+    tern:hasValue <http://createme.org/value/habitat/new-habitat> .
 
 <http://createme.org/attribute/identificationQualifier/11> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -772,17 +834,17 @@
     tern:hasSimpleValue "new remarks" ;
     tern:hasValue <http://createme.org/value/identificationRemarks/16> .
 
-<http://createme.org/attribute/preparations/15> a tern:Attribute ;
+<http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/preparations> ;
     tern:hasSimpleValue "Wet (in ethanol or some other preservative)" ;
-    tern:hasValue <http://createme.org/value/preparations/15> .
+    tern:hasValue <http://createme.org/value/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
-<http://createme.org/attribute/preparations/16> a tern:Attribute ;
+<http://createme.org/attribute/preparations/new-preparations> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/preparations> ;
     tern:hasSimpleValue "new preparations" ;
-    tern:hasValue <http://createme.org/value/preparations/16> .
+    tern:hasValue <http://createme.org/value/preparations/new-preparations> .
 
 <http://createme.org/attribute/taxonRank/15> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -838,6 +900,20 @@
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
     skos:prefLabel "Category 1" ;
     skos:scopeNote "Under the authority of The Department of Biodiversity and Conservation" ;
+    schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
+
+<http://createme.org/bdr-cv/attribute/targetHabitatScope/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a skos:Concept ;
+    skos:broader <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
+    skos:definition "A type of targetHabitatScope" ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
+
+<http://createme.org/bdr-cv/attribute/targetHabitatScope/new-habitat> a skos:Concept ;
+    skos:broader <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
+    skos:definition "A type of targetHabitatScope" ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new habitat" ;
     schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
 
 <http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> a skos:Concept ;
@@ -1084,24 +1160,19 @@
     rdf:value "Caladenia excelsa" ;
     tern:featureType <http://example.com/concept/scientificName> .
 
-<http://createme.org/value/basisOfRecord/13> a tern:IRI,
+<http://createme.org/value/basisOfRecord/HumanObservation> a tern:IRI,
         tern:Value ;
-    rdfs:label "basisOfRecord" ;
-    rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
-
-<http://createme.org/value/basisOfRecord/14> a tern:IRI,
-        tern:Value ;
-    rdfs:label "basisOfRecord" ;
+    rdfs:label "HumanObservation" ;
     rdf:value <http://example.com/basisOfRecord/HumanObservation> .
 
-<http://createme.org/value/basisOfRecord/15> a tern:IRI,
+<http://createme.org/value/basisOfRecord/PreservedSpecimen> a tern:IRI,
         tern:Value ;
-    rdfs:label "basisOfRecord" ;
+    rdfs:label "PreservedSpecimen" ;
     rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
 
-<http://createme.org/value/basisOfRecord/16> a tern:IRI,
+<http://createme.org/value/basisOfRecord/new-basis-of-record> a tern:IRI,
         tern:Value ;
-    rdfs:label "basisOfRecord" ;
+    rdfs:label "new basis of record" ;
     rdf:value <http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> .
 
 <http://createme.org/value/conservationAuthority/15> a tern:IRI,
@@ -1114,17 +1185,13 @@
     rdfs:label "Conservation Authority = WA" ;
     rdf:value <https://sws.geonames.org/2058645/> .
 
-<http://createme.org/value/dataGeneralizations/14> a tern:Text,
-        tern:Value ;
-    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
-
-<http://createme.org/value/dataGeneralizations/15> a tern:Text,
-        tern:Value ;
-    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
-
-<http://createme.org/value/dataGeneralizations/16> a tern:Text,
+<http://createme.org/value/dataGeneralizations/Coordinates-generalised> a tern:Text,
         tern:Value ;
     rdf:value "Coordinates generalised" .
+
+<http://createme.org/value/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
 
 <http://createme.org/value/establishmentMeans/15> a tern:IRI,
         tern:Value ;
@@ -1136,15 +1203,15 @@
     rdfs:label "establishmentMeans-value" ;
     rdf:value <http://createme.org/bdr-cv/parameter/establishmentMeans/new-establishment-means> .
 
-<http://createme.org/value/habitat/15> a tern:Text,
+<http://createme.org/value/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a tern:IRI,
         tern:Value ;
-    rdfs:label "habitat" ;
-    rdf:value "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." .
+    rdfs:label "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    rdf:value <http://createme.org/bdr-cv/attribute/targetHabitatScope/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
-<http://createme.org/value/habitat/16> a tern:Text,
+<http://createme.org/value/habitat/new-habitat> a tern:IRI,
         tern:Value ;
-    rdfs:label "habitat" ;
-    rdf:value "new habitat" .
+    rdfs:label "new habitat" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/targetHabitatScope/new-habitat> .
 
 <http://createme.org/value/identificationQualifier/11> a tern:IRI,
         tern:Value ;
@@ -1222,14 +1289,14 @@
     rdfs:label "organism-remarks" ;
     rdf:value "Leaves brown" .
 
-<http://createme.org/value/preparations/15> a tern:IRI,
+<http://createme.org/value/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:IRI,
         tern:Value ;
-    rdfs:label "preparations" ;
+    rdfs:label "Wet (in ethanol or some other preservative)" ;
     rdf:value <http://createme.org/bdr-cv/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
-<http://createme.org/value/preparations/16> a tern:IRI,
+<http://createme.org/value/preparations/new-preparations> a tern:IRI,
         tern:Value ;
-    rdfs:label "preparations" ;
+    rdfs:label "new preparations" ;
     rdf:value <http://createme.org/bdr-cv/attribute/preparations/new-preparations> .
 
 <http://createme.org/value/reproductiveCondition/15> a tern:IRI,
@@ -1333,24 +1400,6 @@
         tern:Value ;
     rdf:value "Caladenia excelsa" .
 
-<http://createme.org/attribute/dataGeneralizations/14> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/data-generalizations> ;
-    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
-    tern:hasValue <http://createme.org/value/dataGeneralizations/14> .
-
-<http://createme.org/attribute/dataGeneralizations/15> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/data-generalizations> ;
-    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
-    tern:hasValue <http://createme.org/value/dataGeneralizations/15> .
-
-<http://createme.org/attribute/dataGeneralizations/16> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/data-generalizations> ;
-    tern:hasSimpleValue "Coordinates generalised" ;
-    tern:hasValue <http://createme.org/value/dataGeneralizations/16> .
-
 <http://createme.org/bdr-cv/attribute/identificationQualifier/> a skos:Concept ;
     skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
     skos:definition "A type of identificationQualifier." ;
@@ -1380,18 +1429,9 @@
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://createme.org/sample/specimen/13> a tern:FeatureOfInterest,
-        tern:Sample ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    dwc:catalogNumber "CC123"^^<http://createme.org/datatype/catalogNumber/WAM> ;
-    rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://createme.org/sampling/specimen/13> ;
-    sosa:isSampleOf <http://createme.org/sample/field/13> ;
-    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
-
 <http://createme.org/sampling/field/1> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N278dfd421533406986bb77cc190dfa8f ;
+    geo:hasGeometry _:N69b37fc14f0640aaa3eaa32384cc53ae ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1404,7 +1444,7 @@
 
 <http://createme.org/sampling/field/10> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N1de348298aae404fac2dc756fb3780f9 ;
+    geo:hasGeometry _:N00fd4ed347f94e948415ea4633d1ef5e ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1417,7 +1457,7 @@
 
 <http://createme.org/sampling/field/11> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N26e2f6d63453481b86018cb9eab22008 ;
+    geo:hasGeometry _:N2604d7d6b8ea4067a816238a42d38904 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1430,7 +1470,7 @@
 
 <http://createme.org/sampling/field/12> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Naa0e96ff860e4843a9219d7661f52b9e ;
+    geo:hasGeometry _:Nf0621fb2704d43df8d69f173f38d20a6 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1441,7 +1481,7 @@
 
 <http://createme.org/sampling/field/13> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N498bbec2fe164b43b12b1559f322d3ff ;
+    geo:hasGeometry _:N71af728ce6cf4ce2a7a89ab7d85ebc69 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1454,7 +1494,7 @@
 
 <http://createme.org/sampling/field/14> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N84c08dec891e42d1a7a0c6bc8f7d5a78 ;
+    geo:hasGeometry _:Neca9a1778f694a53b1ff879ea3de4a5c ;
     geo:hasMetricSpatialAccuracy 2e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1464,12 +1504,11 @@
     sosa:hasResult <http://createme.org/sample/field/14> ;
     sosa:usedProcedure <http://example.com/sampling-protocol/default> ;
     schema:identifier "14"^^<http://createme.org/datatype/recordID/WAM> ;
-    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/14> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
 <http://createme.org/sampling/field/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nc3a09d8c4a494b45af3aa7da7d4a559c ;
+    geo:hasGeometry _:N83fb40efda7641ea81fe0bcfdf89751d ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1479,13 +1518,11 @@
     sosa:hasResult <http://createme.org/sample/field/15> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     schema:identifier "8022FSJMJ079c5cf"^^<http://createme.org/datatype/recordID/WAM> ;
-    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/15>,
-        <http://createme.org/attribute/habitat/15> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
 <http://createme.org/sampling/field/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nf34ea6bfac784349896e8d62c78c402d ;
+    geo:hasGeometry _:N60961b8fc033448d900c008c80df0da4 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1495,13 +1532,11 @@
     sosa:hasResult <http://createme.org/sample/field/16> ;
     sosa:usedProcedure <http://createme.org/bdr-cv/methods/samplingProtocol/new-sampling-protocol> ;
     schema:identifier "ABC123"^^<http://createme.org/datatype/recordID/WAM> ;
-    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/16>,
-        <http://createme.org/attribute/habitat/16> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
 <http://createme.org/sampling/field/2> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nf42e2c174c764508887208c419969455 ;
+    geo:hasGeometry _:N1f93bb96fe6d410bb4259c16c760baa4 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1514,7 +1549,7 @@
 
 <http://createme.org/sampling/field/3> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N4de58e765f504884abb363d0736da087 ;
+    geo:hasGeometry _:N33320fb2f051478ba7bac483e6e28fa0 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1527,7 +1562,7 @@
 
 <http://createme.org/sampling/field/4> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N4e631811ea14459a8a0137b6d8aca9b6 ;
+    geo:hasGeometry _:N240f256b6d904c09864cb95a0c7d8ccf ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1540,7 +1575,7 @@
 
 <http://createme.org/sampling/field/5> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N118dd799dbf44cfcb624ba30b41bd231 ;
+    geo:hasGeometry _:Nfbce4e13cb6c4ffd8b4e5fa3e282da7e ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1553,7 +1588,7 @@
 
 <http://createme.org/sampling/field/6> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N5c8b7b1466c64c259e5d11e82d37ed77 ;
+    geo:hasGeometry _:N259fc6c30c7a4bb6bf7902942f3f7e37 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1566,7 +1601,7 @@
 
 <http://createme.org/sampling/field/7> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N03794f5923064d7eb40f563b827c7c93 ;
+    geo:hasGeometry _:Ne4caaac238f848ea830f8e2f6d67e514 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1579,7 +1614,7 @@
 
 <http://createme.org/sampling/field/8> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N59b3e76070db4d7992ccbeab265097b9 ;
+    geo:hasGeometry _:N61a087cfaf174c518f2c9d21d84b5ebf ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1592,7 +1627,7 @@
 
 <http://createme.org/sampling/field/9> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nd06eacd20d534ac1a128479ab30c5287 ;
+    geo:hasGeometry _:Nf3a6bbf721df4421ab22981e9eb27623 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1605,7 +1640,7 @@
 
 <http://createme.org/sampling/sequencing/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nf6e92e6b4b144dd7a6f34282a72154fc ;
+    geo:hasGeometry _:N4bbc8fa24f9c456a9f4210bcc51623fe ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "sequencing-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1617,7 +1652,7 @@
 
 <http://createme.org/sampling/sequencing/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N118f964984ed4140bbc1211db879b19f ;
+    geo:hasGeometry _:Nf74fe0c3ee4a43449321574fe5b549cd ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "sequencing-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1629,19 +1664,18 @@
 
 <http://createme.org/sampling/specimen/13> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N71674cbaf8464062868d4187562ab8bb ;
+    geo:hasGeometry _:N9aa0208b9f9f4698ac4a4d1bd983d5a1 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             rdfs:comment "Date unknown, template eventDate used as proxy" ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/13> ;
     sosa:hasResult <http://createme.org/sample/specimen/13> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/13> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/sampling/specimen/14> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N533fd2be0aad4df88a81e9d0526b13d3 ;
+    geo:hasGeometry _:Nc006801924bb402c9055078a043c3926 ;
     geo:hasMetricSpatialAccuracy 2e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1649,35 +1683,29 @@
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/14> ;
     sosa:hasResult <http://createme.org/sample/specimen/14> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/14>,
-        <http://createme.org/attribute/dataGeneralizations/14> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/sampling/specimen/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N3867218252f04a41a81ea80f79b15409 ;
+    geo:hasGeometry _:N4d9eda9e20be4a2e878e46d3baa5a401 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
     sosa:hasResult <http://createme.org/sample/specimen/15> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/15>,
-        <http://createme.org/attribute/dataGeneralizations/15> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/sampling/specimen/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nfb4c6584d6b54d21a7455333904cf4a0 ;
+    geo:hasGeometry _:N2736798247a242fd9da6c0b8f8c28242 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-27"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
     sosa:hasResult <http://createme.org/sample/specimen/16> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/16>,
-        <http://createme.org/attribute/dataGeneralizations/16> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/scientificName/15> a tern:FeatureOfInterest,
         tern:Text,
@@ -1740,14 +1768,6 @@
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     rdfs:comment "field-sample" ;
     sosa:isResultOf <http://createme.org/sampling/field/13> ;
-    sosa:isSampleOf <http://createme.org/location/Australia> ;
-    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
-
-<http://createme.org/sample/field/14> a tern:FeatureOfInterest,
-        tern:Sample ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://createme.org/sampling/field/14> ;
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
@@ -1815,6 +1835,23 @@
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
+<http://createme.org/sample/specimen/13> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    dwc:catalogNumber "CC123"^^<http://createme.org/datatype/catalogNumber/WAM> ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/13> ;
+    sosa:isSampleOf <http://createme.org/sample/field/13> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
+
+<http://createme.org/sample/field/14> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/14> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
 <http://createme.org/sample/specimen/14> a tern:FeatureOfInterest,
         tern:Sample ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -1856,8 +1893,7 @@
     rdfs:comment "specimen-sample" ;
     sosa:isResultOf <http://createme.org/sampling/specimen/15> ;
     sosa:isSampleOf <http://createme.org/sample/field/15> ;
-    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
-    tern:hasAttribute <http://createme.org/attribute/preparations/15> .
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
 
 <http://createme.org/sample/specimen/16> a tern:FeatureOfInterest,
         tern:Sample ;
@@ -1867,8 +1903,7 @@
     rdfs:comment "specimen-sample" ;
     sosa:isResultOf <http://createme.org/sampling/specimen/16> ;
     sosa:isSampleOf <http://createme.org/sample/field/16> ;
-    tern:featureType <http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> ;
-    tern:hasAttribute <http://createme.org/attribute/preparations/16> .
+    tern:featureType <http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> .
 
 <http://createme.org/location/Australia> a tern:FeatureOfInterest ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -1880,23 +1915,15 @@
     schema:name "Stream Environment and Water Pty Ltd" .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> a tern:Dataset ;
-    schema:dateCreated "2024-10-10"^^xsd:date ;
-    schema:dateIssued "2024-10-10"^^xsd:date ;
+    schema:dateCreated "2024-10-22"^^xsd:date ;
+    schema:dateIssued "2024-10-22"^^xsd:date ;
     schema:description "Example Incidental Occurrence Dataset by Gaia Resources" ;
     schema:name "Example Incidental Occurrence Dataset" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N84c08dec891e42d1a7a0c6bc8f7d5a78 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/14> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N5c8b7b1466c64c259e5d11e82d37ed77 ;
+    rdf:object _:N259fc6c30c7a4bb6bf7902942f3f7e37 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/6> ;
     rdfs:comment "supplied as" .
@@ -1904,111 +1931,31 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:Nc3a09d8c4a494b45af3aa7da7d4a559c ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/15> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N4de58e765f504884abb363d0736da087 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/3> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N1de348298aae404fac2dc756fb3780f9 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/10> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:Nf42e2c174c764508887208c419969455 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/2> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:Nd06eacd20d534ac1a128479ab30c5287 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/9> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:N118f964984ed4140bbc1211db879b19f ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/sequencing/16> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:Nf34ea6bfac784349896e8d62c78c402d ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/16> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N498bbec2fe164b43b12b1559f322d3ff ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/13> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N4e631811ea14459a8a0137b6d8aca9b6 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/4> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N533fd2be0aad4df88a81e9d0526b13d3 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/14> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:Naa0e96ff860e4843a9219d7661f52b9e ;
+    rdf:object _:Nf0621fb2704d43df8d69f173f38d20a6 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/12> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N03794f5923064d7eb40f563b827c7c93 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/7> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N71674cbaf8464062868d4187562ab8bb ;
+    rdf:object _:N9aa0208b9f9f4698ac4a4d1bd983d5a1 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/specimen/13> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:N2604d7d6b8ea4067a816238a42d38904 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/11> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:N278dfd421533406986bb77cc190dfa8f ;
+    rdf:object _:N69b37fc14f0640aaa3eaa32384cc53ae ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/1> ;
     rdfs:comment "supplied as" .
@@ -2016,15 +1963,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:Nfb4c6584d6b54d21a7455333904cf4a0 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/16> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:N3867218252f04a41a81ea80f79b15409 ;
+    rdf:object _:N4d9eda9e20be4a2e878e46d3baa5a401 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/specimen/15> ;
     rdfs:comment "supplied as" .
@@ -2032,7 +1971,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N118dd799dbf44cfcb624ba30b41bd231 ;
+    rdf:object _:Nfbce4e13cb6c4ffd8b4e5fa3e282da7e ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/5> ;
     rdfs:comment "supplied as" .
@@ -2040,96 +1979,192 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
-    rdf:object _:Nf6e92e6b4b144dd7a6f34282a72154fc ;
+    rdf:object _:N2736798247a242fd9da6c0b8f8c28242 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/16> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:Ne4caaac238f848ea830f8e2f6d67e514 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/7> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:N00fd4ed347f94e948415ea4633d1ef5e ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/10> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:Nc006801924bb402c9055078a043c3926 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/14> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdf:object _:N4bbc8fa24f9c456a9f4210bcc51623fe ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/sequencing/15> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdf:object _:N60961b8fc033448d900c008c80df0da4 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/16> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:N33320fb2f051478ba7bac483e6e28fa0 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/3> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:Neca9a1778f694a53b1ff879ea3de4a5c ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/14> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:N71af728ce6cf4ce2a7a89ab7d85ebc69 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/13> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:N240f256b6d904c09864cb95a0c7d8ccf ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/4> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdf:object _:Nf74fe0c3ee4a43449321574fe5b549cd ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/sequencing/16> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.01 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:N1f93bb96fe6d410bb4259c16c760baa4 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/2> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
+    rdf:object _:Nf3a6bbf721df4421ab22981e9eb27623 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/9> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (114.99 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N59b3e76070db4d7992ccbeab265097b9 ;
+    rdf:object _:N61a087cfaf174c518f2c9d21d84b5ebf ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/8> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.02 -33.86)"^^geo:wktLiteral ] ;
-    rdf:object _:N26e2f6d63453481b86018cb9eab22008 ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (115.21 -33.8)"^^geo:wktLiteral ] ;
+    rdf:object _:N83fb40efda7641ea81fe0bcfdf89751d ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/11> ;
+    rdf:subject <http://createme.org/sampling/field/15> ;
     rdfs:comment "supplied as" .
 
-_:N03794f5923064d7eb40f563b827c7c93 a geo:Geometry ;
+_:N00fd4ed347f94e948415ea4633d1ef5e a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
+
+_:N1f93bb96fe6d410bb4259c16c760baa4 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.01 -33.86)"^^geo:wktLiteral .
+
+_:N240f256b6d904c09864cb95a0c7d8ccf a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.01 -33.86)"^^geo:wktLiteral .
+
+_:N259fc6c30c7a4bb6bf7902942f3f7e37 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
 
-_:N118dd799dbf44cfcb624ba30b41bd231 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
+_:N2604d7d6b8ea4067a816238a42d38904 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
 
-_:N118f964984ed4140bbc1211db879b19f a geo:Geometry ;
+_:N2736798247a242fd9da6c0b8f8c28242 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N1de348298aae404fac2dc756fb3780f9 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
+_:N33320fb2f051478ba7bac483e6e28fa0 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.01 -33.86)"^^geo:wktLiteral .
 
-_:N26e2f6d63453481b86018cb9eab22008 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
+_:N4bbc8fa24f9c456a9f4210bcc51623fe a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N278dfd421533406986bb77cc190dfa8f a geo:Geometry ;
+_:N4d9eda9e20be4a2e878e46d3baa5a401 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:N60961b8fc033448d900c008c80df0da4 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral .
 
-_:N3867218252f04a41a81ea80f79b15409 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+_:N61a087cfaf174c518f2c9d21d84b5ebf a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
 
-_:N498bbec2fe164b43b12b1559f322d3ff a geo:Geometry ;
+_:N69b37fc14f0640aaa3eaa32384cc53ae a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral .
+
+_:N71af728ce6cf4ce2a7a89ab7d85ebc69 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
 
-_:N4de58e765f504884abb363d0736da087 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.01 -33.86)"^^geo:wktLiteral .
+_:N83fb40efda7641ea81fe0bcfdf89751d a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral .
 
-_:N4e631811ea14459a8a0137b6d8aca9b6 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.01 -33.86)"^^geo:wktLiteral .
-
-_:N533fd2be0aad4df88a81e9d0526b13d3 a geo:Geometry ;
+_:N9aa0208b9f9f4698ac4a4d1bd983d5a1 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N59b3e76070db4d7992ccbeab265097b9 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
-
-_:N5c8b7b1466c64c259e5d11e82d37ed77 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
-
-_:N71674cbaf8464062868d4187562ab8bb a geo:Geometry ;
+_:Nc006801924bb402c9055078a043c3926 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N84c08dec891e42d1a7a0c6bc8f7d5a78 a geo:Geometry ;
+_:Ne4caaac238f848ea830f8e2f6d67e514 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
+
+_:Neca9a1778f694a53b1ff879ea3de4a5c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
 
-_:Naa0e96ff860e4843a9219d7661f52b9e a geo:Geometry ;
+_:Nf0621fb2704d43df8d69f173f38d20a6 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral .
 
-_:Nc3a09d8c4a494b45af3aa7da7d4a559c a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral .
-
-_:Nd06eacd20d534ac1a128479ab30c5287 a geo:Geometry ;
+_:Nf3a6bbf721df4421ab22981e9eb27623 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.02 -33.86)"^^geo:wktLiteral .
 
-_:Nf34ea6bfac784349896e8d62c78c402d a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral .
-
-_:Nf42e2c174c764508887208c419969455 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.01 -33.86)"^^geo:wktLiteral .
-
-_:Nf6e92e6b4b144dd7a6f34282a72154fc a geo:Geometry ;
+_:Nf74fe0c3ee4a43449321574fe5b549cd a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:Nfb4c6584d6b54d21a7455333904cf4a0 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (115.21 -33.8)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+_:Nfbce4e13cb6c4ffd8b4e5fa3e282da7e a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (114.99 -33.86)"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -279,22 +279,14 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         id_qualifier_value = utils.rdf.uri(f"value/identificationQualifier/{row_num}", base_iri)
         id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{row_num}", base_iri)
         id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{row_num}", base_iri)
-        data_generalizations_attribute = utils.rdf.uri(f"attribute/dataGeneralizations/{row_num}", base_iri)
-        data_generalizations_value = utils.rdf.uri(f"value/dataGeneralizations/{row_num}", base_iri)
         taxon_rank_attribute = utils.rdf.uri(f"attribute/taxonRank/{row_num}", base_iri)
         taxon_rank_value = utils.rdf.uri(f"value/taxonRank/{row_num}", base_iri)
         individual_count_observation = utils.rdf.uri(f"observation/individualCount/{row_num}", base_iri)
         individual_count_value = utils.rdf.uri(f"value/individualCount/{row_num}", base_iri)
         organism_remarks_observation = utils.rdf.uri(f"observation/organismRemarks/{row_num}", base_iri)
         organism_remarks_value = utils.rdf.uri(f"value/organismRemarks/{row_num}", base_iri)
-        habitat_attribute = utils.rdf.uri(f"attribute/habitat/{row_num}", base_iri)
-        habitat_value = utils.rdf.uri(f"value/habitat/{row_num}", base_iri)
-        basis_attribute = utils.rdf.uri(f"attribute/basisOfRecord/{row_num}", base_iri)
-        basis_value = utils.rdf.uri(f"value/basisOfRecord/{row_num}", base_iri)
         occurrence_status_observation = utils.rdf.uri(f"observation/occurrenceStatus/{row_num}", base_iri)
         occurrence_status_value = utils.rdf.uri(f"value/occurrenceStatus/{row_num}", base_iri)
-        preparations_attribute = utils.rdf.uri(f"attribute/preparations/{row_num}", base_iri)
-        preparations_value = utils.rdf.uri(f"value/preparations/{row_num}", base_iri)
         establishment_means_observation = utils.rdf.uri(f"observation/establishmentMeans/{row_num}", base_iri)
         establishment_means_value = utils.rdf.uri(f"value/establishmentMeans/{row_num}", base_iri)
         life_stage_observation = utils.rdf.uri(f"observation/lifeStage/{row_num}", base_iri)
@@ -336,6 +328,32 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             owner_record_id_provider = None
             owner_record_id_attribution = None
 
+        # Conditionally create uris dependant of dataGeneralizations field
+        if data_generalizations := row["dataGeneralizations"]:
+            data_generalizations_attribute = utils.rdf.uri(
+                f"attribute/dataGeneralizations/{data_generalizations}", base_iri
+            )
+            data_generalizations_value = utils.rdf.uri(f"value/dataGeneralizations/{data_generalizations}", base_iri)
+            data_generalizations_sample_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "dataGeneralizations", data_generalizations
+            )
+        else:
+            data_generalizations_attribute = None
+            data_generalizations_value = None
+            data_generalizations_sample_collection = None
+
+        # Conditionally create uris dependant of basisOfRecord field
+        if basis_of_record := row["basisOfRecord"]:
+            basis_attribute = utils.rdf.uri(f"attribute/basisOfRecord/{basis_of_record}", base_iri)
+            basis_value = utils.rdf.uri(f"value/basisOfRecord/{basis_of_record}", base_iri)
+            basis_sample_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "basisOfRecord", basis_of_record
+            )
+        else:
+            basis_attribute = None
+            basis_value = None
+            basis_sample_collection = None
+
         # Conditionally create uri's dependent on recordedBy field.
         if recorded_by := row["recordedBy"]:
             record_number_datatype = utils.rdf.uri(f"datatype/recordNumber/{recorded_by}", base_iri)
@@ -343,6 +361,16 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         else:
             record_number_datatype = None
             provider_recorded_by = None
+
+        # Conditionally create uri's dependent on habitat field.
+        if habitat := row["habitat"]:
+            habitat_attribute = utils.rdf.uri(f"attribute/habitat/{habitat}", base_iri)
+            habitat_value = utils.rdf.uri(f"value/habitat/{habitat}", base_iri)
+            habitat_sample_collection = utils.rdf.extend_uri(dataset, "OccurrenceCollection", "habitat", habitat)
+        else:
+            habitat_attribute = None
+            habitat_value = None
+            habitat_sample_collection = None
 
         # Conditionally create uris dependent on catalogNumberSource field.
         if catalog_number_source := row["catalogNumberSource"]:
@@ -362,6 +390,18 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         else:
             other_catalog_numbers_datatype = None
             other_catalog_numbers_provider = None
+
+        # Conditionally create uris dependent on preparations field
+        if preparations := row["preparations"]:
+            preparations_attribute = utils.rdf.uri(f"attribute/preparations/{preparations}", base_iri)
+            preparations_value = utils.rdf.uri(f"value/preparations/{preparations}", base_iri)
+            preparations_sample_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "preparations", preparations
+            )
+        else:
+            preparations_attribute = None
+            preparations_value = None
+            preparations_sample_collection = None
 
         # Add Provider Identified By
         self.add_provider_identified(
@@ -430,9 +470,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             provider=provider_recorded_by,
             feature_of_interest=terminal_foi,
             sample_field=sample_field,
-            generalizations=data_generalizations_attribute,
-            habitat=habitat_attribute,
-            basis=basis_attribute,
             graph=graph,
         )
 
@@ -466,7 +503,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             dataset=dataset,
             sampling_specimen=sampling_specimen,
             sample_field=sample_field,
-            preparations=preparations_attribute,
             catalog_number_datatype=catalog_number_datatype,
             graph=graph,
         )
@@ -508,8 +544,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             dataset=dataset,
             sample_field=sample_field,
             sample_specimen=sample_specimen,
-            generalizations=data_generalizations_attribute,
-            basis=basis_attribute,
             graph=graph,
         )
 
@@ -591,7 +625,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Data Generalizations Attribute
         self.add_data_generalizations_attribute(
             uri=data_generalizations_attribute,
-            row=row,
+            data_generalizations=data_generalizations,
             dataset=dataset,
             data_generalizations_value=data_generalizations_value,
             graph=graph,
@@ -600,7 +634,17 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Data Generalizations Value
         self.add_data_generalizations_value(
             uri=data_generalizations_value,
-            row=row,
+            data_generalizations=data_generalizations,
+            graph=graph,
+        )
+
+        # Add Data Generalizations Sample Collection
+        self.add_data_generalizations_sample_collection(
+            uri=data_generalizations_sample_collection,
+            data_generalizations=data_generalizations,
+            data_generalizations_attribute=data_generalizations_attribute,
+            sample_field=sample_field,
+            dataset=dataset,
             graph=graph,
         )
 
@@ -658,7 +702,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Habitat Attribute
         self.add_habitat_attribute(
             uri=habitat_attribute,
-            row=row,
+            habitat=habitat,
             dataset=dataset,
             habitat_value=habitat_value,
             graph=graph,
@@ -667,14 +711,25 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Habitat Value
         self.add_habitat_value(
             uri=habitat_value,
-            row=row,
+            habitat=habitat,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add habitat attribute sample collection
+        self.add_habitat_sample_collection(
+            uri=habitat_sample_collection,
+            habitat=habitat,
+            habitat_attribute=habitat_attribute,
+            sample_field=sample_field,
+            dataset=dataset,
             graph=graph,
         )
 
         # Add Basis of Record Attribute
         self.add_basis_attribute(
             uri=basis_attribute,
-            row=row,
+            basis_of_record=basis_of_record,
             dataset=dataset,
             basis_value=basis_value,
             graph=graph,
@@ -683,6 +738,18 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Basis of Record Value
         self.add_basis_value(
             uri=basis_value,
+            basis_of_record=basis_of_record,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add Basis of Record Sample Collection
+        self.add_basis_sample_collection(
+            uri=basis_sample_collection,
+            basis_of_record=basis_of_record,
+            basis_attribute=basis_attribute,
+            sample_specimen=sample_specimen,
+            sample_field=sample_field,
             row=row,
             dataset=dataset,
             graph=graph,
@@ -723,7 +790,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Preparations Attribute
         self.add_preparations_attribute(
             uri=preparations_attribute,
-            row=row,
+            preparations=preparations,
             dataset=dataset,
             preparations_value=preparations_value,
             graph=graph,
@@ -732,7 +799,17 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Preparations Value
         self.add_preparations_value(
             uri=preparations_value,
-            row=row,
+            preparations=preparations,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add Preparations attribute Sample Collection
+        self.add_preparations_sample_collection(
+            uri=preparations_sample_collection,
+            preparations=preparations,
+            preparations_attribute=preparations_attribute,
+            sample_specimen=sample_specimen,
             dataset=dataset,
             graph=graph,
         )
@@ -1233,9 +1310,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         provider: rdflib.URIRef | None,
         feature_of_interest: rdflib.URIRef,
         sample_field: rdflib.URIRef,
-        generalizations: rdflib.URIRef,
-        habitat: rdflib.URIRef,
-        basis: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Sampling Field to the Graph
@@ -1251,10 +1325,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                 with this node.
             sample_field (rdflib.URIRef): Sample Field associated with this
                 node
-            generalizations (rdflib.URIRef): Data Generalizations associated
-                with this node
-            habitat (rdflib.URIRef): Habitat associated with this node
-            basis (rdflib.URIRef): Basis Of Record associated with this node
             graph (rdflib.Graph): Graph to add to
         """
         # Extract values from row
@@ -1325,21 +1395,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Add Spatial Accuracy
             accuracy = rdflib.Literal(row["coordinateUncertaintyInMeters"], datatype=rdflib.XSD.double)
             graph.add((uri, utils.namespaces.GEO.hasMetricSpatialAccuracy, accuracy))
-
-        # Check for dataGeneralizations
-        if row["dataGeneralizations"]:
-            # Add Data Generalizations Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, generalizations))
-
-        # Check for habitat
-        if row["habitat"]:
-            # Add Habitat Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, habitat))
-
-        # Check for basisOfRecord and if Row has no Specimen
-        if not has_specimen(row) and row["basisOfRecord"]:
-            # Add Basis Of Record Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, basis))
 
     def add_provider_record_id_agent(
         self,
@@ -1581,8 +1636,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         sample_field: rdflib.URIRef,
         sample_specimen: rdflib.URIRef,
-        generalizations: rdflib.URIRef,
-        basis: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Sampling Specimen to the Graph
@@ -1595,9 +1648,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                 node
             sample_specimen (rdflib.URIRef): Sample Specimen associated with
                 this node
-            generalizations (rdflib.URIRef): Data Generalizations associated
-                with this node
-            basis (rdflib.URIRef): Basis Of Record associated with this node
             graph (rdflib.Graph): Graph to add to
         """
         # Check if Row has a Specimen
@@ -1653,16 +1703,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Add Spatial Accuracy
             accuracy = rdflib.Literal(row["coordinateUncertaintyInMeters"], datatype=rdflib.XSD.double)
             graph.add((uri, utils.namespaces.GEO.hasMetricSpatialAccuracy, accuracy))
-
-        # Check for dataGeneralizations
-        if row["dataGeneralizations"]:
-            # Add Data Generalizations Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, generalizations))
-
-        # Check for basisOfRecord and if Row has a Specimen
-        if has_specimen(row) and row["basisOfRecord"]:
-            # Add Basis Of Record Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, basis))
 
     def add_text_verbatim_id(
         self,
@@ -1812,7 +1852,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         sampling_specimen: rdflib.URIRef,
         sample_field: rdflib.URIRef,
-        preparations: rdflib.URIRef,
         catalog_number_datatype: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
@@ -1826,8 +1865,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                 with this node
             sample_field (rdflib.URIRef): Sample Field associated with this
                 node
-            preparations (rdflib.URIRef): Preparations Attribute associated
-                with this node
             catalog_number_datatype (rdflib.URIRef): Catalog number source
                 datatype.
             graph (rdflib.Graph): Graph to add to
@@ -1867,61 +1904,100 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Add to Graph
             graph.add((uri, utils.namespaces.DWC.collectionCode, rdflib.Literal(row["collectionCode"])))
 
-        # Check for preparations
-        if row["preparations"]:
-            # Add Preparations
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, preparations))
-
     def add_data_generalizations_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        data_generalizations: str | None,
         dataset: rdflib.URIRef,
-        data_generalizations_value: rdflib.URIRef,
+        data_generalizations_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Data Generalizations Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            data_generalizations_value (rdflib.URIRef): Data Generalizations
-                Value associated with this node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            data_generalizations: dataGeneralizations value from the CSV
+            dataset: Dataset this belongs to
+            data_generalizations_value: Data Generalizations Value associated with this node
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["dataGeneralizations"]:
+        if uri is None:
             return
 
         # Data Generalizations Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_DATA_GENERALIZATIONS))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["dataGeneralizations"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, data_generalizations_value))
+        if data_generalizations:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(data_generalizations)))
+        if data_generalizations_value is not None:
+            graph.add((uri, utils.namespaces.TERN.hasValue, data_generalizations_value))
 
     def add_data_generalizations_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        data_generalizations: str | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Data Generalizations Value to the Graph
 
         Args:
             uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
+            data_generalizations: dataGeneralizations value from the CSV
             graph (rdflib.Graph): Graph to add to
         """
         # Check Existence
-        if not row["dataGeneralizations"]:
+        if uri is None:
             return
 
         # Data Generalizations Value
         graph.add((uri, a, utils.namespaces.TERN.Text))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDF.value, rdflib.Literal(row["dataGeneralizations"])))
+        graph.add((uri, rdflib.RDF.value, rdflib.Literal(data_generalizations)))
+
+    def add_data_generalizations_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        data_generalizations: str | None,
+        data_generalizations_attribute: rdflib.URIRef | None,
+        sample_field: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a data generalizations attribute Sample Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            data_generalizations: dataGeneralizations value from template.
+            data_generalizations_attribute: The uri for the attribute node.
+            sample_field: The sample field node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.SampleCollection))
+        # Add identifier
+        if data_generalizations:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(
+                        f"Occurrence Collection - Data Generalizations - {data_generalizations}",
+                    ),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the sample field
+        graph.add((uri, rdflib.SOSA.hasMember, sample_field))
+        # Add link to attribute
+        if data_generalizations_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, data_generalizations_attribute))
 
     def add_taxon_rank_attribute(
         self,
@@ -2136,115 +2212,215 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_habitat_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        habitat: str | None,
         dataset: rdflib.URIRef,
-        habitat_value: rdflib.URIRef,
+        habitat_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Habitat Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            habitat_value (rdflib.URIRef): Habitat Value associated with this
-                node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            habitat: Raw habitat from CSV.
+            dataset: Dataset this belongs to
+            habitat_value: Habitat Value associated with this node
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["habitat"]:
+        if uri is None:
             return
 
         # Habitat Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_HABITAT))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["habitat"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, habitat_value))
+        if habitat:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(habitat)))
+        if habitat_value is not None:
+            graph.add((uri, utils.namespaces.TERN.hasValue, habitat_value))
 
     def add_habitat_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        habitat: str | None,
+        dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Habitat Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            habitat: Habitat from the CSV
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["habitat"]:
+        if uri is None:
             return
 
         # Habitat Value
-        graph.add((uri, a, utils.namespaces.TERN.Text))
+        graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("habitat")))
-        graph.add((uri, rdflib.RDF.value, rdflib.Literal(row["habitat"])))
+        if habitat:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(habitat)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["habitat"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(habitat)
+            # Add value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_habitat_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        habitat: str | None,
+        habitat_attribute: rdflib.URIRef | None,
+        sample_field: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a habitat attribute Sample Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            habitat: Habitat value from template.
+            habitat_attribute: The uri for the attribute node.
+            sample_field: The sample field node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.SampleCollection))
+        # Add identifier
+        if habitat:
+            graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(f"Occurrence Collection - Habitat - {habitat}")))
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the sample field
+        graph.add((uri, rdflib.SOSA.hasMember, sample_field))
+        # Add link to attribute
+        if habitat_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, habitat_attribute))
 
     def add_basis_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        basis_of_record: str | None,
         dataset: rdflib.URIRef,
-        basis_value: rdflib.URIRef,
+        basis_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Basis of Record Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            basis_value (rdflib.URIRef): Basis of Record Value associated with
-                this node
+            uri: URI to use for this node.
+            basis_of_record: basisOfRecord value from the CSV
+            dataset: Dataset this belongs to
+            basis_value: Basis of Record Value associated with this node
             graph (rdflib.Graph): Graph to add to
         """
         # Check Existence
-        if not row["basisOfRecord"]:
+        if uri is None:
             return
 
         # Basis of Record Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_BASIS_OF_RECORD))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["basisOfRecord"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, basis_value))
+        if basis_of_record:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(basis_of_record)))
+        if basis_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, basis_value))
 
     def add_basis_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        basis_of_record: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Basis of Record Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            basis_of_record: basisOfRecord value from the CSV
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["basisOfRecord"]:
+        if uri is None:
             return
-
-        # Retrieve vocab for field
-        vocab = self.fields()["basisOfRecord"].get_vocab()
-
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["basisOfRecord"])
 
         # Basis of Record Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("basisOfRecord")))
-        graph.add((uri, rdflib.RDF.value, term))
+        if basis_of_record:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(basis_of_record)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["basisOfRecord"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(basis_of_record)
+            # Add value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_basis_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        basis_of_record: str | None,
+        basis_attribute: rdflib.URIRef | None,
+        sample_specimen: rdflib.URIRef,
+        sample_field: rdflib.URIRef,
+        row: frictionless.Row,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a basisOfRecord attribute Sample Collection to the graph
+
+        Either the sample_specimen node or the sample_field node should be a member
+        of this collection, depending on if the row has a specimen.
+
+        Args:
+            uri: The uri for the SampleCollection.
+            basis_of_record: basisOfRecord value from template.
+            basis_attribute: The uri for the attribute node.
+            sample_specimen: The sample specimen node.
+            sample_field: The sample field node that.
+            row: The CSV row.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.SampleCollection))
+        # Add identifier
+        if basis_of_record:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Basis Of Record - {basis_of_record}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the appropriate sample node
+        if has_specimen(row):
+            graph.add((uri, rdflib.SOSA.hasMember, sample_specimen))
+        else:
+            graph.add((uri, rdflib.SOSA.hasMember, sample_field))
+        # Add link to attribute
+        if basis_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, basis_attribute))
 
     def add_owner_institution_provider(
         self,
@@ -2368,63 +2544,107 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_preparations_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        preparations: str | None,
         dataset: rdflib.URIRef,
-        preparations_value: rdflib.URIRef,
+        preparations_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Preparations Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            preparations_value (rdflib.URIRef): Preparations Value associated
-                with this node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            preparations: preparations value from the CSV
+            dataset: Dataset this belongs to
+            preparations_value: Preparations Value associated with this node
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["preparations"]:
+        if uri is None:
             return
 
         # Preparations Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_PREPARATIONS))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["preparations"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, preparations_value))
+        if preparations:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(preparations)))
+        if preparations_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, preparations_value))
 
     def add_preparations_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        preparations: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Preparations Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            preparations: preparations value from the CSV
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["preparations"]:
+        if uri is None:
             return
-
-        # Retrieve vocab for field
-        vocab = self.fields()["preparations"].get_vocab()
-
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["preparations"])
 
         # Preparations Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("preparations")))
-        graph.add((uri, rdflib.RDF.value, term))
+        if preparations:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(preparations)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["preparations"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(preparations)
+            # Add value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_preparations_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        preparations: str | None,
+        preparations_attribute: rdflib.URIRef | None,
+        sample_specimen: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a preparations attribute Sample Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            preparations: preparations value from template.
+            preparations_attribute: The uri for the attribute node.
+            sample_specimen: The sample specimen node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.SampleCollection))
+        # Add identifier
+        if preparations:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Preparations - {preparations}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the sample_specimen node
+        graph.add((uri, rdflib.SOSA.hasMember, sample_specimen))
+        # Add link to attribute
+        if preparations_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, preparations_attribute))
 
     def add_establishment_means_observation(
         self,


### PR DESCRIPTION
* The Attribute and Attribute Value IRIs now have the value in them, instead of the row number. This greatly reduces the number we create.
* A new SampleCollection joins the Attribute node and the rows that had that attribute, remove the direct links from the rows to the Attribute nodes.
* other small changes to the Attribute and Value nodes

The following attributes are changed:
* basisOfRecord
* habitat
* preparations
* dataGeneralizations