### PR TITLE
BDRSPS-925 Implement collections for remaining attributes in incidental v3 mapping

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -19,59 +19,126 @@
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/HumanObservation> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/specimen/14> ;
     schema:identifier "Occurrence Collection - Basis Of Record - HumanObservation" ;
+    schema:member <http://createme.org/sample/specimen/14> ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/HumanObservation> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/PreservedSpecimen> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
     schema:member <http://createme.org/sample/specimen/13>,
         <http://createme.org/sample/specimen/15> ;
-    schema:identifier "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/PreservedSpecimen> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/basisOfRecord/new-basis-of-record> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/specimen/16> ;
     schema:identifier "Occurrence Collection - Basis Of Record - new basis of record" ;
+    schema:member <http://createme.org/sample/specimen/16> ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/new-basis-of-record> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/conservationAuthority/Wet-in-ethanol-or-some-other-preservative> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Conservation Authority - WA" ;
+    schema:member <http://createme.org/observation/threatStatus/15> ;
+    tern:hasAttribute <http://createme.org/attribute/conservationAuthority/WA> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/conservationAuthority/new-preparations> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Conservation Authority - WA" ;
+    schema:member <http://createme.org/observation/threatStatus/16> ;
+    tern:hasAttribute <http://createme.org/attribute/conservationAuthority/WA> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/dataGeneralizations/Coordinates-generalised> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/field/16> ;
     schema:identifier "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
+    schema:member <http://createme.org/sample/field/16> ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     schema:member <http://createme.org/sample/field/14>,
         <http://createme.org/sample/field/15> ;
-    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/field/15> ;
     schema:identifier "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
+    schema:member <http://createme.org/sample/field/15> ;
     tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/habitat/new-habitat> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/field/16> ;
     schema:identifier "Occurrence Collection - Habitat - new habitat" ;
+    schema:member <http://createme.org/sample/field/16> ;
     tern:hasAttribute <http://createme.org/attribute/habitat/new-habitat> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationQualifier/> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Qualifier - ?" ;
+    schema:member <http://createme.org/observation/scientificName/11>,
+        <http://createme.org/observation/scientificName/14> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationQualifier/new-identification-qualifier> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Qualifier - new identification qualifier" ;
+    schema:member <http://createme.org/observation/scientificName/16> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/new-identification-qualifier> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationQualifier/species-incerta> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Qualifier - species incerta" ;
+    schema:member <http://createme.org/observation/scientificName/15> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/species-incerta> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Remarks - Could not confirm the ID due to damaged flower" ;
+    schema:member <http://createme.org/observation/scientificName/14> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Remarks - One unopened flower when recorded and one leaf only. ID not confirmed" ;
+    schema:member <http://createme.org/observation/scientificName/11> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationRemarks/new-remarks> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Remarks - new remarks" ;
+    schema:member <http://createme.org/observation/scientificName/16> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationRemarks/new-remarks> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/identificationRemarks/no-flowers-present> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Identification Remarks - no flowers present" ;
+    schema:member <http://createme.org/observation/scientificName/15> ;
+    tern:hasAttribute <http://createme.org/attribute/identificationRemarks/no-flowers-present> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/preparations/Wet-in-ethanol-or-some-other-preservative> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/specimen/15> ;
     schema:identifier "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
+    schema:member <http://createme.org/sample/specimen/15> ;
     tern:hasAttribute <http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/preparations/new-preparations> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    schema:member <http://createme.org/sample/specimen/16> ;
     schema:identifier "Occurrence Collection - Preparations - new preparations" ;
+    schema:member <http://createme.org/sample/specimen/16> ;
     tern:hasAttribute <http://createme.org/attribute/preparations/new-preparations> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/taxonRank/new-taxon-rank> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Taxon Rank - new taxon rank" ;
+    schema:member <http://createme.org/observation/scientificName/16> ;
+    tern:hasAttribute <http://createme.org/attribute/taxonRank/new-taxon-rank> .
+
+<http://createme.org/dataset/Example-Incidental-Occurrence-Dataset/OccurrenceCollection/taxonRank/species> a schema:Collection ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    schema:identifier "Occurrence Collection - Taxon Rank - species" ;
+    schema:member <http://createme.org/observation/scientificName/15> ;
+    tern:hasAttribute <http://createme.org/attribute/taxonRank/species> .
 
 <http://createme.org/datatype/catalogNumber/BHP> a rdfs:Datatype ;
     skos:definition "A catalog number for the sample" ;
@@ -307,21 +374,6 @@
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> .
 
-<http://createme.org/observation/scientificName/11> a tern:Observation ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "scientificName-observation" ;
-    time:hasTime [ a time:Instant ;
-            rdfs:comment "Date unknown, template eventDate used as proxy" ;
-            time:inXSDDate "2019-09-26"^^xsd:date ] ;
-    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
-    sosa:hasResult <http://createme.org/scientificName/11> ;
-    sosa:hasSimpleResult "Caladenia excelsa" ;
-    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
-    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/11>,
-        <http://createme.org/attribute/identificationRemarks/11> .
-
 <http://createme.org/observation/scientificName/12> a tern:Observation ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     rdfs:comment "scientificName-observation" ;
@@ -346,51 +398,6 @@
     sosa:hasSimpleResult "Caladenia excelsa" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> .
