### PR TITLE
BDRSPS-925 Add Collections for certain attributes in the survey occurrence v2 mapping

### DIFF
--- a/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -23,6 +23,62 @@
     tern:hasSimpleValue "Category 1 - Department of Biodiversity and Conservation" ;
     tern:hasValue <http://createme.org/value/sensitivityCategory/16> .
 
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/HumanObservation> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/14> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - HumanObservation" ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/HumanObservation> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/PreservedSpecimen> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/13>,
+        <http://createme.org/sample/specimen/15> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/PreservedSpecimen> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/new-basis-of-record> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/16> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - new basis of record" ;
+    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/new-basis-of-record> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/dataGeneralizations/Coordinates-generalised> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/16> ;
+    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/14>,
+        <http://createme.org/sample/field/15> ;
+    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/15> ;
+    schema:identifier "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/habitat/new-habitat> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/field/16> ;
+    schema:identifier "Occurrence Collection - Habitat - new habitat" ;
+    tern:hasAttribute <http://createme.org/attribute/habitat/new-habitat> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/15> ;
+    schema:identifier "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset/OccurrenceCollection/preparations/new-preparations> a tern:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    sosa:hasMember <http://createme.org/sample/specimen/16> ;
+    schema:identifier "Occurrence Collection - Preparations - new preparations" ;
+    tern:hasAttribute <http://createme.org/attribute/preparations/new-preparations> .
+
 <http://createme.org/datatype/catalogNumber/BHP> a rdfs:Datatype ;
     skos:definition "A catalog number for the sample" ;
     skos:prefLabel "BHP catalogNumber" ;
@@ -682,29 +738,23 @@
 <http://createme.org/agent/WAM> a prov:Agent ;
     schema:name "WAM" .
 
-<http://createme.org/attribute/basisOfRecord/13> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/basisOfRecord> ;
-    tern:hasSimpleValue "PreservedSpecimen" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/13> .
-
-<http://createme.org/attribute/basisOfRecord/14> a tern:Attribute ;
+<http://createme.org/attribute/basisOfRecord/HumanObservation> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;
     tern:hasSimpleValue "HumanObservation" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/14> .
+    tern:hasValue <http://createme.org/value/basisOfRecord/HumanObservation> .
 
-<http://createme.org/attribute/basisOfRecord/15> a tern:Attribute ;
+<http://createme.org/attribute/basisOfRecord/PreservedSpecimen> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;
     tern:hasSimpleValue "PreservedSpecimen" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/15> .
+    tern:hasValue <http://createme.org/value/basisOfRecord/PreservedSpecimen> .
 
-<http://createme.org/attribute/basisOfRecord/16> a tern:Attribute ;
+<http://createme.org/attribute/basisOfRecord/new-basis-of-record> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;
     tern:hasSimpleValue "new basis of record" ;
-    tern:hasValue <http://createme.org/value/basisOfRecord/16> .
+    tern:hasValue <http://createme.org/value/basisOfRecord/new-basis-of-record> .
 
 <http://createme.org/attribute/conservationAuthority/15> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
@@ -718,17 +768,29 @@
     tern:hasSimpleValue "WA" ;
     tern:hasValue <http://createme.org/value/conservationAuthority/16> .
 
-<http://createme.org/attribute/habitat/15> a tern:Attribute ;
+<http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates generalised" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/Coordinates-generalised> .
+
+<http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/data-generalizations> ;
+    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
+    tern:hasValue <http://createme.org/value/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
+
+<http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
     tern:hasSimpleValue "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
-    tern:hasValue <http://createme.org/value/habitat/15> .
+    tern:hasValue <http://createme.org/value/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
-<http://createme.org/attribute/habitat/16> a tern:Attribute ;
+<http://createme.org/attribute/habitat/new-habitat> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
     tern:hasSimpleValue "new habitat" ;
-    tern:hasValue <http://createme.org/value/habitat/16> .
+    tern:hasValue <http://createme.org/value/habitat/new-habitat> .
 
 <http://createme.org/attribute/identificationQualifier/11> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
@@ -778,17 +840,17 @@
     tern:hasSimpleValue "new remarks" ;
     tern:hasValue <http://createme.org/value/identificationRemarks/16> .
 
-<http://createme.org/attribute/preparations/15> a tern:Attribute ;
+<http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/preparations> ;
     tern:hasSimpleValue "Wet (in ethanol or some other preservative)" ;
-    tern:hasValue <http://createme.org/value/preparations/15> .
+    tern:hasValue <http://createme.org/value/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
-<http://createme.org/attribute/preparations/16> a tern:Attribute ;
+<http://createme.org/attribute/preparations/new-preparations> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/preparations> ;
     tern:hasSimpleValue "new preparations" ;
-    tern:hasValue <http://createme.org/value/preparations/16> .
+    tern:hasValue <http://createme.org/value/preparations/new-preparations> .
 
 <http://createme.org/attribute/taxonRank/15> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
@@ -836,6 +898,20 @@
     skos:definition "A type of preparations." ;
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
     skos:prefLabel "new preparations" ;
+    schema:citation "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI .
+
+<http://createme.org/bdr-cv/attribute/targetHabitatScope/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a skos:Concept ;
+    skos:broader <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
+    skos:definition "A type of targetHabitatScope" ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    schema:citation "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI .
+
+<http://createme.org/bdr-cv/attribute/targetHabitatScope/new-habitat> a skos:Concept ;
+    skos:broader <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
+    skos:definition "A type of targetHabitatScope" ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "new habitat" ;
     schema:citation "http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset"^^xsd:anyURI .
 
 <http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> a skos:Concept ;
@@ -1082,24 +1158,19 @@
     rdf:value "Caladenia excelsa" ;
     tern:featureType <http://example.com/concept/scientificName> .
 
-<http://createme.org/value/basisOfRecord/13> a tern:IRI,
+<http://createme.org/value/basisOfRecord/HumanObservation> a tern:IRI,
         tern:Value ;
-    rdfs:label "basisOfRecord" ;
-    rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
-
-<http://createme.org/value/basisOfRecord/14> a tern:IRI,
-        tern:Value ;
-    rdfs:label "basisOfRecord" ;
+    rdfs:label "HumanObservation" ;
     rdf:value <http://example.com/basisOfRecord/HumanObservation> .
 
-<http://createme.org/value/basisOfRecord/15> a tern:IRI,
+<http://createme.org/value/basisOfRecord/PreservedSpecimen> a tern:IRI,
         tern:Value ;
