### PR TITLE
BDRSPS-979 docs.tables.fields module refactored 

### DIFF
--- a/docs/tables/fields.py
+++ b/docs/tables/fields.py
@@ -137,8 +137,7 @@ class FieldTabler(tables.base.BaseTabler):
         """Getter for the table header."""
         # Get titles from model
         raw_hdr = (hdr.alias or hdr.title for hdr in FieldTableRow.model_computed_fields.values())
-        r = [hdr for hdr in raw_hdr if hdr is not None]
-        return r
+        return [hdr for hdr in raw_hdr if hdr is not None]
 
     @property
     def fields(self) -> list[types.schema.Field]:

--- a/tests/docs/tables/test_fields.py
+++ b/tests/docs/tables/test_fields.py
@@ -223,7 +223,7 @@ def test_determine_checklist() -> None:
 @pytest.mark.parametrize(
     "tabler_class, expected",
     [
-        (
+        pytest.param(
             tables.fields.FieldTabler,
             (
                 "Field Name,Description,Mandatory / Optional,Datatype Format,Examples\r\n"
@@ -233,8 +233,9 @@ def test_determine_checklist() -> None:
                 "123,Numbers,Conditionally mandatory with abc,String,Numbers EXAMPLE\r\n"
                 "threatStatus,The conservation status (or code) assigned to an organism that is recognised in conjunction with a specific authority.,Optional,String,VU\r\n\n"
             ),
+            id="FieldTabler",
         ),
-        (
+        pytest.param(
             tables.fields.OccurrenceFieldTabler,
             (
                 "Field Name,Description,Mandatory / Optional,Datatype Format,Examples\r\n"
@@ -244,9 +245,9 @@ def test_determine_checklist() -> None:
                 "123,Numbers,Conditionally mandatory with abc,String,Numbers EXAMPLE\r\n"
                 "threatStatus,The conservation status (or code) assigned to an organism that is recognised in conjunction with a specific authority.,Optional,String,VU\r\n\n"
             ),
+            id="OccurrenceFieldTabler",
         ),
     ],
-    ids=["FieldTabler", "OccurrenceFieldTabler"],
 )
 def test_generate_table(
     tabler_class: Type[tables.fields.FieldTabler],


### PR DESCRIPTION
in an attempt to reduce the amount of conditionals being used within the Tabler, made it so serialization is primarily pushed back onto the table row objects, and the table wide concerns remain. Still a fair bit messy but  hopefully improves the situation a bit. 