-
-<http://createme.org/observation/scientificName/14> a tern:Observation ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "scientificName-observation" ;
-    time:hasTime [ a time:Instant ;
-            rdfs:comment "Date unknown, template eventDate used as proxy" ;
-            time:inXSDDate "2019-09-26"^^xsd:date ] ;
-    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/14> ;
-    sosa:hasResult <http://createme.org/scientificName/14> ;
-    sosa:hasSimpleResult "Caladenia excelsa" ;
-    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
-    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> ;
-    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/14>,
-        <http://createme.org/attribute/identificationRemarks/14> .
-
-<http://createme.org/observation/scientificName/15> a tern:Observation ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "scientificName-observation" ;
-    time:hasTime [ a time:Instant ;
-            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
-    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
-    sosa:hasResult <http://createme.org/scientificName/15> ;
-    sosa:hasSimpleResult "Caladenia excelsa" ;
-    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
-    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> ;
-    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/15>,
-        <http://createme.org/attribute/identificationRemarks/15>,
-        <http://createme.org/attribute/taxonRank/15> .
-
-<http://createme.org/observation/scientificName/16> a tern:Observation ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "scientificName-observation" ;
-    time:hasTime [ a time:Instant ;
-            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
-    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
-    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
-    sosa:hasResult <http://createme.org/scientificName/16> ;
-    sosa:hasSimpleResult "Caladenia excelsa" ;
-    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
-    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> ;
-    tern:hasAttribute <http://createme.org/attribute/identificationQualifier/16>,
-        <http://createme.org/attribute/identificationRemarks/16>,
-        <http://createme.org/attribute/taxonRank/16> .
 
 <http://createme.org/observation/scientificName/2> a tern:Observation ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -521,33 +528,6 @@
     sosa:hasSimpleResult "new sex" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/05cbf534-c233-4aa8-a08c-00b28976ed36> ;
     sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/ea1d6342-1901-4f88-8482-3111286ec157> .
-
-<http://createme.org/observation/threatStatus/15> a tern:Observation ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "threatStatus-observation" ;
-    time:hasTime [ a time:Instant ;
-            rdfs:comment "Date unknown, template dateIdentified used as proxy" ;
-            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
-    prov:wasAssociatedWith <http://createme.org/provider/WA-BIO> ;
-    prov:wasInfluencedBy <http://createme.org/attribute/conservationAuthority/15> ;
-    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/15> ;
-    sosa:hasResult <http://createme.org/value/threatStatus/15> ;
-    sosa:hasSimpleResult "VU" ;
-    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
-    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> .
-
-<http://createme.org/observation/threatStatus/16> a tern:Observation ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    rdfs:comment "threatStatus-observation" ;
-    time:hasTime [ a time:Instant ;
-            rdfs:comment "Date unknown, template dateIdentified used as proxy" ;
-            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
-    prov:wasInfluencedBy <http://createme.org/attribute/conservationAuthority/16> ;
-    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/16> ;
-    sosa:hasResult <http://createme.org/value/threatStatus/16> ;
-    sosa:hasSimpleResult "new threat status" ;
-    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
-    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/a-random-selection> .
 
 <http://createme.org/observation/verbatimID/1> a tern:Observation ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -750,18 +730,6 @@
     tern:hasSimpleValue "new basis of record" ;
     tern:hasValue <http://createme.org/value/basisOfRecord/new-basis-of-record> .
 
-<http://createme.org/attribute/conservationAuthority/15> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
-    tern:hasSimpleValue "WA" ;
-    tern:hasValue <http://createme.org/value/conservationAuthority/15> .
-
-<http://createme.org/attribute/conservationAuthority/16> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
-    tern:hasSimpleValue "WA" ;
-    tern:hasValue <http://createme.org/value/conservationAuthority/16> .
-
 <http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/data-generalizations> ;
@@ -786,53 +754,47 @@
     tern:hasSimpleValue "new habitat" ;
     tern:hasValue <http://createme.org/value/habitat/new-habitat> .
 
-<http://createme.org/attribute/identificationQualifier/11> a tern:Attribute ;
+<http://createme.org/attribute/identificationQualifier/> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
     tern:hasSimpleValue "?" ;
-    tern:hasValue <http://createme.org/value/identificationQualifier/11> .
+    tern:hasValue <http://createme.org/value/identificationQualifier/> .
 
-<http://createme.org/attribute/identificationQualifier/14> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
-    tern:hasSimpleValue "?" ;
-    tern:hasValue <http://createme.org/value/identificationQualifier/14> .
-
-<http://createme.org/attribute/identificationQualifier/15> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
-    tern:hasSimpleValue "species incerta" ;
-    tern:hasValue <http://createme.org/value/identificationQualifier/15> .
-
-<http://createme.org/attribute/identificationQualifier/16> a tern:Attribute ;
+<http://createme.org/attribute/identificationQualifier/new-identification-qualifier> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
     tern:hasSimpleValue "new identification qualifier" ;
-    tern:hasValue <http://createme.org/value/identificationQualifier/16> .
+    tern:hasValue <http://createme.org/value/identificationQualifier/new-identification-qualifier> .
 
-<http://createme.org/attribute/identificationRemarks/11> a tern:Attribute ;
+<http://createme.org/attribute/identificationQualifier/species-incerta> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
-    tern:hasSimpleValue "One unopened flower when recorded and one leaf only. ID not confirmed" ;
-    tern:hasValue <http://createme.org/value/identificationRemarks/11> .
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/54e40f12-8c13-495a-9f8d-838d78faa5a7> ;
+    tern:hasSimpleValue "species incerta" ;
+    tern:hasValue <http://createme.org/value/identificationQualifier/species-incerta> .
 
-<http://createme.org/attribute/identificationRemarks/14> a tern:Attribute ;
+<http://createme.org/attribute/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
     tern:hasSimpleValue "Could not confirm the ID due to damaged flower" ;
-    tern:hasValue <http://createme.org/value/identificationRemarks/14> .
+    tern:hasValue <http://createme.org/value/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> .
 
-<http://createme.org/attribute/identificationRemarks/15> a tern:Attribute ;
+<http://createme.org/attribute/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
-    tern:hasSimpleValue "no flowers present" ;
-    tern:hasValue <http://createme.org/value/identificationRemarks/15> .
+    tern:hasSimpleValue "One unopened flower when recorded and one leaf only. ID not confirmed" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> .
 
-<http://createme.org/attribute/identificationRemarks/16> a tern:Attribute ;
+<http://createme.org/attribute/identificationRemarks/new-remarks> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
     tern:hasSimpleValue "new remarks" ;
-    tern:hasValue <http://createme.org/value/identificationRemarks/16> .
+    tern:hasValue <http://createme.org/value/identificationRemarks/new-remarks> .
+
+<http://createme.org/attribute/identificationRemarks/no-flowers-present> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/45a86abc-43c7-4a30-ac73-fc8d62538140> ;
+    tern:hasSimpleValue "no flowers present" ;
+    tern:hasValue <http://createme.org/value/identificationRemarks/no-flowers-present> .
 
 <http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -846,17 +808,17 @@
     tern:hasSimpleValue "new preparations" ;
     tern:hasValue <http://createme.org/value/preparations/new-preparations> .
 
-<http://createme.org/attribute/taxonRank/15> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    tern:attribute <http://example.com/concept/taxonRank> ;
-    tern:hasSimpleValue "species" ;
-    tern:hasValue <http://createme.org/value/taxonRank/15> .
-
-<http://createme.org/attribute/taxonRank/16> a tern:Attribute ;
+<http://createme.org/attribute/taxonRank/new-taxon-rank> a tern:Attribute ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     tern:attribute <http://example.com/concept/taxonRank> ;
     tern:hasSimpleValue "new taxon rank" ;
-    tern:hasValue <http://createme.org/value/taxonRank/16> .
+    tern:hasValue <http://createme.org/value/taxonRank/new-taxon-rank> .
+
+<http://createme.org/attribute/taxonRank/species> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://example.com/concept/taxonRank> ;
+    tern:hasSimpleValue "species" ;
+    tern:hasValue <http://createme.org/value/taxonRank/species> .
 
 <http://createme.org/attribution/Stream-Environment-and-Water-Pty-Ltd/owner> a prov:Attribution ;
     prov:agent <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
@@ -871,6 +833,13 @@
     skos:definition "A type of basisOfRecord." ;
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
     skos:prefLabel "new basis of record" ;
+    schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
+
+<http://createme.org/bdr-cv/attribute/identificationQualifier/> a skos:Concept ;
+    skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
+    skos:definition "A type of identificationQualifier." ;
+    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
+    skos:prefLabel "?" ;
     schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
 
 <http://createme.org/bdr-cv/attribute/identificationQualifier/new-identification-qualifier> a skos:Concept ;
@@ -1018,6 +987,31 @@
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e> ;
     skos:prefLabel "WA/new threat status" ;
     schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
+
+<http://createme.org/observation/threatStatus/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "threatStatus-observation" ;
+    time:hasTime [ a time:Instant ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ;
+            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/WA-BIO> ;
+    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/15> ;
+    sosa:hasResult <http://createme.org/value/threatStatus/15> ;
+    sosa:hasSimpleResult "VU" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> .
+
+<http://createme.org/observation/threatStatus/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "threatStatus-observation" ;
+    time:hasTime [ a time:Instant ;
+            rdfs:comment "Date unknown, template dateIdentified used as proxy" ;
+            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
+    sosa:hasFeatureOfInterest <http://createme.org/value/acceptedNameUsage/16> ;
+    sosa:hasResult <http://createme.org/value/threatStatus/16> ;
+    sosa:hasSimpleResult "new threat status" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/threatStatusCheckProtocol/a-random-selection> .
 
 <http://createme.org/provider/BHP> a prov:Agent ;
     schema:name "BHP" .
@@ -1175,14 +1169,9 @@
     rdfs:label "new basis of record" ;
     rdf:value <http://createme.org/bdr-cv/attribute/basisOfRecord/new-basis-of-record> .
 
-<http://createme.org/value/conservationAuthority/15> a tern:IRI,
+<http://createme.org/value/conservationAuthority/WA> a tern:IRI,
         tern:Value ;
-    rdfs:label "Conservation Authority = WA" ;
-    rdf:value <https://sws.geonames.org/2058645/> .
-
-<http://createme.org/value/conservationAuthority/16> a tern:IRI,
-        tern:Value ;
-    rdfs:label "Conservation Authority = WA" ;
+    rdfs:label "WA" ;
     rdf:value <https://sws.geonames.org/2058645/> .
 
 <http://createme.org/value/dataGeneralizations/Coordinates-generalised> a tern:Text,
@@ -1213,41 +1202,36 @@
     rdfs:label "new habitat" ;
     rdf:value <http://createme.org/bdr-cv/attribute/targetHabitatScope/new-habitat> .
 
-<http://createme.org/value/identificationQualifier/11> a tern:IRI,
+<http://createme.org/value/identificationQualifier/> a tern:IRI,
         tern:Value ;
-    rdfs:label "identificationQualifier" ;
+    rdfs:label "?" ;
     rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/> .
 
-<http://createme.org/value/identificationQualifier/14> a tern:IRI,
+<http://createme.org/value/identificationQualifier/new-identification-qualifier> a tern:IRI,
         tern:Value ;
-    rdfs:label "identificationQualifier" ;
-    rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/> .
-
-<http://createme.org/value/identificationQualifier/15> a tern:IRI,
-        tern:Value ;
-    rdfs:label "identificationQualifier" ;
-    rdf:value <http://example.com/identificationQualifier/species-incerta> .
-
-<http://createme.org/value/identificationQualifier/16> a tern:IRI,
-        tern:Value ;
-    rdfs:label "identificationQualifier" ;
+    rdfs:label "new identification qualifier" ;
     rdf:value <http://createme.org/bdr-cv/attribute/identificationQualifier/new-identification-qualifier> .
 
-<http://createme.org/value/identificationRemarks/11> a tern:Text,
+<http://createme.org/value/identificationQualifier/species-incerta> a tern:IRI,
         tern:Value ;
-    rdf:value "One unopened flower when recorded and one leaf only. ID not confirmed" .
+    rdfs:label "species incerta" ;
+    rdf:value <http://example.com/identificationQualifier/species-incerta> .
 
-<http://createme.org/value/identificationRemarks/14> a tern:Text,
+<http://createme.org/value/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> a tern:Text,
         tern:Value ;
     rdf:value "Could not confirm the ID due to damaged flower" .
 
-<http://createme.org/value/identificationRemarks/15> a tern:Text,
+<http://createme.org/value/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> a tern:Text,
         tern:Value ;
-    rdf:value "no flowers present" .
+    rdf:value "One unopened flower when recorded and one leaf only. ID not confirmed" .
 
-<http://createme.org/value/identificationRemarks/16> a tern:Text,
+<http://createme.org/value/identificationRemarks/new-remarks> a tern:Text,
         tern:Value ;
     rdf:value "new remarks" .
+
+<http://createme.org/value/identificationRemarks/no-flowers-present> a tern:Text,
+        tern:Value ;
+    rdf:value "no flowers present" .
 
 <http://createme.org/value/individualCount/15> a tern:Integer,
         tern:Value ;
@@ -1324,15 +1308,15 @@
     rdfs:label "sex-value" ;
     rdf:value <http://createme.org/bdr-cv/parameter/sex/new-sex> .
 
-<http://createme.org/value/taxonRank/15> a tern:IRI,
+<http://createme.org/value/taxonRank/new-taxon-rank> a tern:IRI,
         tern:Value ;
-    rdfs:label "taxon rank = species" ;
-    rdf:value <http://example.com/species> .
-
-<http://createme.org/value/taxonRank/16> a tern:IRI,
-        tern:Value ;
-    rdfs:label "taxon rank = new taxon rank" ;
+    rdfs:label "new taxon rank" ;
     rdf:value <http://createme.org/bdr-cv/attribute/taxonRank/new-taxon-rank> .
+
+<http://createme.org/value/taxonRank/species> a tern:IRI,
+        tern:Value ;
+    rdfs:label "species" ;
+    rdf:value <http://example.com/species> .
 
 <http://createme.org/value/threatStatus/15> a tern:IRI,
         tern:Value ;
@@ -1400,12 +1384,11 @@
         tern:Value ;
     rdf:value "Caladenia excelsa" .
 
-<http://createme.org/bdr-cv/attribute/identificationQualifier/> a skos:Concept ;
-    skos:broader <http://example.com/bdr-cv/attribute/identificationQualifier> ;
-    skos:definition "A type of identificationQualifier." ;
-    skos:inScheme <http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924> ;
-    skos:prefLabel "?" ;
-    schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
+<http://createme.org/attribute/conservationAuthority/WA> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    tern:attribute <http://linked.data.gov.au/def/tern-cv/755b1456-b76f-4d54-8690-10e41e25c5a7> ;
+    tern:hasSimpleValue "WA" ;
+    tern:hasValue <http://createme.org/value/conservationAuthority/WA> .
 
 <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> a skos:Concept ;
     skos:broader <http://example.com/bdr-cv/methods/identificationMethod> ;
@@ -1421,6 +1404,32 @@
     skos:prefLabel "new identification method" ;
     schema:citation "http://createme.org/dataset/Example-Incidental-Occurrence-Dataset"^^xsd:anyURI .
 
+<http://createme.org/observation/scientificName/11> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    time:hasTime [ a time:Instant ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ;
+            time:inXSDDate "2019-09-26"^^xsd:date ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/field/11> ;
+    sosa:hasResult <http://createme.org/scientificName/11> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> .
+
+<http://createme.org/observation/scientificName/14> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    time:hasTime [ a time:Instant ;
+            rdfs:comment "Date unknown, template eventDate used as proxy" ;
+            time:inXSDDate "2019-09-26"^^xsd:date ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/14> ;
+    sosa:hasResult <http://createme.org/scientificName/14> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:usedProcedure <http://linked.data.gov.au/def/tern-cv/2eef4e87-beb3-449a-9251-f59f5c07d653> .
+
 <http://createme.org/sample/field/12> a tern:FeatureOfInterest,
         tern:Sample ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
@@ -1431,7 +1440,7 @@
 
 <http://createme.org/sampling/field/1> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nb93fa40cae3d49f0b0e1ed763346fbf9 ;
+    geo:hasGeometry _:Nff61611b8ec24d47a910ac3391c13a43 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1444,7 +1453,7 @@
 
 <http://createme.org/sampling/field/10> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N127c0a74b1354552b613ed3e0940b014 ;
+    geo:hasGeometry _:N033540d2428e485783ffc0beb5faa2fc ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1457,7 +1466,7 @@
 
 <http://createme.org/sampling/field/11> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N0847a7d8902848efa38abc5841027d98 ;
+    geo:hasGeometry _:N3e9fc775acdc42fbb7f02f2de88297b3 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1470,7 +1479,7 @@
 
 <http://createme.org/sampling/field/12> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nbd83b29515754ac1ab8bc850940b1bda ;
+    geo:hasGeometry _:N29c91acf846c46b698fab32a8070b6b7 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1481,7 +1490,7 @@
 
 <http://createme.org/sampling/field/13> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N53c13a2daa284bfa9aefc44ff7946974 ;
+    geo:hasGeometry _:N893de034299d4661bf15da9ad185b6fa ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1494,7 +1503,7 @@
 
 <http://createme.org/sampling/field/14> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Ndeaf6c7868534321b412a4a29fea9948 ;
+    geo:hasGeometry _:N53b1a661fd0b4bb59df39a009b8a44bc ;
     geo:hasMetricSpatialAccuracy 2e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1508,7 +1517,7 @@
 
 <http://createme.org/sampling/field/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N917f81384ae743d28a0236fc9097e012 ;
+    geo:hasGeometry _:N2ee30852bbb64c599b9517126afbf6ab ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1522,7 +1531,7 @@
 
 <http://createme.org/sampling/field/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nb2c33f0f2a004c5586a6c1326c6d728b ;
+    geo:hasGeometry _:N6150cc5744814fdabe6912cd4a4d68cb ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1536,7 +1545,7 @@
 
 <http://createme.org/sampling/field/2> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N5b4e33a523684ee2bca99d2ecb0753e9 ;
+    geo:hasGeometry _:Nb973b643150e4fda9cca00454891b0e1 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1549,7 +1558,7 @@
 
 <http://createme.org/sampling/field/3> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N087f0a8c71274cebacd8db820d529eb7 ;
+    geo:hasGeometry _:N9a31de414c384cf9b243bfd3e94da210 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1562,7 +1571,7 @@
 
 <http://createme.org/sampling/field/4> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N55393adb5edd4b398664d14cf22c3aed ;
+    geo:hasGeometry _:N00a12a0ee17848c9a638c3c306647077 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1575,7 +1584,7 @@
 
 <http://createme.org/sampling/field/5> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nd6e700a7d80742539421851d0adf1ef4 ;
+    geo:hasGeometry _:N0ebd4a0e887845cb918ff54abdaaa097 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1588,7 +1597,7 @@
 
 <http://createme.org/sampling/field/6> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N788a19723b4f45589e0c1559d1df4a1e ;
+    geo:hasGeometry _:N01614219f05a411dabd6550d8cc45cb4 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1601,7 +1610,7 @@
 
 <http://createme.org/sampling/field/7> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N137e9e5672fd4c3293a4f81d705fe505 ;
+    geo:hasGeometry _:N53fcb54f932d43fd8a414d0d6840a3db ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1614,7 +1623,7 @@
 
 <http://createme.org/sampling/field/8> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nbf34a34d027a42daad93aaf13c2aeaed ;
+    geo:hasGeometry _:N99e7d158fa6f4a489ef56061f7556c20 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1627,7 +1636,7 @@
 
 <http://createme.org/sampling/field/9> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nb4f5fcae2dd14400bad2efbb4589b876 ;
+    geo:hasGeometry _:N4d97b3a37fed47d4ace62ca45ae12128 ;
     rdfs:comment "field-sampling" ;
     time:hasTime [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1640,7 +1649,7 @@
 
 <http://createme.org/sampling/sequencing/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nd027f2462da44fe690765fdde4307dcb ;
+    geo:hasGeometry _:N4f307db471c2409c87154669f9d234b5 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "sequencing-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1652,7 +1661,7 @@
 
 <http://createme.org/sampling/sequencing/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N862fdd3f1eec47758448450875eee7fa ;
+    geo:hasGeometry _:N412c07b27e954330a54fa44c8b0ec568 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "sequencing-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1664,7 +1673,7 @@
 
 <http://createme.org/sampling/specimen/13> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nfdb32781ebe04b7bbd0929980406f10d ;
+    geo:hasGeometry _:Nb4222d8ad76648f593f29c56220eddcb ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
             rdfs:comment "Date unknown, template eventDate used as proxy" ;
@@ -1675,7 +1684,7 @@
 
 <http://createme.org/sampling/specimen/14> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:Nf41b862b4c754663ae2baa5fb460caae ;
+    geo:hasGeometry _:N1696fa5cad3c4198bd5550b2233c2761 ;
     geo:hasMetricSpatialAccuracy 2e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1687,7 +1696,7 @@
 
 <http://createme.org/sampling/specimen/15> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N71cd8888cb134da5bc7e925a5753a2d2 ;
+    geo:hasGeometry _:Nf51c0357bafb4bf9a3ac649445997e5f ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1698,7 +1707,7 @@
 
 <http://createme.org/sampling/specimen/16> a tern:Sampling ;
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
-    geo:hasGeometry _:N98a2994e7ae946988c2bc796f5cb2ed3 ;
+    geo:hasGeometry _:N75e642faac9d47b0bf5b1b53ca275636 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "specimen-sampling" ;
     time:hasTime [ a time:Instant ;
@@ -1738,6 +1747,30 @@
     void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     rdf:value "Caladenia excelsa Hopper & A.P.Br." ;
     tern:featureType <http://example.com/concept/acceptedNameUsage> .
+
+<http://createme.org/observation/scientificName/15> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    time:hasTime [ a time:Instant ;
+            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/15> ;
+    sosa:hasResult <http://createme.org/scientificName/15> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/Visually-identified-in-the-field-sighting> .
+
+<http://createme.org/observation/scientificName/16> a tern:Observation ;
+    void:inDataset <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
+    rdfs:comment "scientificName-observation" ;
+    time:hasTime [ a time:Instant ;
+            time:inXSDDateTimeStamp "2019-09-27T12:34:00+08:00"^^xsd:dateTimeStamp ] ;
+    prov:wasAssociatedWith <http://createme.org/provider/Stream-Environment-and-Water-Pty-Ltd> ;
+    sosa:hasFeatureOfInterest <http://createme.org/sample/specimen/16> ;
+    sosa:hasResult <http://createme.org/scientificName/16> ;
+    sosa:hasSimpleResult "Caladenia excelsa" ;
+    sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/70646576-6dc7-4bc5-a9d8-c4c366850df0> ;
+    sosa:usedProcedure <http://createme.org/bdr-cv/methods/identificationMethod/new-identification-method> .
 
 <http://createme.org/sample/field/1> a tern:FeatureOfInterest,
         tern:Sample ;
@@ -1915,55 +1948,15 @@
     schema:name "Stream Environment and Water Pty Ltd" .
 
 <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> a tern:Dataset ;
-    schema:dateCreated "2024-10-22"^^xsd:date ;
-    schema:dateIssued "2024-10-22"^^xsd:date ;
+    schema:dateCreated "2024-10-31"^^xsd:date ;
+    schema:dateIssued "2024-10-31"^^xsd:date ;
     schema:description "Example Incidental Occurrence Dataset by Gaia Resources" ;
     schema:name "Example Incidental Occurrence Dataset" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N0847a7d8902848efa38abc5841027d98 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/11> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N137e9e5672fd4c3293a4f81d705fe505 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/7> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Nb4f5fcae2dd14400bad2efbb4589b876 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/9> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N087f0a8c71274cebacd8db820d529eb7 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/3> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nb2c33f0f2a004c5586a6c1326c6d728b ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/16> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nd027f2462da44fe690765fdde4307dcb ;
+    rdf:object _:N4f307db471c2409c87154669f9d234b5 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/sequencing/15> ;
     rdfs:comment "supplied as" .
@@ -1971,71 +1964,47 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Ndeaf6c7868534321b412a4a29fea9948 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/14> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Nf41b862b4c754663ae2baa5fb460caae ;
+    rdf:object _:N1696fa5cad3c4198bd5550b2233c2761 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/specimen/14> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:N29c91acf846c46b698fab32a8070b6b7 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/12> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N53c13a2daa284bfa9aefc44ff7946974 ;
+    rdf:object _:N893de034299d4661bf15da9ad185b6fa ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/13> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Nbf34a34d027a42daad93aaf13c2aeaed ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/8> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N5b4e33a523684ee2bca99d2ecb0753e9 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/2> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Nfdb32781ebe04b7bbd0929980406f10d ;
+    rdf:object _:N3e9fc775acdc42fbb7f02f2de88297b3 ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/13> ;
+    rdf:subject <http://createme.org/sampling/field/11> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N917f81384ae743d28a0236fc9097e012 ;
+    rdf:object _:N2ee30852bbb64c599b9517126afbf6ab ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/15> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N71cd8888cb134da5bc7e925a5753a2d2 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/15> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N55393adb5edd4b398664d14cf22c3aed ;
+    rdf:object _:N00a12a0ee17848c9a638c3c306647077 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/4> ;
     rdfs:comment "supplied as" .
@@ -2043,23 +2012,71 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nb93fa40cae3d49f0b0e1ed763346fbf9 ;
+    rdf:object _:Nff61611b8ec24d47a910ac3391c13a43 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/1> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Nd6e700a7d80742539421851d0adf1ef4 ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
+    rdf:object _:Nb973b643150e4fda9cca00454891b0e1 ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/5> ;
+    rdf:subject <http://createme.org/sampling/field/2> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:N75e642faac9d47b0bf5b1b53ca275636 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/16> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N127c0a74b1354552b613ed3e0940b014 ;
+    rdf:object _:Nb4222d8ad76648f593f29c56220eddcb ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/13> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
+    rdf:object _:N9a31de414c384cf9b243bfd3e94da210 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/3> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N4d97b3a37fed47d4ace62ca45ae12128 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/9> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
+    rdf:object _:N99e7d158fa6f4a489ef56061f7556c20 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/8> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Nf51c0357bafb4bf9a3ac649445997e5f ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/specimen/15> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N033540d2428e485783ffc0beb5faa2fc ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/10> ;
     rdfs:comment "supplied as" .
@@ -2067,104 +2084,120 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nbd83b29515754ac1ab8bc850940b1bda ;
+    rdf:object _:N6150cc5744814fdabe6912cd4a4d68cb ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/field/12> ;
+    rdf:subject <http://createme.org/sampling/field/16> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:N53b1a661fd0b4bb59df39a009b8a44bc ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/14> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N788a19723b4f45589e0c1559d1df4a1e ;
+    rdf:object _:N53fcb54f932d43fd8a414d0d6840a3db ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/sampling/field/7> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
+    rdf:object _:N01614219f05a411dabd6550d8cc45cb4 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/field/6> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N98a2994e7ae946988c2bc796f5cb2ed3 ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
+    rdf:object _:N0ebd4a0e887845cb918ff54abdaaa097 ;
     rdf:predicate geo:hasGeometry ;
-    rdf:subject <http://createme.org/sampling/specimen/16> ;
+    rdf:subject <http://createme.org/sampling/field/5> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N862fdd3f1eec47758448450875eee7fa ;
+    rdf:object _:N412c07b27e954330a54fa44c8b0ec568 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/sampling/sequencing/16> ;
     rdfs:comment "supplied as" .
 
-_:N0847a7d8902848efa38abc5841027d98 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
-
-_:N087f0a8c71274cebacd8db820d529eb7 a geo:Geometry ;
+_:N00a12a0ee17848c9a638c3c306647077 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:N127c0a74b1354552b613ed3e0940b014 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
-
-_:N137e9e5672fd4c3293a4f81d705fe505 a geo:Geometry ;
+_:N01614219f05a411dabd6550d8cc45cb4 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N53c13a2daa284bfa9aefc44ff7946974 a geo:Geometry ;
+_:N033540d2428e485783ffc0beb5faa2fc a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N55393adb5edd4b398664d14cf22c3aed a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
-
-_:N5b4e33a523684ee2bca99d2ecb0753e9 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
-
-_:N71cd8888cb134da5bc7e925a5753a2d2 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:N788a19723b4f45589e0c1559d1df4a1e a geo:Geometry ;
+_:N0ebd4a0e887845cb918ff54abdaaa097 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N862fdd3f1eec47758448450875eee7fa a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:N917f81384ae743d28a0236fc9097e012 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:N98a2994e7ae946988c2bc796f5cb2ed3 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:Nb2c33f0f2a004c5586a6c1326c6d728b a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:Nb4f5fcae2dd14400bad2efbb4589b876 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
-
-_:Nb93fa40cae3d49f0b0e1ed763346fbf9 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:Nbd83b29515754ac1ab8bc850940b1bda a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
-
-_:Nbf34a34d027a42daad93aaf13c2aeaed a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
-
-_:Nd027f2462da44fe690765fdde4307dcb a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:Nd6e700a7d80742539421851d0adf1ef4 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
-
-_:Ndeaf6c7868534321b412a4a29fea9948 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
-
-_:Nf41b862b4c754663ae2baa5fb460caae a geo:Geometry ;
+_:N1696fa5cad3c4198bd5550b2233c2761 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:Nfdb32781ebe04b7bbd0929980406f10d a geo:Geometry ;
+_:N29c91acf846c46b698fab32a8070b6b7 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+
+_:N2ee30852bbb64c599b9517126afbf6ab a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+
+_:N3e9fc775acdc42fbb7f02f2de88297b3 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
+
+_:N412c07b27e954330a54fa44c8b0ec568 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:N4d97b3a37fed47d4ace62ca45ae12128 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
+
+_:N4f307db471c2409c87154669f9d234b5 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:N53b1a661fd0b4bb59df39a009b8a44bc a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
+
+_:N53fcb54f932d43fd8a414d0d6840a3db a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
+
+_:N6150cc5744814fdabe6912cd4a4d68cb a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+
+_:N75e642faac9d47b0bf5b1b53ca275636 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:N893de034299d4661bf15da9ad185b6fa a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
+
+_:N99e7d158fa6f4a489ef56061f7556c20 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
+
+_:N9a31de414c384cf9b243bfd3e94da210 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
+
+_:Nb4222d8ad76648f593f29c56220eddcb a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:Nb973b643150e4fda9cca00454891b0e1 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
+
+_:Nf51c0357bafb4bf9a3ac649445997e5f a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:Nff61611b8ec24d47a910ac3391c13a43 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -275,12 +275,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         text_verbatim_id = utils.rdf.uri(f"verbatimID/{row_num}", base_iri)
         observation_scientific_name = utils.rdf.uri(f"observation/scientificName/{row_num}", base_iri)
         observation_verbatim_id = utils.rdf.uri(f"observation/verbatimID/{row_num}", base_iri)
-        id_qualifier_attribute = utils.rdf.uri(f"attribute/identificationQualifier/{row_num}", base_iri)
-        id_qualifier_value = utils.rdf.uri(f"value/identificationQualifier/{row_num}", base_iri)
-        id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{row_num}", base_iri)
-        id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{row_num}", base_iri)
-        taxon_rank_attribute = utils.rdf.uri(f"attribute/taxonRank/{row_num}", base_iri)
-        taxon_rank_value = utils.rdf.uri(f"value/taxonRank/{row_num}", base_iri)
         individual_count_observation = utils.rdf.uri(f"observation/individualCount/{row_num}", base_iri)
         individual_count_value = utils.rdf.uri(f"value/individualCount/{row_num}", base_iri)
         organism_remarks_observation = utils.rdf.uri(f"observation/organismRemarks/{row_num}", base_iri)
@@ -301,8 +295,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         sample_sequence = utils.rdf.uri(f"sample/sequence/{row_num}", base_iri)
         threat_status_observation = utils.rdf.uri(f"observation/threatStatus/{row_num}", base_iri)
         threat_status_value = utils.rdf.uri(f"value/threatStatus/{row_num}", base_iri)
-        conservation_authority_attribute = utils.rdf.uri(f"attribute/conservationAuthority/{row_num}", base_iri)
-        conservation_authority_value = utils.rdf.uri(f"value/conservationAuthority/{row_num}", base_iri)
         sensitivity_category_attribute = utils.rdf.uri(f"attribute/sensitivityCategory/{row_num}", base_iri)
         sensitivity_category_value = utils.rdf.uri(f"value/sensitivityCategory/{row_num}", base_iri)
         provider_determined_by = utils.rdf.uri(f"provider/{row['threatStatusDeterminedBy']}", base_iri)
@@ -402,6 +394,60 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             preparations_attribute = None
             preparations_value = None
             preparations_sample_collection = None
+
+        # Conditionally create IRIs for the identificationQualifier field
+        id_qualifier: str | None = row["identificationQualifier"]
+        if id_qualifier:
+            id_qualifier_attribute = utils.rdf.uri(f"attribute/identificationQualifier/{id_qualifier}", base_iri)
+            id_qualifier_value = utils.rdf.uri(f"value/identificationQualifier/{id_qualifier}", base_iri)
+            id_qualifier_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "identificationQualifier", id_qualifier
+            )
+        else:
+            id_qualifier_attribute = None
+            id_qualifier_value = None
+            id_qualifier_collection = None
+
+        # Conditionally create IRIs for the identificationRemarks field
+        id_remarks: str | None = row["identificationRemarks"]
+        if id_remarks:
+            id_remarks_attribute = utils.rdf.uri(f"attribute/identificationRemarks/{id_remarks}", base_iri)
+            id_remarks_value = utils.rdf.uri(f"value/identificationRemarks/{id_remarks}", base_iri)
+            id_remarks_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "identificationRemarks", id_remarks
+            )
+        else:
+            id_remarks_attribute = None
+            id_remarks_value = None
+            id_remarks_collection = None
+
+        # Conditionally create IRIs for the taxonRank field
+        taxon_rank: str | None = row["taxonRank"]
+        if taxon_rank:
+            taxon_rank_attribute = utils.rdf.uri(f"attribute/taxonRank/{taxon_rank}", base_iri)
+            taxon_rank_value = utils.rdf.uri(f"value/taxonRank/{taxon_rank}", base_iri)
+            taxon_rank_collection = utils.rdf.extend_uri(dataset, "OccurrenceCollection", "taxonRank", taxon_rank)
+        else:
+            taxon_rank_attribute = None
+            taxon_rank_value = None
+            taxon_rank_collection = None
+
+        # Conditionally create IRIs for the conservationAuthority field
+        conservation_authority: str | None = row["conservationAuthority"]
+        if conservation_authority:
+            conservation_authority_attribute = utils.rdf.uri(
+                f"attribute/conservationAuthority/{conservation_authority}", base_iri
+            )
+            conservation_authority_value = utils.rdf.uri(
+                f"value/conservationAuthority/{conservation_authority}", base_iri
+            )
+            conservation_authority_collection = utils.rdf.extend_uri(
+                dataset, "OccurrenceCollection", "conservationAuthority", preparations
+            )
+        else:
+            conservation_authority_attribute = None
+            conservation_authority_value = None
+            conservation_authority_collection = None
 
         # Add Provider Identified By
         self.add_provider_identified(
@@ -558,16 +604,26 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Identification Qualifier Attribute
         self.add_id_qualifier_attribute(
             uri=id_qualifier_attribute,
-            row=row,
-            dataset=dataset,
+            id_qualifier=id_qualifier,
             id_qualifier_value=id_qualifier_value,
+            dataset=dataset,
             graph=graph,
         )
 
         # Add Identification Qualifier Value
         self.add_id_qualifier_value(
             uri=id_qualifier_value,
-            row=row,
+            id_qualifier=id_qualifier,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add Identification Qualifier Collection
+        self.add_id_qualifier_collection(
+            uri=id_qualifier_collection,
+            id_qualifier=id_qualifier,
+            id_qualifier_attribute=id_qualifier_attribute,
+            observation_scientific_name=observation_scientific_name,
             dataset=dataset,
             graph=graph,
         )
@@ -575,16 +631,26 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Identification Remarks Attribute
         self.add_id_remarks_attribute(
             uri=id_remarks_attribute,
-            row=row,
-            dataset=dataset,
+            id_remarks=id_remarks,
             id_remarks_value=id_remarks_value,
+            dataset=dataset,
             graph=graph,
         )
 
         # Add Identification Remarks Value
         self.add_id_remarks_value(
             uri=id_remarks_value,
-            row=row,
+            id_remarks=id_remarks,
+            graph=graph,
+        )
+
+        # Add identification Remarks collection
+        self.add_id_remarks_collection(
+            uri=id_remarks_collection,
+            id_remarks=id_remarks,
+            id_remarks_attribute=id_remarks_attribute,
+            observation_scientific_name=observation_scientific_name,
+            dataset=dataset,
             graph=graph,
         )
 
@@ -604,9 +670,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             sample_field=sample_field,
             sample_specimen=sample_specimen,
             scientific_name=text_scientific_name,
-            qualifier=id_qualifier_attribute,
-            remarks=id_remarks_attribute,
-            taxon_rank=taxon_rank_attribute,
             graph=graph,
         )
 
@@ -651,7 +714,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Taxon Rank Attribute
         self.add_taxon_rank_attribute(
             uri=taxon_rank_attribute,
-            row=row,
+            taxon_rank=taxon_rank,
             dataset=dataset,
             taxon_rank_value=taxon_rank_value,
             graph=graph,
@@ -660,7 +723,17 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Taxon Rank Value
         self.add_taxon_rank_value(
             uri=taxon_rank_value,
-            row=row,
+            taxon_rank=taxon_rank,
+            dataset=dataset,
+            graph=graph,
+        )
+
+        # Add Taxon Rank collection
+        self.add_taxon_rank_collection(
+            uri=taxon_rank_collection,
+            taxon_rank=taxon_rank,
+            taxon_rank_attribute=taxon_rank_attribute,
+            observation_scientific_name=observation_scientific_name,
             dataset=dataset,
             graph=graph,
         )
@@ -942,7 +1015,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             accepted_name_usage=accepted_name_usage_value,
             scientific_name=text_scientific_name,
             threat_status_value=threat_status_value,
-            authority_attribute=conservation_authority_attribute,
             determined_by=provider_determined_by,
             graph=graph,
         )
@@ -958,16 +1030,26 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Add Conservation Authority Attribute
         self.add_conservation_authority_attribute(
             uri=conservation_authority_attribute,
-            row=row,
-            dataset=dataset,
+            conservation_authority=conservation_authority,
             conservation_authority_value=conservation_authority_value,
+            dataset=dataset,
             graph=graph,
         )
 
         # Add Conservation Authority Value
         self.add_conservation_authority_value(
             uri=conservation_authority_value,
-            row=row,
+            conservation_authority=conservation_authority,
+            graph=graph,
+        )
+
+        # Add conservation Authority Collection
+        self.add_conservation_authority_collection(
+            uri=conservation_authority_collection,
+            conservation_authority=conservation_authority,
+            conservation_authority_attribute=conservation_authority_attribute,
+            threat_status_observation=threat_status_observation,
+            dataset=dataset,
             graph=graph,
         )
 
@@ -1052,9 +1134,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         sample_field: rdflib.URIRef,
         sample_specimen: rdflib.URIRef,
         scientific_name: rdflib.URIRef,
-        qualifier: rdflib.URIRef,
-        remarks: rdflib.URIRef,
-        taxon_rank: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Observation Scientific Name to the Graph
@@ -1069,12 +1148,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             sample_specimen (rdflib.URIRef): Sample Specimen associated with
                 this node
             scientific_name (rdflib.URIRef): Scientific Name associated with
-                this node
-            qualifier (rdflib.URIRef): Identification Qualifier attribute
-                associated with this node
-            remarks (rdflib.URIRef): Identification Remarks attribute
-                associated with this node
-            taxon_rank (rdflib.URIRef): Taxon Rank attribute associated with
                 this node
             graph (rdflib.Graph): Graph to add to
         """
@@ -1115,18 +1188,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Add comment to temporal entity
             comment = "Date unknown, template eventDate used as proxy"
             graph.add((temporal_entity, rdflib.RDFS.comment, rdflib.Literal(comment)))
-
-        # Check for identificationQualifier
-        if row["identificationQualifier"]:
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, qualifier))
-
-        # Check for identificationRemarks
-        if row["identificationRemarks"]:
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, remarks))
-
-        # Check for taxonRank
-        if row["taxonRank"]:
-            graph.add((uri, utils.namespaces.TERN.hasAttribute, taxon_rank))
 
     def add_observation_verbatim_id(
         self,
@@ -1417,114 +1478,206 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_id_qualifier_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        id_qualifier: str | None,
+        id_qualifier_value: rdflib.URIRef | None,
         dataset: rdflib.URIRef,
-        id_qualifier_value: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identification Qualifier Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
+            uri: URI to use for this node.
+            id_qualifier: identificationQualifier value from the template
+            id_qualifier_value: Identification Qualifier Value associated with this node.
             dataset (rdflib.URIRef): Dataset this belongs to
-            id_qualifier_value (rdflib.URIRef): Identification Qualifier Value
-                associated with this node.
             graph (rdflib.Graph): Graph to add to
         """
         # Check identificationQualifier
-        if not row["identificationQualifier"]:
+        if uri is None:
             return
 
         # Identification Qualifier Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_ID_UNCERTAINTY))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["identificationQualifier"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, id_qualifier_value))
+        if id_qualifier:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(id_qualifier)))
+        if id_qualifier_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, id_qualifier_value))
 
     def add_id_qualifier_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        id_qualifier: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identification Qualifier Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
+            uri: URI to use for this node.
+            id_qualifier: identificationQualifier value from the template
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
         """
-        # Check identificationQualifier
-        if not row["identificationQualifier"]:
+        # Check node should be created
+        if uri is None:
             return
 
-        # Retrieve vocab for field
-        vocab = self.fields()["identificationQualifier"].get_vocab()
-
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["identificationQualifier"])
-
-        # Identification Qualifier Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal("identificationQualifier")))
-        graph.add((uri, rdflib.RDF.value, term))
+
+        if id_qualifier:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(id_qualifier)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["identificationQualifier"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(id_qualifier)
+            # Identification Qualifier Value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_id_qualifier_collection(
+        self,
+        *,
+        uri: rdflib.URIRef | None,
+        id_qualifier: str | None,
+        id_qualifier_attribute: rdflib.URIRef | None,
+        observation_scientific_name: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a identification qualifier Collection to the graph
+
+        Args:
+            uri: The uri for the Collection.
+            id_qualifier: identificationQualifier value from template.
+            id_qualifier_attribute: The uri for the attribute node.
+            observation_scientific_name: The node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, rdflib.SDO.Collection))
+        # Add identifier
+        if id_qualifier:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Identification Qualifier - {id_qualifier}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the scientific name observation node
+        graph.add((uri, rdflib.SDO.member, observation_scientific_name))
+        # Add link to attribute
+        if id_qualifier_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, id_qualifier_attribute))
 
     def add_id_remarks_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        id_remarks: str | None,
+        id_remarks_value: rdflib.URIRef | None,
         dataset: rdflib.URIRef,
-        id_remarks_value: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identification Remarks Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
+            uri: URI to use for this node.
+            id_remarks: identificationRemarks value from the template
+            id_remarks_value: Identification Remarks Value associated with this node
             dataset (rdflib.URIRef): Dataset this belongs to
-            id_remarks_value (rdflib.URIRef): Identification Remarks Value
-                associated with this node
             graph (rdflib.Graph): Graph to add to
         """
         # Check identificationRemarks
-        if not row["identificationRemarks"]:
+        if uri is None:
             return
 
         # Identification Remarks Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_ID_REMARKS))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["identificationRemarks"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, id_remarks_value))
+        if id_remarks:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(id_remarks)))
+        if id_remarks_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, id_remarks_value))
 
     def add_id_remarks_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        id_remarks: str | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identification Remarks Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