-    rdfs:label "basisOfRecord" ;
+    rdfs:label "PreservedSpecimen" ;
     rdf:value <http://example.com/basisOfRecord/PreservedSpecimen> .
 
-<http://createme.org/value/basisOfRecord/16> a tern:IRI,
+<http://createme.org/value/basisOfRecord/new-basis-of-record> a tern:IRI,
         tern:Value ;
-    rdfs:label "basisOfRecord" ;
+    rdfs:label "new basis of record" ;
     rdf:value <http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> .
 
 <http://createme.org/value/conservationAuthority/15> a tern:IRI,
@@ -1112,17 +1183,13 @@
     rdfs:label "Conservation Authority = WA" ;
     rdf:value <https://sws.geonames.org/2058645/> .
 
-<http://createme.org/value/dataGeneralizations/14> a tern:Text,
-        tern:Value ;
-    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
-
-<http://createme.org/value/dataGeneralizations/15> a tern:Text,
-        tern:Value ;
-    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
-
-<http://createme.org/value/dataGeneralizations/16> a tern:Text,
+<http://createme.org/value/dataGeneralizations/Coordinates-generalised> a tern:Text,
         tern:Value ;
     rdf:value "Coordinates generalised" .
+
+<http://createme.org/value/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:Text,
+        tern:Value ;
+    rdf:value "Coordinates rounded to the nearest 10 km for conservation concern" .
 
 <http://createme.org/value/establishmentMeans/15> a tern:IRI,
         tern:Value ;
@@ -1134,15 +1201,15 @@
     rdfs:label "establishmentMeans-value" ;
     rdf:value <http://createme.org/bdr-cv/parameter/establishmentMeans/new-establishment-means> .
 
-<http://createme.org/value/habitat/15> a tern:Text,
+<http://createme.org/value/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a tern:IRI,
         tern:Value ;
-    rdfs:label "habitat" ;
-    rdf:value "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." .
+    rdfs:label "Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    rdf:value <http://createme.org/bdr-cv/attribute/targetHabitatScope/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
-<http://createme.org/value/habitat/16> a tern:Text,
+<http://createme.org/value/habitat/new-habitat> a tern:IRI,
         tern:Value ;
-    rdfs:label "habitat" ;
-    rdf:value "new habitat" .
+    rdfs:label "new habitat" ;
+    rdf:value <http://createme.org/bdr-cv/attribute/targetHabitatScope/new-habitat> .
 
 <http://createme.org/value/identificationQualifier/11> a tern:IRI,
         tern:Value ;
@@ -1220,14 +1287,14 @@
     rdfs:label "organism-remarks" ;
     rdf:value "Leaves brown" .
 
-<http://createme.org/value/preparations/15> a tern:IRI,
+<http://createme.org/value/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:IRI,
         tern:Value ;
-    rdfs:label "preparations" ;
+    rdfs:label "Wet (in ethanol or some other preservative)" ;
     rdf:value <http://createme.org/bdr-cv/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
-<http://createme.org/value/preparations/16> a tern:IRI,
+<http://createme.org/value/preparations/new-preparations> a tern:IRI,
         tern:Value ;
-    rdfs:label "preparations" ;
+    rdfs:label "new preparations" ;
     rdf:value <http://createme.org/bdr-cv/attribute/preparations/new-preparations> .
 
 <http://createme.org/value/reproductiveCondition/15> a tern:IRI,
@@ -1336,24 +1403,6 @@
         tern:Value ;
     rdf:value "Caladenia excelsa" .
 
-<http://createme.org/attribute/dataGeneralizations/14> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/data-generalizations> ;
-    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
-    tern:hasValue <http://createme.org/value/dataGeneralizations/14> .
-
-<http://createme.org/attribute/dataGeneralizations/15> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/data-generalizations> ;
-    tern:hasSimpleValue "Coordinates rounded to the nearest 10 km for conservation concern" ;
-    tern:hasValue <http://createme.org/value/dataGeneralizations/15> .
-
-<http://createme.org/attribute/dataGeneralizations/16> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/data-generalizations> ;
-    tern:hasSimpleValue "Coordinates generalised" ;
-    tern:hasValue <http://createme.org/value/dataGeneralizations/16> .
-
 <http://createme.org/bdr-cv/attribute/identificationQualifier/> a skos:Concept ;
     skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
     skos:definition "A type of identificationQualifier." ;
@@ -1397,18 +1446,9 @@
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
-<http://createme.org/sample/specimen/13> a tern:FeatureOfInterest,
-        tern:Sample ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    dwc:catalogNumber "CC123"^^<http://createme.org/datatype/catalogNumber/WAM> ;
-    rdfs:comment "specimen-sample" ;
-    sosa:isResultOf <http://createme.org/sampling/specimen/13> ;
-    sosa:isSampleOf <http://createme.org/sample/field/13> ;
-    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
-
 <http://createme.org/sampling/field/1> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N2785c100b4d34aad8658807984e5adf1 ;
+    geo:hasGeometry _:N911fc829f8654658b87be2aa9e87dae8 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1421,7 +1461,7 @@
 
 <http://createme.org/sampling/field/10> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N6a7e577f06fe43ae812ffcd0bee8dfa3 ;
+    geo:hasGeometry _:Ncbdc257307b14cbfa00907d39d50f248 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1434,7 +1474,7 @@
 
 <http://createme.org/sampling/field/11> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N0f0accf826014c7ea87a191961e3749c ;
+    geo:hasGeometry _:N655151124e224420a2c2c193374611a4 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1447,7 +1487,7 @@
 
 <http://createme.org/sampling/field/12> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N3ce4535007644d9bb24268eeff3d347f ;
+    geo:hasGeometry _:Nbd6cdf0e1bde4a0db276f8b70fcb6105 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1458,7 +1498,7 @@
 
 <http://createme.org/sampling/field/13> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nebf401339c004449b39d8cc29c83068b ;
+    geo:hasGeometry _:N7663b9d06f74465cb7813ec120d3efbe ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1471,7 +1511,7 @@
 
 <http://createme.org/sampling/field/14> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N4ea37c6b3a8449ad80e34419cb37f650 ;
+    geo:hasGeometry _:N1e8b723d531f4549a071235c6ee5dd4e ;
     geo:hasMetricSpatialAccuracy 2e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1481,12 +1521,11 @@
     sosa:hasResult <http://createme.org/sample/field/14> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:identifier "14"^^<http://createme.org/datatype/recordID/WAM> ;
