### PR TITLE
BDRSPS-932: Made it so no rows in instructions are generated when a field only contains unpublishable vocabs.

### DIFF
--- a/docs/tables/vocabs.py
+++ b/docs/tables/vocabs.py
@@ -94,7 +94,11 @@ class VocabTabler(tables.base.BaseTabler):
         """
         # Retrieve publishable vocabs for field
         vocabs = (utils.vocabs.get_vocab(v) for v in field.vocabularies)
-        publishable_vocabs = (v for v in vocabs if v.publish)
+        publishable_vocabs = [v for v in vocabs if v.publish]
+
+        # If no publishable vocabs then no rows
+        if not publishable_vocabs:
+            return
 
         # Map terms based on their preferred label
         grouped_terms = (v.terms for v in publishable_vocabs)

--- a/tests/docs/tables/test_vocabs_tabler.py
+++ b/tests/docs/tables/test_vocabs_tabler.py
@@ -69,8 +69,9 @@ def test_generate_table_unpublishable_vocab(
     mocked_mapper: unittest.mock.MagicMock, mocked_vocab: unittest.mock.MagicMock, mocker: pytest_mock.MockerFixture
 ) -> None:
     """Makes sure row does not get created from an unpublishable vocab."""
-    #
+    # Set the mocks publish attribute to False
     mocked_vocab.return_value.publish = False
+
     # Create a tabler
     tabler = tables.vocabs.VocabTabler("some_id", format="markdown")
 

--- a/tests/docs/tables/test_vocabs_tabler.py
+++ b/tests/docs/tables/test_vocabs_tabler.py
@@ -65,6 +65,22 @@ def test_generate_table_markdown(
     )
 
 
+def test_generate_table_unpublishable_vocab(
+    mocked_mapper: unittest.mock.MagicMock, mocked_vocab: unittest.mock.MagicMock, mocker: pytest_mock.MockerFixture
+) -> None:
+    """Makes sure row does not get created from an unpublishable vocab."""
+    #
+    mocked_vocab.return_value.publish = False
+    # Create a tabler
+    tabler = tables.vocabs.VocabTabler("some_id", format="markdown")
+
+    # Invoke
+    actual = tabler.generate_table()
+
+    # Assert
+    assert actual == ("|Template field name|Preferred label|Definition|Alternate label|\n" "|:---|:---|:---|:---|\n")
+
+
 class TestTBC:
     """Tests the table generation for vocabs with no terms."""
 


### PR DESCRIPTION
threatStatus and conservationAuthority were being rendered previously into table 2 of occurrence instructions. 