### PR TITLE
BDRSPS-951 Updated the mapping for attributes for the plan node of the metadata template.

### DIFF
--- a/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
@@ -75,30 +75,6 @@
     skos:prefLabel "Insecta" ;
     schema:citation "http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset"^^xsd:anyURI .
 
-<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/surveyType/Wet-pitfall-trapping> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
-    tern:attribute <http://example.com/concept/surveyType> ;
-    tern:hasSimpleValue "Wet pitfall trapping" ;
-    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/surveyType/Wet-pitfall-trapping> .
-
-<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetHabitatScope/Woodland> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
-    tern:attribute <https://linked.data.gov.au/def/nrm/ae2c88be-63d5-44d3-95ac-54b14c4a4b28> ;
-    tern:hasSimpleValue "Woodland" ;
-    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/targetHabitatScope/Woodland> .
-
-<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetTaxonomicScope/Coleoptera> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
-    tern:attribute <https://linked.data.gov.au/def/nrm/7ea12fed-6b87-4c20-9ab4-600b32ce15ec> ;
-    tern:hasSimpleValue "Coleoptera" ;
-    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/targetTaxonomicScope/Coleoptera> .
-
-<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetTaxonomicScope/Insecta> a tern:Attribute ;
-    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
-    tern:attribute <https://linked.data.gov.au/def/nrm/7ea12fed-6b87-4c20-9ab4-600b32ce15ec> ;
-    tern:hasSimpleValue "Insecta" ;
-    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/targetTaxonomicScope/Insecta> .
-
 <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/surveyType/Wet-pitfall-trapping> a tern:IRI,
         tern:Value ;
     rdfs:label "Wet pitfall trapping" ;
@@ -124,9 +100,10 @@
     schema:description "Our experimental design consisted of four 400 m transects running from inside each woodland patch out into four adjoining farmland uses (crop, rested, woody debris application, revegetation plantings). To quantify potential edge efects on beetle species traits, we sampled beetles at five locations along each transect: 200 and 20 m inside woodlands, 200 and 20 m inside farmlands, and at the woodland–farmland edge (0 m). Each sampling location comprised a pair of wet invertebrate pitfall traps.  separated by a drift fence (60 cm long x 10 cm high) to help direct arthropods into traps. We opened a total of 220 pairs of traps for 14 days during spring (Oct–Nov 2014), and repeated sampling during summer (January–February 2015). Beetle samples from each pitfall trap pair, and across the two time periods, were pooled to provide one sample per sampling location." ;
     schema:url "https://biocollect.ala.org.au/document/download/2022-01/202201%20CBR%20Flora%20and%20Vegetation%20report_draftv1.pdf"^^xsd:anyURI,
         "https://doi.org/10.1002/9781118945568.ch11"^^xsd:anyURI ;
-    tern:hasAttribute <http://createme.org/attribute/surveyType>,
-        <http://createme.org/attribute/targetHabitatScope>,
-        <http://createme.org/attribute/targetTaxa> .
+    tern:hasAttribute <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/surveyType/Wet-pitfall-trapping>,
+        <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetHabitatScope/Woodland>,
+        <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetTaxonomicScope/Coleoptera>,
+        <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetTaxonomicScope/Insecta> .
 
 <http://createme.org/survey/procedure/surveyMethod/1> a prov:Plan ;
     schema:citation "Ng, K., Barton, P.S., Blanchard, W. et al. Disentangling the effects of farmland use, habitat edges, and vegetation structure on ground beetle morphological traits. Oecologia 188, 645–657 (2018). https://doi.org/10.1007/s00442-018-4180-9\"" ;
@@ -134,11 +111,35 @@
     schema:url "https://biocollect.ala.org.au/document/download/2022-01/202201%20CBR%20Flora%20and%20Vegetation%20report_draftv1.pdf"^^xsd:anyURI,
         "https://doi.org/10.1002/9781118945568.ch11"^^xsd:anyURI .
 
+<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/surveyType/Wet-pitfall-trapping> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
+    tern:attribute <http://example.com/concept/surveyType> ;
+    tern:hasSimpleValue "Wet pitfall trapping" ;
+    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/surveyType/Wet-pitfall-trapping> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetHabitatScope/Woodland> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
+    tern:attribute <https://linked.data.gov.au/def/nrm/ae2c88be-63d5-44d3-95ac-54b14c4a4b28> ;
+    tern:hasSimpleValue "Woodland" ;
+    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/targetHabitatScope/Woodland> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetTaxonomicScope/Coleoptera> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
+    tern:attribute <https://linked.data.gov.au/def/nrm/7ea12fed-6b87-4c20-9ab4-600b32ce15ec> ;
+    tern:hasSimpleValue "Coleoptera" ;
+    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/targetTaxonomicScope/Coleoptera> .
+
+<http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/attribute/targetTaxonomicScope/Insecta> a tern:Attribute ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
+    tern:attribute <https://linked.data.gov.au/def/nrm/7ea12fed-6b87-4c20-9ab4-600b32ce15ec> ;
+    tern:hasSimpleValue "Insecta" ;
+    tern:hasValue <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset/value/targetTaxonomicScope/Insecta> .
+
 <http://createme.org/survey/SSD-Survey/1> a tern:Survey ;
     bdr:purpose "Summer sampling for peak insect diversity." ;
     bdr:target "Coleoptera",
         "Insecta" ;