-    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/14> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
 <http://createme.org/sampling/field/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N2244ad6d3d854b0aa12de5864bd42d88 ;
+    geo:hasGeometry _:Nc4609d9c6074403ebce153f52d92a0fb ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1497,14 +1536,12 @@
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> ;
     schema:identifier "8022FSJMJ079c5cf"^^<http://createme.org/datatype/recordID/WAM> ;
     schema:memberOf <http://createme.org/survey/MR-R1> ;
-    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/15>,
-        <http://createme.org/attribute/habitat/15> ;
     tern:hasSiteVisit <http://createme.org/visit/MR-R1-V1> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
 <http://createme.org/sampling/field/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N5a9bda06d1064f7b99a824d8a7aca7c9 ;
+    geo:hasGeometry _:N2cbe385a530746ffbbe4e4cfed9a1e91 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1515,13 +1552,11 @@
     sosa:usedProcedure <http://createme.org/bdr-cv/methods/samplingProtocol/new-sampling-protocol> ;
     schema:identifier "ABC123"^^<http://createme.org/datatype/recordID/WAM> ;
     schema:memberOf <http://createme.org/survey/MR-R1> ;
-    tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/16>,
-        <http://createme.org/attribute/habitat/16> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
 <http://createme.org/sampling/field/2> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N09236ab5706c440c92d97449192ac376 ;
+    geo:hasGeometry _:N67ba5b4861214b9aafbdc7f1dd33d5d2 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1534,7 +1569,7 @@
 
 <http://createme.org/sampling/field/3> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N6b743579d1e24b47ac41247065582c82 ;
+    geo:hasGeometry _:N7617f7bc78ce4b24a5616ba1099fbaa8 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1547,7 +1582,7 @@
 
 <http://createme.org/sampling/field/4> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nacfd341a028f42b5b12af378e212407f ;
+    geo:hasGeometry _:N24d008f6e3a341f2950563899ce12321 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1560,7 +1595,7 @@
 
 <http://createme.org/sampling/field/5> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N8b5a76e3749345eaa9fb410f702e40ed ;
+    geo:hasGeometry _:N4e7b6c31fbf742b9b79bbb67e6279def ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1573,7 +1608,7 @@
 
 <http://createme.org/sampling/field/6> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N3d479997da4d4ec0b31704ece34ba634 ;
+    geo:hasGeometry _:N662b3705c6c74adc98e47f19e5ecaf8f ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1586,7 +1621,7 @@
 
 <http://createme.org/sampling/field/7> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nceaa399a4b1e4ff0b7872751b24679c8 ;
+    geo:hasGeometry _:N70a8d21dd45c4bcab2f5d4e1e3e74d12 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1599,7 +1634,7 @@
 
 <http://createme.org/sampling/field/8> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N4117681e6c9147f284745ed566246ed5 ;
+    geo:hasGeometry _:Ne26427b58d8a46e3bca678dbfa31cb5c ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1612,7 +1647,7 @@
 
 <http://createme.org/sampling/field/9> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N2df27070ad4f480f86c503bc76f706bb ;
+    geo:hasGeometry _:Na96de3f7358d423ea08f23f19615a527 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1625,7 +1660,7 @@
 
 <http://createme.org/sampling/sequencing/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N26e3f3196cba44df99ab3ff0500045b4 ;
+    geo:hasGeometry _:Nbdd2043bb4ba4ef1a76392071c1f35f8 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "sequencing-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1637,7 +1672,7 @@
 
 <http://createme.org/sampling/sequencing/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N1f48a30338c54a65b8d87cb91b59db8f ;
+    geo:hasGeometry _:N978577e9841248d9a905182f24013afe ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "sequencing-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1649,19 +1684,18 @@
 
 <http://createme.org/sampling/specimen/13> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N291b37af4c4643308afa2f419b20d71e ;
+    geo:hasGeometry _:Nc50e3cff85d6445cb4ed05d2735b8a07 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             rdfs:comment "Date unknown, template eventDate used as proxy" ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/13> ;
     sosa:hasResult <http://createme.org/sample/specimen/13> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/13> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/sampling/specimen/14> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N6b4cb35d31df4fa99587ab818da02f21 ;
+    geo:hasGeometry _:N520f39cdafc64802940dc32ee9f91f8b ;
     geo:hasMetricSpatialAccuracy 2e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1669,35 +1703,29 @@
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/14> ;
     sosa:hasResult <http://createme.org/sample/specimen/14> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/14>,
-        <http://createme.org/attribute/dataGeneralizations/14> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/sampling/specimen/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:N53202988e18a4370817d06c27df0f286 ;
+    geo:hasGeometry _:Ne281f95ffb06401ca2b4c27a2adf1177 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/15> ;
     sosa:hasResult <http://createme.org/sample/specimen/15> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/15>,
-        <http://createme.org/attribute/dataGeneralizations/15> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/sampling/specimen/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nb6e8b84dfc374e0285eaed98f726a882 ;
+    geo:hasGeometry _:N5cd0fa45ce0f4bac8b88571b419e6ea1 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-27"^^xsd:date ] ;
     sosa:hasFeatureOfInterest <http://createme.org/sample/field/16> ;
     sosa:hasResult <http://createme.org/sample/specimen/16> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> ;
-    tern:hasAttribute <http://createme.org/attribute/basisOfRecord/16>,
-        <http://createme.org/attribute/dataGeneralizations/16> .
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/7930424c-f2e1-41fa-9128-61524b67dbd5> .
 
 <http://createme.org/scientificName/15> a tern:FeatureOfInterest,
         tern:Text,
@@ -1760,14 +1788,6 @@
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     rdfs:comment "field-sample" ;
     sosa:isResultOf <http://createme.org/sampling/field/13> ;
-    sosa:isSampleOf <http://createme.org/location/Australia> ;
-    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
-
-<http://createme.org/sample/field/14> a tern:FeatureOfInterest,
-        tern:Sample ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
-    rdfs:comment "field-sample" ;
-    sosa:isResultOf <http://createme.org/sampling/field/14> ;
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
@@ -1835,6 +1855,23 @@
     sosa:isSampleOf <http://createme.org/location/Australia> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
 