+            uri: URI to use for this node
+            id_remarks: identificationRemarks value from the template
             graph (rdflib.Graph): Graph to add to
         """
         # Check identificationRemarks
-        if not row["identificationRemarks"]:
+        if uri is None:
             return
 
         # Identification Remarks Value
         graph.add((uri, a, utils.namespaces.TERN.Text))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDF.value, rdflib.Literal(row["identificationRemarks"])))
+        graph.add((uri, rdflib.RDF.value, rdflib.Literal(id_remarks)))
+
+    def add_id_remarks_collection(
+        self,
+        *,
+        uri: rdflib.URIRef | None,
+        id_remarks: str | None,
+        id_remarks_attribute: rdflib.URIRef | None,
+        observation_scientific_name: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a identification remarks Collection to the graph
+
+        Args:
+            uri: The uri for the Collection.
+            id_remarks: identificationRemarks value from template
+            id_remarks_attribute: The uri for the attribute node.
+            observation_scientific_name: The node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, rdflib.SDO.Collection))
+        # Add identifier
+        if id_remarks:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Identification Remarks - {id_remarks}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the scientific name observation node
+        graph.add((uri, rdflib.SDO.member, observation_scientific_name))
+        # Add link to attribute
+        if id_remarks_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, id_remarks_attribute))
 
     def add_text_scientific_name(
         self,
@@ -2001,62 +2154,110 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_taxon_rank_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        taxon_rank: str | None,
+        taxon_rank_value: rdflib.URIRef | None,
         dataset: rdflib.URIRef,
-        taxon_rank_value: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Taxon Rank Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
+            uri: URI to use for this node.
+            taxon_rank: taxonRank value from the template.
+            taxon_rank_value: Taxon Rank Value associated with this node
             dataset (rdflib.URIRef): Dataset this belongs to
-            taxon_rank_value (rdflib.URIRef): Taxon Rank Value associated with
-                this node
             graph (rdflib.Graph): Graph to add to
         """
         # Check Existence