-    geo:hasGeometry _:N3ef3a82dbea244cc8b716f7bfb8328af ;
+    geo:hasGeometry _:N0a0dab4ad2544ed3845f0717a9e1a09c ;
     time:hasTime [ a time:TemporalEntity ;
             time:hasBeginning [ a time:Instant ;
                     time:inXSDDate "2015-01-21"^^xsd:date ] ;
@@ -159,19 +160,19 @@
     schema:name "Disentangling the effects of farmland use, habitat edges, and vegetation structure on ground beetle morphological traits - Summer" .
 
 <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> a tern:Dataset ;
-    schema:dateCreated "2024-10-10"^^xsd:date ;
-    schema:dateIssued "2024-10-10"^^xsd:date ;
+    schema:dateCreated "2024-10-31"^^xsd:date ;
+    schema:dateIssued "2024-10-31"^^xsd:date ;
     schema:description "Example Systematic Survey Metadata Dataset by Gaia Resources" ;
     schema:name "Example Systematic Survey Metadata Dataset" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.826 146.363, -33.826 148.499, -34.411 148.499, -33.826 146.363))"^^geo:wktLiteral ] ;
-    rdf:object _:N3ef3a82dbea244cc8b716f7bfb8328af ;
+    rdf:object _:N0a0dab4ad2544ed3845f0717a9e1a09c ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <http://createme.org/survey/SSD-Survey/1> ;
     rdfs:comment "supplied as" .
 
-_:N3ef3a82dbea244cc8b716f7bfb8328af a geo:Geometry ;
+_:N0a0dab4ad2544ed3845f0717a9e1a09c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.826 146.363, -33.826 148.499, -34.411 148.499, -33.826 146.363))"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -692,7 +692,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
         Args:
             uri: Plan reference.
-            survey_type_attribute: SurveyType attribute for the node 
+            survey_type_attribute: SurveyType attribute for the node
             target_habitat_scope_attribute: targetHabitatScope attribute for the node.
             target_taxa_attribute: target taxa attribute for the node.
             row: Raw data row.

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -249,10 +249,8 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
                 survey_org_objects.append(
                     SurveyIDDatatype(
                         name=raw_org,
-                        datatype=utils.rdf.uri(
-                            internal_id=f"datatype/surveyID/{raw_org}", namespace=utils.namespaces.CREATEME
-                        ),
-                        agent=utils.rdf.uri(internal_id=f"agent/{raw_org}"),
+                        datatype=utils.rdf.uri(f"datatype/surveyID/{raw_org}", base_iri),
+                        agent=utils.rdf.uri(f"agent/{raw_org}"),
                     )
                 )
 
@@ -314,6 +312,9 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         # Add plan
         self.add_plan(
             uri=survey_plan,
+            survey_type_attribute=survey_type_attribute,
+            target_habitat_scope_attributes=(hbt.attribute for hbt in target_habitat_objects),
+            target_taxa_attributes=(tx.attribute for tx in target_taxonomic_objects),
             row=row,
             graph=graph,
         )
@@ -681,44 +682,34 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
     def add_plan(
         self,
         uri: rdflib.URIRef,
+        survey_type_attribute: rdflib.URIRef | None,
+        target_habitat_scope_attributes: Iterator[rdflib.URIRef],
+        target_taxa_attributes: Iterator[rdflib.URIRef],
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds plan to graph.
 
         Args:
-            uri (rdflib.URIRef): Plan reference.
-            row (frictionless.Row): Raw data row.
-            graph (rdflib.Graph): Graph to be modified.
+            uri: Plan reference.
+            survey_type_attribute: SurveyType attribute for the node 
+            target_habitat_scope_attribute: targetHabitatScope attribute for the node.
+            target_taxa_attribute: target taxa attribute for the node.
+            row: Raw data row.
+            graph: Graph to be modified.
         """
         # Add type
         graph.add((uri, a, rdflib.PROV.Plan))
 
         # Add attributes
-        if row["surveyType"]:
-            graph.add(
-                (
-                    uri,
-                    utils.namespaces.TERN.hasAttribute,
-                    utils.rdf.uri("attribute/surveyType", utils.namespaces.CREATEME),
-                )
-            )
-        if row["targetHabitatScope"]:
-            graph.add(
-                (
-                    uri,
-                    utils.namespaces.TERN.hasAttribute,
-                    utils.rdf.uri("attribute/targetHabitatScope", utils.namespaces.CREATEME),
-                )
-            )
-        if row["targetTaxonomicScope"]:
-            graph.add(
-                (
-                    uri,
-                    utils.namespaces.TERN.hasAttribute,
-                    utils.rdf.uri("attribute/targetTaxa", utils.namespaces.CREATEME),
-                )
-            )
+        if survey_type_attribute:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, survey_type_attribute))
+
+        for hbt_attr in target_habitat_scope_attributes:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, hbt_attr))
+
+        for tx_attr in target_taxa_attributes:
+            graph.add((uri, utils.namespaces.TERN.hasAttribute, tx_attr))
 
         # Add citation(s)
         if citations := row["surveyMethodCitation"]:


### PR DESCRIPTION
This will remove the creation of CREATEME iri from within the template's mapping methods. 
The attributes being assigned previously were incorrect and now use those IRIs created for `tern:Attribute` nodes.