+<http://createme.org/sample/specimen/13> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    dwc:catalogNumber "CC123"^^<http://createme.org/datatype/catalogNumber/WAM> ;
+    rdfs:comment "specimen-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/specimen/13> ;
+    sosa:isSampleOf <http://createme.org/sample/field/13> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
+
+<http://createme.org/sample/field/14> a tern:FeatureOfInterest,
+        tern:Sample ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
+    rdfs:comment "field-sample" ;
+    sosa:isResultOf <http://createme.org/sampling/field/14> ;
+    sosa:isSampleOf <http://createme.org/location/Australia> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
+
 <http://createme.org/sample/specimen/14> a tern:FeatureOfInterest,
         tern:Sample ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
@@ -1878,8 +1915,7 @@
     rdfs:comment "specimen-sample" ;
     sosa:isResultOf <http://createme.org/sampling/specimen/15> ;
     sosa:isSampleOf <http://createme.org/sample/field/15> ;
-    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
-    tern:hasAttribute <http://createme.org/attribute/preparations/15> .
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> .
 
 <http://createme.org/sample/specimen/16> a tern:FeatureOfInterest,
         tern:Sample ;
@@ -1889,8 +1925,7 @@
     rdfs:comment "specimen-sample" ;
     sosa:isResultOf <http://createme.org/sampling/specimen/16> ;
     sosa:isSampleOf <http://createme.org/sample/field/16> ;
-    tern:featureType <http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> ;
-    tern:hasAttribute <http://createme.org/attribute/preparations/16> .
+    tern:featureType <http://createme.org/bdr-cv/featureType/specimen/kingdom/new-kingdom> .
 
 <http://createme.org/location/Australia> a tern:FeatureOfInterest ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
@@ -1902,39 +1937,39 @@
     schema:name "Stream Environment and Water Pty Ltd" .
 
 <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> a tern:Dataset ;
-    schema:dateCreated "2024-10-22"^^xsd:date ;
-    schema:dateIssued "2024-10-22"^^xsd:date ;
+    schema:dateCreated "2024-10-24"^^xsd:date ;
+    schema:dateIssued "2024-10-24"^^xsd:date ;
     schema:description "Example Systematic Survey Occurrence Dataset by Gaia Resources" ;
     schema:name "Example Systematic Survey Occurrence Dataset" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N5a9bda06d1064f7b99a824d8a7aca7c9 ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N1e8b723d531f4549a071235c6ee5dd4e ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/16> ;
+    rdf:subject <http://createme.org/sampling/field/14> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:N5cd0fa45ce0f4bac8b88571b419e6ea1 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/16> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:Nacfd341a028f42b5b12af378e212407f ;
+    rdf:object _:N67ba5b4861214b9aafbdc7f1dd33d5d2 ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/4> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N2244ad6d3d854b0aa12de5864bd42d88 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/15> ;
+    rdf:subject <http://createme.org/sampling/field/2> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N2df27070ad4f480f86c503bc76f706bb ;
+    rdf:object _:Na96de3f7358d423ea08f23f19615a527 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/9> ;
     rdfs:comment "supplied as" .
@@ -1942,111 +1977,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N4ea37c6b3a8449ad80e34419cb37f650 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/14> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N291b37af4c4643308afa2f419b20d71e ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/13> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Nebf401339c004449b39d8cc29c83068b ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/13> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N1f48a30338c54a65b8d87cb91b59db8f ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/sequencing/16> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N6b4cb35d31df4fa99587ab818da02f21 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/14> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N0f0accf826014c7ea87a191961e3749c ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/11> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N53202988e18a4370817d06c27df0f286 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/15> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N26e3f3196cba44df99ab3ff0500045b4 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/sequencing/15> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N09236ab5706c440c92d97449192ac376 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/2> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N3d479997da4d4ec0b31704ece34ba634 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/6> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N6b743579d1e24b47ac41247065582c82 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/3> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N3ce4535007644d9bb24268eeff3d347f ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/12> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N4117681e6c9147f284745ed566246ed5 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/8> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N6a7e577f06fe43ae812ffcd0bee8dfa3 ;
+    rdf:object _:Ncbdc257307b14cbfa00907d39d50f248 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/10> ;
     rdfs:comment "supplied as" .
@@ -2054,7 +1985,103 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Nceaa399a4b1e4ff0b7872751b24679c8 ;
+    rdf:object _:Ne26427b58d8a46e3bca678dbfa31cb5c ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/8> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:N978577e9841248d9a905182f24013afe ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/sequencing/16> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
+    rdf:object _:N4e7b6c31fbf742b9b79bbb67e6279def ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/5> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N655151124e224420a2c2c193374611a4 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/11> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N7663b9d06f74465cb7813ec120d3efbe ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/13> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Nc4609d9c6074403ebce153f52d92a0fb ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/15> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:N2cbe385a530746ffbbe4e4cfed9a1e91 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/16> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Ne281f95ffb06401ca2b4c27a2adf1177 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/15> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:Nc50e3cff85d6445cb4ed05d2735b8a07 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/13> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
+    rdf:object _:N24d008f6e3a341f2950563899ce12321 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/4> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N520f39cdafc64802940dc32ee9f91f8b ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/14> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Nbd6cdf0e1bde4a0db276f8b70fcb6105 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/12> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
+    rdf:object _:N70a8d21dd45c4bcab2f5d4e1e3e74d12 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/7> ;
     rdfs:comment "supplied as" .
@@ -2062,96 +2089,104 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N8b5a76e3749345eaa9fb410f702e40ed ;
+    rdf:object _:N662b3705c6c74adc98e47f19e5ecaf8f ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/5> ;
+    rdf:subject <http://createme.org/sampling/field/6> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nb6e8b84dfc374e0285eaed98f726a882 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/16> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N2785c100b4d34aad8658807984e5adf1 ;
+    rdf:object _:N911fc829f8654658b87be2aa9e87dae8 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/1> ;
     rdfs:comment "supplied as" .
 
-_:N09236ab5706c440c92d97449192ac376 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Nbdd2043bb4ba4ef1a76392071c1f35f8 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/sequencing/15> ;
+    rdfs:comment "supplied as" .
 