-        if not row["taxonRank"]:
+        if uri is None:
             return
 
         # Taxon Rank Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_TAXON_RANK))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["taxonRank"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, taxon_rank_value))
+        if taxon_rank:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(taxon_rank)))
+        if taxon_rank_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, taxon_rank_value))
 
     def add_taxon_rank_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        taxon_rank: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Taxon Rank Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
+            uri: URI to use for this node
+            taxon_rank: taxonRank value from the template.
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
         """
         # Check Existence
-        if not row["taxonRank"]:
+        if uri is None:
             return
-        # Retrieve vocab for field
-        vocab = self.fields()["taxonRank"].get_vocab()
 
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["taxonRank"])
-
-        # Taxon Rank Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal(f"taxon rank = {row['taxonRank']}")))
-        graph.add((uri, rdflib.RDF.value, term))
+
+        if taxon_rank:
+            # Add label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(taxon_rank)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["taxonRank"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph, source=dataset).get(taxon_rank)
+            # Taxon Rank Value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_taxon_rank_collection(
+        self,
+        *,
+        uri: rdflib.URIRef | None,
+        taxon_rank: str | None,
+        taxon_rank_attribute: rdflib.URIRef | None,
+        observation_scientific_name: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a taxon rank Collection to the graph
+
+        Args:
+            uri: The uri for the Collection.
+            taxon_rank: taxonRank value from template.
+            taxon_rank_attribute: The uri for the attribute node.
+            observation_scientific_name: The node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, rdflib.SDO.Collection))
+        # Add identifier
+        if taxon_rank:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Taxon Rank - {taxon_rank}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the scientific name observation node
+        graph.add((uri, rdflib.SDO.member, observation_scientific_name))
+        # Add link to attribute
+        if taxon_rank_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, taxon_rank_attribute))
 
     def add_individual_count_observation(
         self,
@@ -3229,7 +3430,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         accepted_name_usage: rdflib.URIRef,
         scientific_name: rdflib.URIRef,
         threat_status_value: rdflib.URIRef,
-        authority_attribute: rdflib.URIRef,
         determined_by: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
@@ -3245,8 +3445,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                 this node
             threat_status_value (rdflib.URIRef): Threat Status Value associated
                 with this node
-            authority_attribute (rdflib.URIRef): Conservation Authority
-                Attribute associated with this node
             determined_by (rdflib.URIRef): Determined By Provider associated
                 with this node
             graph (rdflib.Graph): Graph to add to
@@ -3280,7 +3478,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         graph.add((uri, rdflib.SOSA.hasResult, threat_status_value))
         graph.add((uri, rdflib.SOSA.hasSimpleResult, rdflib.Literal(row["threatStatus"])))
         graph.add((uri, rdflib.SOSA.observedProperty, CONCEPT_CONSERVATION_STATUS))
-        graph.add((uri, rdflib.PROV.wasInfluencedBy, authority_attribute))
         graph.add((uri, rdflib.SOSA.usedProcedure, term))
         temporal_entity = rdflib.BNode()
         graph.add((uri, rdflib.TIME.hasTime, temporal_entity))
@@ -3339,64 +3536,108 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_conservation_authority_attribute(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        conservation_authority: str | None,
+        conservation_authority_value: rdflib.URIRef | None,
         dataset: rdflib.URIRef,
-        conservation_authority_value: rdflib.URIRef,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Conservation Authority Attribute to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            row (frictionless.Row): Row to retrieve data from
-            dataset (rdflib.URIRef): Dataset this belongs to
-            conservation_authority_value (rdflib.URIRef): Conservation
-                Authority Value associated with this node
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node.
+            conservation_authority: conservationAuthority value from the CSV
+            conservation_authority_value: Conservation Authority Value associated with this node
+            dataset: Dataset this belongs to
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["conservationAuthority"]:
+        if uri is None:
             return
 
         # Conservation Authority Attribute
         graph.add((uri, a, utils.namespaces.TERN.Attribute))
         graph.add((uri, rdflib.VOID.inDataset, dataset))
         graph.add((uri, utils.namespaces.TERN.attribute, CONCEPT_CONSERVATION_AUTHORITY))
-        graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(row["conservationAuthority"])))
-        graph.add((uri, utils.namespaces.TERN.hasValue, conservation_authority_value))
+        if conservation_authority:
+            graph.add((uri, utils.namespaces.TERN.hasSimpleValue, rdflib.Literal(conservation_authority)))
+        if conservation_authority_value:
+            graph.add((uri, utils.namespaces.TERN.hasValue, conservation_authority_value))
 
     def add_conservation_authority_value(
         self,
-        uri: rdflib.URIRef,
-        row: frictionless.Row,
+        *,
+        uri: rdflib.URIRef | None,
+        conservation_authority: str | None,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Conservation Authority Value to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node
-            row (frictionless.Row): Row to retrieve data from
-            graph (rdflib.Graph): Graph to add to
+            uri: URI to use for this node
+            conservation_authority: conservationAuthority value from the CSV
+            graph: Graph to add to
         """
         # Check Existence