-_:N0f0accf826014c7ea87a191961e3749c a geo:Geometry ;
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
+    rdf:object _:N7617f7bc78ce4b24a5616ba1099fbaa8 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/3> ;
+    rdfs:comment "supplied as" .
+
+_:N1e8b723d531f4549a071235c6ee5dd4e a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N1f48a30338c54a65b8d87cb91b59db8f a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+_:N24d008f6e3a341f2950563899ce12321 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:N2244ad6d3d854b0aa12de5864bd42d88 a geo:Geometry ;
+_:N2cbe385a530746ffbbe4e4cfed9a1e91 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 
-_:N26e3f3196cba44df99ab3ff0500045b4 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+_:N4e7b6c31fbf742b9b79bbb67e6279def a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N2785c100b4d34aad8658807984e5adf1 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:N291b37af4c4643308afa2f419b20d71e a geo:Geometry ;
+_:N520f39cdafc64802940dc32ee9f91f8b a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N2df27070ad4f480f86c503bc76f706bb a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
-
-_:N3ce4535007644d9bb24268eeff3d347f a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:N3d479997da4d4ec0b31704ece34ba634 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
-
-_:N4117681e6c9147f284745ed566246ed5 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
-
-_:N4ea37c6b3a8449ad80e34419cb37f650 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
-
-_:N53202988e18a4370817d06c27df0f286 a geo:Geometry ;
+_:N5cd0fa45ce0f4bac8b88571b419e6ea1 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N5a9bda06d1064f7b99a824d8a7aca7c9 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:N6a7e577f06fe43ae812ffcd0bee8dfa3 a geo:Geometry ;
+_:N655151124e224420a2c2c193374611a4 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N6b4cb35d31df4fa99587ab818da02f21 a geo:Geometry ;
+_:N662b3705c6c74adc98e47f19e5ecaf8f a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
+
+_:N67ba5b4861214b9aafbdc7f1dd33d5d2 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
+
+_:N70a8d21dd45c4bcab2f5d4e1e3e74d12 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
+
+_:N7617f7bc78ce4b24a5616ba1099fbaa8 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
+
+_:N7663b9d06f74465cb7813ec120d3efbe a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
+
+_:N911fc829f8654658b87be2aa9e87dae8 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+
+_:N978577e9841248d9a905182f24013afe a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:Na96de3f7358d423ea08f23f19615a527 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
+
+_:Nbd6cdf0e1bde4a0db276f8b70fcb6105 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+
+_:Nbdd2043bb4ba4ef1a76392071c1f35f8 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:Nc4609d9c6074403ebce153f52d92a0fb a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+
+_:Nc50e3cff85d6445cb4ed05d2735b8a07 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N6b743579d1e24b47ac41247065582c82 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
+_:Ncbdc257307b14cbfa00907d39d50f248 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N8b5a76e3749345eaa9fb410f702e40ed a geo:Geometry ;
+_:Ne26427b58d8a46e3bca678dbfa31cb5c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:Nacfd341a028f42b5b12af378e212407f a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
-
-_:Nb6e8b84dfc374e0285eaed98f726a882 a geo:Geometry ;
+_:Ne281f95ffb06401ca2b4c27a2adf1177 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:Nceaa399a4b1e4ff0b7872751b24679c8 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
-
-_:Nebf401339c004449b39d8cc29c83068b a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -406,22 +406,14 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         id_qualifier_value = utils.rdf.uri(f"value/identificationQualifier/{row_num}", base_iri)
         id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{row_num}", base_iri)
         id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{row_num}", base_iri)
-        data_generalizations_attribute = utils.rdf.uri(f"attribute/dataGeneralizations/{row_num}", base_iri)
-        data_generalizations_value = utils.rdf.uri(f"value/dataGeneralizations/{row_num}", base_iri)
         taxon_rank_attribute = utils.rdf.uri(f"attribute/taxonRank/{row_num}", base_iri)
         taxon_rank_value = utils.rdf.uri(f"value/taxonRank/{row_num}", base_iri)
         individual_count_observation = utils.rdf.uri(f"observation/individualCount/{row_num}", base_iri)
         individual_count_value = utils.rdf.uri(f"value/individualCount/{row_num}", base_iri)
         organism_remarks_observation = utils.rdf.uri(f"observation/organismRemarks/{row_num}", base_iri)
         organism_remarks_value = utils.rdf.uri(f"value/organismRemarks/{row_num}", base_iri)
-        habitat_attribute = utils.rdf.uri(f"attribute/habitat/{row_num}", base_iri)
-        habitat_value = utils.rdf.uri(f"value/habitat/{row_num}", base_iri)
-        basis_attribute = utils.rdf.uri(f"attribute/basisOfRecord/{row_num}", base_iri)
-        basis_value = utils.rdf.uri(f"value/basisOfRecord/{row_num}", base_iri)
         occurrence_status_observation = utils.rdf.uri(f"observation/occurrenceStatus/{row_num}", base_iri)
         occurrence_status_value = utils.rdf.uri(f"value/occurrenceStatus/{row_num}", base_iri)
-        preparations_attribute = utils.rdf.uri(f"attribute/preparations/{row_num}", base_iri)
-        preparations_value = utils.rdf.uri(f"value/preparations/{row_num}", base_iri)
         establishment_means_observation = utils.rdf.uri(f"observation/establishmentMeans/{row_num}", base_iri)
         establishment_means_value = utils.rdf.uri(f"value/establishmentMeans/{row_num}", base_iri)
         life_stage_observation = utils.rdf.uri(f"observation/lifeStage/{row_num}", base_iri)
@@ -456,6 +448,50 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             namespace=base_iri,
         )
 
+        # Conditionally create uris dependant of dataGeneralizations field
+        if data_generalizations := row["dataGeneralizations"]:
+            data_generalizations_attribute = utils.rdf.uri(
+                f"attribute/dataGeneralizations/{data_generalizations}", base_iri
+            )
+            data_generalizations_value = utils.rdf.uri(f"value/dataGeneralizations/{data_generalizations}", base_iri)
+            data_generalizations_sample_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "dataGeneralizations", data_generalizations
+            )
+        else:
+            data_generalizations_attribute = None
+            data_generalizations_value = None
+            data_generalizations_sample_collection = None
+
+        # Conditionally create uris dependant of basisOfRecord field
+        if basis_of_record := row["basisOfRecord"]:
+            basis_attribute = utils.rdf.uri(f"attribute/basisOfRecord/{basis_of_record}", base_iri)
+            basis_value = utils.rdf.uri(f"value/basisOfRecord/{basis_of_record}", base_iri)
+            basis_sample_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "basisOfRecord", basis_of_record
+            )
+        else:
+            basis_attribute = None
+            basis_value = None
+            basis_sample_collection = None
+
+        # Conditionally create uri's dependent on recordedBy field.
+        if recorded_by := row["recordedBy"]:
+            record_number_datatype = utils.rdf.uri(f"datatype/recordNumber/{recorded_by}", base_iri)
+            provider_recorded_by = utils.rdf.uri(f"provider/{recorded_by}", base_iri)
+        else:
+            record_number_datatype = None
+            provider_recorded_by = None
+
+        # Conditionally create uri's dependent on habitat field.
+        if habitat := row["habitat"]:
+            habitat_attribute = utils.rdf.uri(f"attribute/habitat/{habitat}", base_iri)
+            habitat_value = utils.rdf.uri(f"value/habitat/{habitat}", base_iri)
+            habitat_sample_collection = utils.rdf.extend_uri(dataset, "OccurrenceCollection", "habitat", habitat)
+        else:
+            habitat_attribute = None
+            habitat_value = None
+            habitat_sample_collection = None
+
         # Conditionally create uris dependent on ownerRecordIDSource field
         if owner_record_id_source := row["ownerRecordIDSource"]:
             owner_record_id_datatype = utils.rdf.uri(f"datatype/recordID/{owner_record_id_source}", base_iri)
@@ -465,14 +501,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             owner_record_id_datatype = None
             owner_record_id_provider = None
             owner_record_id_attribution = None
-
-        # Conditionally create uri's dependent on recordedBy field.
-        if recorded_by := row["recordedBy"]:
-            record_number_datatype = utils.rdf.uri(f"datatype/recordNumber/{recorded_by}", base_iri)
-            provider_recorded_by = utils.rdf.uri(f"provider/{recorded_by}", base_iri)
-        else:
-            record_number_datatype = None
-            provider_recorded_by = None
 
         # Conditionally create uris dependent on catalogNumberSource field.
         if catalog_number_source := row["catalogNumberSource"]:
@@ -492,6 +520,18 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         else:
             other_catalog_numbers_datatype = None
             other_catalog_numbers_provider = None
+
+        # Conditionally create uris dependent on preparations field
+        if preparations := row["preparations"]:
+            preparations_attribute = utils.rdf.uri(f"attribute/preparations/{preparations}", base_iri)
+            preparations_value = utils.rdf.uri(f"value/preparations/{preparations}", base_iri)
+            preparations_sample_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "preparations", preparations
+            )
+        else:
+            preparations_attribute = None
+            preparations_value = None
+            preparations_sample_collection = None
 
         # Conditionally create uri dependent on surveyID field.
         if survey_id := row["surveyID"]:
@@ -580,9 +620,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             provider=provider_recorded_by,
             feature_of_interest=terminal_foi,
             sample_field=sample_field,
-            generalizations=data_generalizations_attribute,
-            habitat=habitat_attribute,
-            basis=basis_attribute,
             site=site,
             site_id_geometry_map=site_id_geometry_map,
             survey=survey,
@@ -621,7 +658,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             dataset=dataset,
             sampling_specimen=sampling_specimen,
             sample_field=sample_field,
-            preparations=preparations_attribute,
             catalog_number_datatype=catalog_number_datatype,
             graph=graph,
         )
@@ -663,8 +699,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             dataset=dataset,
             sample_field=sample_field,
             sample_specimen=sample_specimen,
-            generalizations=data_generalizations_attribute,
-            basis=basis_attribute,
             site_id_geometry_map=site_id_geometry_map,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
             graph=graph,