-        if not row["conservationAuthority"]:
+        if uri is None:
             return
 
-        # Retrieve vocab for field
-        vocab = self.fields()["conservationAuthority"].get_vocab()
-
-        # Retrieve term or Create on the Fly
-        term = vocab(graph=graph).get(row["conservationAuthority"])
-
-        # Construct Label
-        label = f"Conservation Authority = {row['conservationAuthority']}"
-
-        # Conservation Authority Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
         graph.add((uri, a, utils.namespaces.TERN.Value))
-        graph.add((uri, rdflib.RDFS.label, rdflib.Literal(label)))
-        graph.add((uri, rdflib.RDF.value, term))
+
+        if conservation_authority:
+            # Construct Label
+            graph.add((uri, rdflib.RDFS.label, rdflib.Literal(conservation_authority)))
+
+            # Retrieve vocab for field
+            vocab = self.fields()["conservationAuthority"].get_vocab()
+            # Retrieve term or Create on the Fly
+            term = vocab(graph=graph).get(conservation_authority)
+            # Conservation Authority Value
+            graph.add((uri, rdflib.RDF.value, term))
+
+    def add_conservation_authority_collection(
+        self,
+        *,
+        uri: rdflib.URIRef | None,
+        conservation_authority: str | None,
+        conservation_authority_attribute: rdflib.URIRef | None,
+        threat_status_observation: rdflib.URIRef,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+    ) -> None:
+        """Add a conservation authority Collection to the graph
+
+        Args:
+            uri: The uri for the SampleCollection.
+            conservation_authority: conservationAuthority value from template.
+            conservation_authority_attribute: The uri for the attribute node.
+            threat_status_observation: The node that should be a member of the collection.
+            dataset: The uri for the dateset node.
+            graph: The graph.
+        """
+        if uri is None:
+            return
+
+        # Add type
+        graph.add((uri, a, rdflib.SDO.Collection))
+        # Add identifier
+        if conservation_authority:
+            graph.add(
+                (
+                    uri,
+                    rdflib.SDO.identifier,
+                    rdflib.Literal(f"Occurrence Collection - Conservation Authority - {conservation_authority}"),
+                )
+            )
+        # Add link to dataset
+        graph.add((uri, rdflib.VOID.inDataset, dataset))
+        # add link to the threat status observation node
+        graph.add((uri, rdflib.SDO.member, threat_status_observation))
+        # Add link to attribute
+        if conservation_authority_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, conservation_authority_attribute))
 
     def add_sensitivity_category_attribute(
         self,


### PR DESCRIPTION
Adds attribute collections for remaining attributes in the incidental v3 template:
* conservationAuthority
* identificationQualifier
* identificationRemarks
* taxonRank

These attributes are no longer linked directly to the scientific name tern:Observation and threat status tern:Observation nodes.
Instead those nodes are now members of the collections.