@@ -750,7 +784,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Data Generalizations Attribute
         self.add_data_generalizations_attribute(
             uri=data_generalizations_attribute,
-            row=row,
+            data_generalizations=data_generalizations,
             dataset=dataset,
             data_generalizations_value=data_generalizations_value,
             graph=graph,
@@ -759,7 +793,17 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Data Generalizations Value
         self.add_data_generalizations_value(
             uri=data_generalizations_value,
-            row=row,
+            data_generalizations=data_generalizations,
+            graph=graph,
+        )
+
+        # Add Data Generalizations Sample Collection
+        self.add_data_generalizations_sample_collection(
+            uri=data_generalizations_sample_collection,
+            data_generalizations=data_generalizations,
+            data_generalizations_attribute=data_generalizations_attribute,
+            sample_field=sample_field,
+            dataset=dataset,
             graph=graph,
         )
 
@@ -819,7 +863,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Habitat Attribute
         self.add_habitat_attribute(
             uri=habitat_attribute,
-            row=row,
+            habitat=habitat,
             dataset=dataset,
             habitat_value=habitat_value,
             graph=graph,
@@ -828,14 +872,25 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Habitat Value
         self.add_habitat_value(
             uri=habitat_value,
-            row=row,
+            habitat=habitat,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add habitat attribute sample collection
+        self.add_habitat_sample_collection(
+            uri=habitat_sample_collection,
+            habitat=habitat,
+            habitat_attribute=habitat_attribute,
+            sample_field=sample_field,
+            dataset=dataset,
             graph=graph,
         )
 
         # Add Basis of Record Attribute
         self.add_basis_attribute(
             uri=basis_attribute,
-            row=row,
+            basis_of_record=basis_of_record,
             dataset=dataset,
             basis_value=basis_value,
             graph=graph,
@@ -844,6 +899,18 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Basis of Record Value
         self.add_basis_value(
             uri=basis_value,
+            basis_of_record=basis_of_record,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add Basis of Record Sample Collection
+        self.add_basis_sample_collection(
+            uri=basis_sample_collection,
+            basis_of_record=basis_of_record,
+            basis_attribute=basis_attribute,
+            sample_specimen=sample_specimen,
+            sample_field=sample_field,
             row=row,
             dataset=dataset,
             graph=graph,
@@ -885,7 +952,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Preparations Attribute
         self.add_preparations_attribute(
             uri=preparations_attribute,
-            row=row,
+            preparations=preparations,
             dataset=dataset,
             preparations_value=preparations_value,
             graph=graph,
@@ -894,7 +961,17 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         # Add Preparations Value
         self.add_preparations_value(
             uri=preparations_value,
-            row=row,
+            preparations=preparations,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add Preparations attribute Sample Collection
+        self.add_preparations_sample_collection(
+            uri=preparations_sample_collection,
+            preparations=preparations,
+            preparations_attribute=preparations_attribute,
+            sample_specimen=sample_specimen,
             dataset=dataset,
             graph=graph,
         )
@@ -1523,9 +1600,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider: rdflib.URIRef | None,
         feature_of_interest: rdflib.URIRef,
         sample_field: rdflib.URIRef,
-        generalizations: rdflib.URIRef,
-        habitat: rdflib.URIRef,
-        basis: rdflib.URIRef,
         site: rdflib.URIRef | None,
         site_id_geometry_map: dict[str, str] | None,
         survey: rdflib.URIRef | None,
@@ -1546,10 +1620,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 with this node.
             sample_field (rdflib.URIRef): Sample Field associated with this
                 node
-            generalizations (rdflib.URIRef): Data Generalizations associated
-                with this node
-            habitat (rdflib.URIRef): Habitat associated with this node
-            basis (rdflib.URIRef): Basis Of Record associated with this node
             site (rdflib.URIRef | None): Site if one was provided else None.
             site_id_geometry_map (dict[str, str] | None): Default geometry value to use
                 if none available for given site id.
@@ -1663,21 +1733,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Add Spatial Accuracy
             accuracy = rdflib.Literal(row["coordinateUncertaintyInMeters"], datatype=rdflib.XSD.double)
             graph.add((uri, utils.namespaces.GEO.hasMetricSpatialAccuracy, accuracy))
-
-        # Check for dataGeneralizations
-        if row["dataGeneralizations"]:
-            # Add Data Generalizations Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, generalizations))
-
-        # Check for habitat
-        if row["habitat"]:
-            # Add Habitat Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, habitat))
-
-        # Check for basisOfRecord and if Row has no Specimen
-        if not has_specimen(row) and row["basisOfRecord"]:
-            # Add Basis Of Record Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, basis))
 
     def add_provider_record_id_agent(
         self,
@@ -1915,8 +1970,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         sample_field: rdflib.URIRef,
         sample_specimen: rdflib.URIRef,
-        generalizations: rdflib.URIRef,
-        basis: rdflib.URIRef,
         site_id_geometry_map: dict[str, str] | None,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
@@ -1931,9 +1984,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 node
             sample_specimen (rdflib.URIRef): Sample Specimen associated with
                 this node
-            generalizations (rdflib.URIRef): Data Generalizations associated
-                with this node
-            basis (rdflib.URIRef): Basis Of Record associated with this node
             site_id_geometry_map (dict[str, str] | None): Map with default wkt
                 string for a given site id.
             site_visit_id_temporal_map (dict[str, str] | None): Map with default
@@ -2023,16 +2073,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Add Spatial Accuracy
             accuracy = rdflib.Literal(row["coordinateUncertaintyInMeters"], datatype=rdflib.XSD.double)
             graph.add((uri, utils.namespaces.GEO.hasMetricSpatialAccuracy, accuracy))
-
-        # Check for dataGeneralizations
-        if row["dataGeneralizations"]:
-            # Add Data Generalizations Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, generalizations))
-
-        # Check for basisOfRecord and if Row has a Specimen
-        if has_specimen(row) and row["basisOfRecord"]:
-            # Add Basis Of Record Attribute
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, basis))
 
     def add_text_verbatim_id(
         self,
@@ -2193,7 +2233,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         sampling_specimen: rdflib.URIRef,
         sample_field: rdflib.URIRef,
-        preparations: rdflib.URIRef,
         catalog_number_datatype: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
@@ -2207,8 +2246,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 with this node
             sample_field (rdflib.URIRef): Sample Field associated with this
                 node
-            preparations (rdflib.URIRef): Preparations Attribute associated
-                with this node
             catalog_number_datatype (rdflib.URIRef | None): Catalog number source
                 datatype.
             graph (rdflib.Graph): Graph to add to
@@ -2248,61 +2285,100 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Add to Graph
             graph.add((uri, utils.namespaces.DWC.collectionCode, rdflib.Literal(row["collectionCode"])))
 
-        # Check for preparations
-        if row["preparations"]:
-            # Add Preparations
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, preparations))
-
     def add_data_generalizations_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        data_generalizations: str | None,
         dataset: rdflib.URIRef,
-        data_generalizations_value: rdflib.URIRef,
+        data_generalizations_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Data Generalizations Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            data_generalizations_value (rdflib.URIRef): Data Generalizations
-                Value associated with this node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            data_generalizations: dataGeneralizations value from the CSV
+            dataset: Dataset this belongs to
+            data_generalizations_value: Data Generalizations Value associated with this node
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["dataGeneralizations"]:
+        if uri is None:
             return
 
         # Data Generalizations Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_DATA_GENERALIZATIONS))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["dataGeneralizations"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, data_generalizations_value))
+        if data_generalizations:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(data_generalizations)))
+        if data_generalizations_value is not None:
+            graph.add((uri, utils.namespaces.TERN.hasValue, data_generalizations_value))
 
     def add_data_generalizations_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        data_generalizations: str | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Data Generalizations Value to the Graph
 
         Args:
             uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
+            data_generalizations: dataGeneralizations value from the CSV
             graph (rdflib.Graph): Graph to add to
         """
         # Check Existence
-        if not row["dataGeneralizations"]:
+        if uri is None:
             return
 
         # Data Generalizations Value
         graph.add((uri, a, utils.namespaces.TERN.Text))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDF.value, rdflib.Literal(row["dataGeneralizations"])))
+        graph.add((uri, rdflib.RDF.value, rdflib.Literal(data_generalizations)))
+
+    def add_data_generalizations_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        data_generalizations: str | None,
+        data_generalizations_attribute: rdflib.URIRef | None,
+        sample_field: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a data generalizations attribute Sample Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            data_generalizations: dataGeneralizations value from template.
+            data_generalizations_attribute: The uri for the attribute node.
+            sample_field: The sample field node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.Collection))
+        # Add identifier
+        if data_generalizations:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(
+                        f"Occurrence Collection - Data Generalizations - {data_generalizations}",
+                    ),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the sample field
+        graph.add((uri, rdflib.SOSA.hasMember, sample_field))
+        # Add link to attribute
+        if data_generalizations_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, data_generalizations_attribute))
 
     def add_taxon_rank_attribute(
         self,
@@ -2550,115 +2626,215 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_habitat_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        habitat: str | None,
         dataset: rdflib.URIRef,
-        habitat_value: rdflib.URIRef,
+        habitat_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Habitat Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            habitat_value (rdflib.URIRef): Habitat Value associated with this
-                node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            habitat: Raw habitat from CSV.
+            dataset: Dataset this belongs to
+            habitat_value: Habitat Value associated with this node
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["habitat"]:
+        if uri is None:
             return
 
         # Habitat Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_HABITAT))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["habitat"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, habitat_value))
+        if habitat:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(habitat)))
+        if habitat_value is not None:
+            graph.add((uri, utils.namespaces.TERN.hasValue, habitat_value))
 
     def add_habitat_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        habitat: str | None,
+        dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Habitat Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            habitat: Habitat from the CSV
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["habitat"]:
+        if uri is None:
             return
 
         # Habitat Value
-        graph.add((uri, a, utils.namespaces.TERN.Text))
+        graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("habitat")))
-        graph.add((uri, rdflib.RDF.value, rdflib.Literal(row["habitat"])))
+        if habitat:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(habitat)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["habitat"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(habitat)
+            # Add value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_habitat_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        habitat: str | None,
+        habitat_attribute: rdflib.URIRef | None,
+        sample_field: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a habitat attribute Sample Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            habitat: Habitat value from template.
+            habitat_attribute: The uri for the attribute node.
+            sample_field: The sample field node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.Collection))
+        # Add identifier
+        if habitat:
+            graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(f"Occurrence Collection - Habitat - {habitat}")))
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the sample field
+        graph.add((uri, rdflib.SOSA.hasMember, sample_field))
+        # Add link to attribute
+        if habitat_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, habitat_attribute))
 
     def add_basis_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        basis_of_record: str | None,
         dataset: rdflib.URIRef,
-        basis_value: rdflib.URIRef,
+        basis_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Basis of Record Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            basis_value (rdflib.URIRef): Basis of Record Value associated with
-                this node
+            uri: URI to use for this node.
+            basis_of_record: basisOfRecord value from the CSV
+            dataset: Dataset this belongs to
+            basis_value: Basis of Record Value associated with this node
             graph (rdflib.Graph): Graph to add to
         """
         # Check Existence
-        if not row["basisOfRecord"]:
+        if uri is None:
             return
 
         # Basis of Record Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_BASIS_OF_RECORD))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["basisOfRecord"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, basis_value))
+        if basis_of_record:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(basis_of_record)))
+        if basis_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, basis_value))
 
     def add_basis_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        basis_of_record: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Basis of Record Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            basis_of_record: basisOfRecord value from the CSV
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["basisOfRecord"]:
+        if uri is None:
             return
-
-        # Retrieve vocab for field
-        vocab = self.fields()["basisOfRecord"].get_vocab()
-
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["basisOfRecord"])
 
         # Basis of Record Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("basisOfRecord")))
-        graph.add((uri, rdflib.RDF.value, term))
+        if basis_of_record:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(basis_of_record)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["basisOfRecord"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(basis_of_record)
+            # Add value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_basis_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        basis_of_record: str | None,
+        basis_attribute: rdflib.URIRef | None,
+        sample_specimen: rdflib.URIRef,
+        sample_field: rdflib.URIRef,
+        row: frictionless.Row,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a basisOfRecord attribute Sample Collection to the graph
+
+        Either the sample_specimen node or the sample_field node should be a member
+        of this collection, depending on if the row has a specimen.
+
+        Args:
+            uri: The uri for the SampleCollection.
+            basis_of_record: basisOfRecord value from template.
+            basis_attribute: The uri for the attribute node.
+            sample_specimen: The sample specimen node.
+            sample_field: The sample field node that.
+            row: The CSV row.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.Collection))
+        # Add identifier
+        if basis_of_record:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Basis Of Record - {basis_of_record}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the appropriate sample node
+        if has_specimen(row):
+            graph.add((uri, rdflib.SOSA.hasMember, sample_specimen))
+        else:
+            graph.add((uri, rdflib.SOSA.hasMember, sample_field))
+        # Add link to attribute
+        if basis_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, basis_attribute))
 
     def add_owner_institution_provider(
         self,
@@ -2799,63 +2975,107 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_preparations_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        preparations: str | None,
         dataset: rdflib.URIRef,
-        preparations_value: rdflib.URIRef,
+        preparations_value: rdflib.URIRef | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Preparations Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            preparations_value (rdflib.URIRef): Preparations Value associated
-                with this node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            preparations: preparations value from the CSV
+            dataset: Dataset this belongs to
+            preparations_value: Preparations Value associated with this node
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["preparations"]:
+        if uri is None:
             return
 
         # Preparations Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_PREPARATIONS))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["preparations"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, preparations_value))
+        if preparations:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(preparations)))
+        if preparations_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, preparations_value))
 
     def add_preparations_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        uri: rdflib.URIRef | None,
+        preparations: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Preparations Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            preparations: preparations value from the CSV
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["preparations"]:
+        if uri is None:
             return
-
-        # Retrieve vocab for field
-        vocab = self.fields()["preparations"].get_vocab()
-
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["preparations"])
 
         # Preparations Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("preparations")))
-        graph.add((uri, rdflib.RDF.value, term))
+        if preparations:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(preparations)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["preparations"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(preparations)
+            # Add value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_preparations_sample_collection(
+        self,
+        uri: rdflib.URIRef | None,
+        preparations: str | None,
+        preparations_attribute: rdflib.URIRef | None,
+        sample_specimen: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a preparations attribute Sample Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            preparations: preparations value from template.
+            preparations_attribute: The uri for the attribute node.
+            sample_specimen: The sample specimen node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, utils.namespaces.TERN.Collection))
+        # Add identifier
+        if preparations:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Preparations - {preparations}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the sample_specimen node
+        graph.add((uri, rdflib.SOSA.hasMember, sample_specimen))
+        # Add link to attribute
+        if preparations_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, preparations_attribute))
 
     def add_establishment_means_observation(
         self,

--- a/abis_mapping/templates/survey_occurrence_data_v2/schema.json
+++ b/abis_mapping/templates/survey_occurrence_data_v2/schema.json
@@ -205,7 +205,10 @@
       "url": "http://rs.tdwg.org/dwc/terms/habitat",
       "constraints": {
         "required": false
-      }
+      },
+      "vocabularies": [
+        "TARGET_HABITAT_SCOPE"
+      ]
     },
     {
       "name": "establishmentMeans",


### PR DESCRIPTION
BDRSPS-925 Add Collections for certain attributes in the survey occurrence v2 mapping
    
The Attribute and Attribute Value IRIs now have the value in them, instead of the row number.
This greatly reduces the number we create.
A new Collection node joins the Attribute node and the rows that had that attribute.
    
The following attributes are changed:
* basisOfRecord
* habitat
* preparations
* dataGeneralizations
    
Same as #272, but for the survey occurrence template