### PR TITLE
BDRSPS-819 Made necessary tests or changes to types code after investigating low coverage on tests.

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -166,7 +166,7 @@ class ABISMapper(abc.ABC):
         """Generates a blank csv for the template.
 
         It is based on the schema field names and writes it to a file within
-        the template mapper's root dir. Note: full schema validation is not applied,
+        the template mapper's root dir. NOTE: full schema validation is not applied,
         and metadata validation is.
         """
         # Retrieve Schema Filepath

--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -11,6 +11,7 @@ import pathlib
 # Third-Party
 import frictionless
 import rdflib
+import rdflib.term
 
 # Local
 from . import types as base_types
@@ -125,9 +126,9 @@ class ABISMapper(abc.ABC):
 
     def add_geometry_supplied_as(
         self,
-        subj: rdflib.graph.Node,
-        pred: rdflib.graph.Node,
-        obj: rdflib.graph.Node,
+        subj: rdflib.term.Node,
+        pred: rdflib.term.Node,
+        obj: rdflib.term.Node,
         geom: types.spatial.Geometry,
         graph: rdflib.Graph,
         spatial_accuracy: rdflib.Literal | None = None,
@@ -135,13 +136,13 @@ class ABISMapper(abc.ABC):
         """Add geometry supplied as originally to the graph.
 
         Args:
-            subj (rdflib.graph.Node): Subject identifying geometry use.
-            pred (rdflib.graph.Node): Predicate of where transformed
+            subj: Subject identifying geometry use.
+            pred: Predicate of where transformed
                 geometry used.
-            obj (rdflib.graph.Node): Object containing the transformed geometry.
-            geom (spatial.Geometry): Geometry object containing values.
-            graph (rdflib.Graph): Graph to be added to.
-            spatial_accuracy: Spatial accuracy of the supplied geometry.
+            obj: Object containing the transformed geometry.
+            geom: Geometry object containing values.
+            graph: Graph to be added to.
+            spatial_accuracy: Measurement tolerance of the supplied geometry.
         """
         # Create top blank node to hold statement
         top_node = rdflib.BNode()

--- a/abis_mapping/plugins/required.py
+++ b/abis_mapping/plugins/required.py
@@ -14,7 +14,7 @@ class RequiredEnhanced(frictionless.Check):
     """Checks whether specified columns are all provided in a row-wise manner.
 
     It also allows the bypassing of the constraint through the provision
-    of whitelists. Note: This check is only effective when the original
+    of whitelists. This check is only effective when the original
     schema for each field is `required = False`, otherwise the check,
     does nothing.
 

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -1401,7 +1401,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         top_node = next(temp_graph.subjects(a, rdflib.TIME.TemporalEntity))
 
         # Merge with main graph using addition assignment (modify inplace).
-        # Note: Be aware that BNode IDs are not modified or checked during this process
+        # NOTE: Be aware that BNode IDs are not modified or checked during this process
         # and there are risks of name collision during merging. If blank nodes are ever
         # assigned names manually in future, then that may impact this operation
         # Refer to https://rdflib.readthedocs.io/en/stable/merging.html for more information.

--- a/abis_mapping/types/schema.py
+++ b/abis_mapping/types/schema.py
@@ -125,12 +125,12 @@ class Field(pydantic.BaseModel):
             list[str]: The validated vocabulary ids.
 
         Raises:
-            KeyError: A provided vocabulary id does not exist.
+            ValueError: A provided vocabulary id does not exist.
         """
         # Check each provided name to see if it exists in the registry
         for name in values:
-            if utils.vocabs.get_vocab(name) is None:
-                raise ValueError(f"Vocabulary id {name} does not exist.")
+            # Will raise an error if the vocab doesn't exist
+            utils.vocabs.get_vocab(name)
 
         # Return list
         return values

--- a/abis_mapping/types/spatial.py
+++ b/abis_mapping/types/spatial.py
@@ -112,8 +112,7 @@ class Geometry:
             return vocab(graph=rdflib.Graph()).get(self.original_datum_name)
         except utils.vocabs.VocabularyError as exc:
             raise GeometryError(
-                f"CRS {self.original_datum_name} is "
-                "not defined for the GEODETIC_DATUM fixed vocabulary."
+                f"CRS {self.original_datum_name} is " "not defined for the GEODETIC_DATUM fixed vocabulary."
             ) from exc
 
     @property
@@ -142,14 +141,13 @@ class Geometry:
         # Retrieve vocab class
         vocab = utils.vocabs.get_vocab("GEODETIC_DATUM")
         default_crs = settings.Settings().DEFAULT_TARGET_CRS
-        
+
         try:
             # Init with dummy graph and return corresponding uri
             return vocab(graph=rdflib.Graph()).get(default_crs)
         except utils.vocabs.VocabularyError as exc:
             raise GeometryError(
-                f"Default CRS {default_crs} is "
-                "not defined for the GEODETIC_DATUM fixed vocabulary."
+                f"Default CRS {default_crs} is " "not defined for the GEODETIC_DATUM fixed vocabulary."
             ) from exc
 
     @classmethod
@@ -172,7 +170,7 @@ class Geometry:
         # Perform match
         match = regex.match(str(literal))
         if match is None:
-            # NOTE 11/11/2024 @jcrowleygaia: It is currently pretty impossible for a non-match to occur 
+            # NOTE 11/11/2024 @jcrowleygaia: It is currently pretty impossible for a non-match to occur
             # however it may be necessary to keep this check in case of a change to the above
             # compiled regex in the future.
             raise ValueError(f"supplied literal '{literal}' is not GeoSPARQL WKT format.")

--- a/abis_mapping/types/spatial.py
+++ b/abis_mapping/types/spatial.py
@@ -51,7 +51,9 @@ class Geometry:
 
         Args:
             raw (LatLong | str | shapely.Geometry): Input geometry
-            datum (str | None): Geodetic datum corresponding to input.
+            datum (str | None): Geodetic datum corresponding to input. Datum is assumed
+                to be a lat-long coordinate system. This class should not be used
+                for long-lat datums.
 
         Raises:
             TypeError: If unsupported type for raw supplied.
@@ -59,11 +61,8 @@ class Geometry:
         """
         # Determine type of argument supplied and process.
         if isinstance(raw, LatLong):
-            # Attempt to make shapely geometry and catch errors
-            try:
-                self._geometry: shapely.Geometry = shapely.Point(raw.longitude, raw.latitude)
-            except shapely.errors.ShapelyError as exc:
-                raise GeometryError from exc
+            # Make shapely point
+            self._geometry: shapely.Geometry = shapely.Point(raw.longitude, raw.latitude)
         elif isinstance(raw, str):
             # Attempt to make shapely geometry and catch errors
             try:
@@ -100,14 +99,22 @@ class Geometry:
         """Getter for the original datum URI.
 
         Returns:
-            rdflib.URIRef: Uri corresponding to original datum if known, else None.
+            rdflib.URIRef: Uri corresponding to original datum.
+
+        Raises:
+            GeometryError: If the original datum name is not part
+                of the GEODETIC_DATUM fixed vocab.
         """
         # Retrieve vocab class
-        if (vocab := utils.vocabs.get_vocab("GEODETIC_DATUM")) is not None:
+        vocab = utils.vocabs.get_vocab("GEODETIC_DATUM")
+        try:
             # Init with dummy graph and return corresponding URI
             return vocab(graph=rdflib.Graph()).get(self.original_datum_name)
-        else:
-            return None
+        except utils.vocabs.VocabularyError as exc:
+            raise GeometryError(
+                f"CRS {self.original_datum_name} is "
+                "not defined for the GEODETIC_DATUM fixed vocabulary."
+            ) from exc
 
     @property
     def _transformed_geometry(self) -> shapely.Geometry:
@@ -126,15 +133,24 @@ class Geometry:
         """Getter for the transformed datum URI.
 
         Returns:
-            rdflib.URIRef: Uri corresponding to transformer datum if known, else None.
+            rdflib.URIRef: Uri corresponding to transformer datum.
+
+        Raises:
+            GeometryError: If the project default CRS is not a part
+                of the GEODETIC_DATUM fixed vocab.
         """
         # Retrieve vocab class
-        if (vocab := utils.vocabs.get_vocab("GEODETIC_DATUM")) is not None:
+        vocab = utils.vocabs.get_vocab("GEODETIC_DATUM")
+        default_crs = settings.Settings().DEFAULT_TARGET_CRS
+        
+        try:
             # Init with dummy graph and return corresponding uri
-            return vocab(graph=rdflib.Graph()).get(settings.Settings().DEFAULT_TARGET_CRS)
-
-        # If vocab doesn't exist
-        return None
+            return vocab(graph=rdflib.Graph()).get(default_crs)
+        except utils.vocabs.VocabularyError as exc:
+            raise GeometryError(
+                f"Default CRS {default_crs} is "
+                "not defined for the GEODETIC_DATUM fixed vocabulary."
+            ) from exc
 
     @classmethod
     def from_geosparql_wkt_literal(cls, literal: rdflib.Literal | str) -> "Geometry":
@@ -156,6 +172,9 @@ class Geometry:
         # Perform match
         match = regex.match(str(literal))
         if match is None:
+            # NOTE 11/11/2024 @jcrowleygaia: It is currently pretty impossible for a non-match to occur 
+            # however it may be necessary to keep this check in case of a change to the above
+            # compiled regex in the future.
             raise ValueError(f"supplied literal '{literal}' is not GeoSPARQL WKT format.")
 
         # Attempt to make shapely geometry and catch errors
@@ -167,7 +186,7 @@ class Geometry:
         # Check to see if datum provided
         if datum := match.group(1):
             # Flip the coordinates from lat-long to long-lat
-            # Note: Assumption is that the datum provided is of lat-long orientation.
+            # NOTE: Assumption is that the datum provided is of lat-long orientation.
             raw = _swap_coordinates(raw)
 
         # Create and return Geometry object
@@ -186,7 +205,7 @@ class Geometry:
         datum_string = f"<{self.original_datum_uri}> " if self.original_datum_uri is not None else ""
 
         # Manipulate geometry coordinates to suit datum string as per geosparql
-        # literal requirements. Note: It is assumed all geodetic datums supplied are of
+        # literal requirements. NOTE: It is assumed all geodetic datums supplied are of
         # the lat-long orientation and not the default WKT representation of long-lat.
         geometry = _swap_coordinates(self._geometry) if datum_string else self._geometry
 
@@ -211,7 +230,7 @@ class Geometry:
         datum_string = f"<{self.transformer_datum_uri}> " if self.transformer_datum_uri is not None else ""
 
         # Manipulate geometry coordinates to suit datum string as per geosparql
-        # literal requirements. Note: It is assumed all geodetic datums supplied are of
+        # literal requirements. NOTE: It is assumed all geodetic datums supplied are of
         # the lat-long orientation and not the default WKT representation of long-lat.
         geometry = _swap_coordinates(self._transformed_geometry) if datum_string else self._transformed_geometry
 

--- a/abis_mapping/types/spatial.py
+++ b/abis_mapping/types/spatial.py
@@ -95,7 +95,7 @@ class Geometry:
         return self._crs.name.replace(" ", "")
 
     @property
-    def original_datum_uri(self) -> rdflib.URIRef | None:
+    def original_datum_uri(self) -> rdflib.URIRef:
         """Getter for the original datum URI.
 
         Returns:
@@ -128,7 +128,7 @@ class Geometry:
         )
 
     @property
-    def transformer_datum_uri(self) -> rdflib.URIRef | None:
+    def transformer_datum_uri(self) -> rdflib.URIRef:
         """Getter for the transformed datum URI.
 
         Returns:
@@ -147,7 +147,7 @@ class Geometry:
             return vocab(graph=rdflib.Graph()).get(default_crs)
         except utils.vocabs.VocabularyError as exc:
             raise GeometryError(
-                f"Default CRS {default_crs} is " "not defined for the GEODETIC_DATUM fixed vocabulary."
+                f"Default CRS {default_crs} is not defined for the GEODETIC_DATUM fixed vocabulary."
             ) from exc
 
     @classmethod
@@ -268,7 +268,7 @@ def _swap_coordinates(original: shapely.Geometry) -> shapely.Geometry:
     return txd
 
 
-class GeometryError(BaseException):
+class GeometryError(Exception):
     """Exception class for the geometry type."""
 
     pass

--- a/docs/tables/fields.py
+++ b/docs/tables/fields.py
@@ -253,7 +253,7 @@ class OccurrenceFieldTabler(FieldTabler):
         """Getter for the fields.
 
         Returns:
-            list[OccurrenceField]: List of all fields from schema. Note: this specifically
+            list[OccurrenceField]: List of all fields from schema. NOTE: this specifically
                 returns OccurrenceField object list
         """
         # Get fields from schema and return

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -54,9 +54,13 @@ class TestField:
         # Modify the field fixture to have invalid vocab
         field_d["vocabularies"] = ["AFAKEVOCAB123"]
 
-        with pytest.raises(pydantic.ValidationError):
+        with pytest.raises(pydantic.ValidationError) as exc:
             # Create field
             types.schema.Field.model_validate(field_d)
+        
+        # Should have been raised through catching a ValueError only
+        assert len(exc.value.errors()) == 1
+        assert exc.value.errors()[0]["type"] == "value_error"
 
     def test_get_vocab(self, field_d: dict[str, Any]) -> None:
         """Tests the get vocab method.

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -57,7 +57,7 @@ class TestField:
         with pytest.raises(pydantic.ValidationError) as exc:
             # Create field
             types.schema.Field.model_validate(field_d)
-        
+
         # Should have been raised through catching a ValueError only
         assert len(exc.value.errors()) == 1
         assert exc.value.errors()[0]["type"] == "value_error"

--- a/tests/types/test_spatial.py
+++ b/tests/types/test_spatial.py
@@ -6,6 +6,7 @@ import copy
 # Third-party
 import shapely
 import pytest
+import pytest_mock
 import rdflib
 
 # Local
@@ -15,7 +16,7 @@ from abis_mapping import utils
 from abis_mapping import vocabs
 
 # Typing
-from typing import Type
+from typing import Type, Callable, Iterator
 
 
 def test_geometry_init_wkt_string_valid() -> None:
@@ -107,7 +108,7 @@ def test_geometry_original_datum_uri(datum: str, uri: str) -> None:
     # Create geometry
     geometry = types.spatial.Geometry(
         raw="POINT(0 0)",
-        datum="WGS84",
+        datum=datum,
     )
 
     # Create expected output
@@ -130,6 +131,85 @@ def test_geometry_transformer_datum_uri() -> None:
     # Assert default datum
     assert vocab is not None
     assert geometry.transformer_datum_uri == vocab(graph=rdflib.Graph()).get(settings.Settings().DEFAULT_TARGET_CRS)
+
+
+@pytest.fixture
+def temp_default_crs(mocker: pytest_mock.MockerFixture) -> Iterator[Callable[[str], None]]:
+    """Provides a temporary value for Default CRS when called.
+
+    Args:
+        mocker: The mocker fixture
+
+    Yields:
+        Function to perform the change with new value as arg.
+    """
+    # Retain the original setting
+    original = settings.SETTINGS.DEFAULT_TARGET_CRS
+
+    # Define callable
+    def change_crs(value: str) -> None:
+        """Performs the change.
+
+        Args:
+            value: New default CRS name to use for the test.
+        """
+
+        # Create a stubbed settings model
+        class TempSettings(settings.Settings):
+            # Modified fields below
+            DEFAULT_TARGET_CRS: str = value
+
+        # Patch Settings
+        mocker.patch(
+            "abis_mapping.settings.Settings",
+            new=TempSettings,
+        )
+
+        # Change assigned variable
+        settings.SETTINGS.DEFAULT_TARGET_CRS = value
+
+    # Yield
+    yield change_crs
+
+    # Change setting back to original
+    settings.SETTINGS.DEFAULT_TARGET_CRS = original
+
+
+def test_geometry_transformer_datum_uri_invalid(temp_default_crs: Callable[[str], None]) -> None:
+    """Tests the transformer_datum_uri with unrecognised default crs.
+
+    Args:
+        temp_default_crs: Callable fixture allowing setting of the project's
+            default crs temporarily
+    """
+    # Create geometry
+    geometry = types.spatial.Geometry(
+        raw="POINT(0 0)",
+        datum="OSGB36",
+    )
+
+    # Set temp default crs
+    temp_default_crs("NOTADATUM")
+
+    # Should raise exception on invalid CRS not in fixed datum vocabulary
+    with pytest.raises(types.spatial.GeometryError, match=r"NOTADATUM .+ GEODETIC_DATUM") as exc:
+        _ = geometry.transformer_datum_uri
+    
+    # Should have been raised from VocabularyError
+    assert exc.value.__cause__.__class__ is utils.vocabs.VocabularyError
+
+
+def test_geometry_original_datum_uri_invalid() -> None:
+    """Tests the transformer_datum_uri with unrecognised default crs."""
+    # Create geometry
+    geometry = types.spatial.Geometry(
+        raw="POINT(0 0)",
+        datum="OSGB36",
+    )
+
+    # Should raise exception on invalid CRS not in fixed datum vocabulary
+    with pytest.raises(types.spatial.GeometryError, match=r"OSGB36 .+ GEODETIC_DATUM"):
+        _ = geometry.original_datum_uri
 
 
 @pytest.mark.parametrize(

--- a/tests/types/test_spatial.py
+++ b/tests/types/test_spatial.py
@@ -194,7 +194,7 @@ def test_geometry_transformer_datum_uri_invalid(temp_default_crs: Callable[[str]
     # Should raise exception on invalid CRS not in fixed datum vocabulary
     with pytest.raises(types.spatial.GeometryError, match=r"NOTADATUM .+ GEODETIC_DATUM") as exc:
         _ = geometry.transformer_datum_uri
-    
+
     # Should have been raised from VocabularyError
     assert exc.value.__cause__.__class__ is utils.vocabs.VocabularyError
 

--- a/tests/types/test_temporal.py
+++ b/tests/types/test_temporal.py
@@ -1,12 +1,13 @@
 """Provides Unit Tests for the `abis_mapping.utils.timestamps` module"""
 
+# Standard
+import contextlib
+import datetime
+import re
+
 # Third-Party
 import pytest
 import rdflib
-
-# Standard
-import datetime
-import contextlib
 
 # Local
 from abis_mapping.types import temporal
@@ -67,6 +68,13 @@ def test_timestamp_parse_invalid(raw: Any) -> None:
     # Parse Invalid Timestamps
     with pytest.raises(ValueError):
         temporal.parse_timestamp(raw)
+
+
+def test_timestamp_le_invalid_other() -> None:
+    ts: temporal.Timestamp = temporal.Date(2024, 11, 11)
+
+    with pytest.raises(NotImplementedError, match=r"^Unable to compare .*temporal\.Date'> .*'int'>"):
+        _ = ts <= 1
 
 
 @pytest.mark.parametrize(
@@ -130,7 +138,7 @@ def test_max_date(
     expected: int,
     raise_error: contextlib.AbstractContextManager,
 ) -> None:
-    """Tests the functionality of the max_data function.
+    """Tests the functionality of the max_date property.
 
     Args:
         year (int): Year input
@@ -141,6 +149,40 @@ def test_max_date(
     """
     with raise_error:
         assert temporal.YearMonth(year, month).max_date == expected
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        temporal.Year(2024),
+        temporal.Date(2024, 11, 11),
+        5,
+        "yearmonth",
+    ],
+)
+def test_year_month_equality_invalid_other(other: Any) -> None:
+    """Tests the equality of year month against any other type."""
+    # Should raise for every non YearMonth type
+    with pytest.raises(NotImplementedError, match="Unable to compare YearMonth and "):
+        _ = temporal.YearMonth(2024, 11) == other
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        temporal.YearMonth(2024, 11),
+        temporal.Date(2024, 11, 11),
+        5,
+        "year",
+    ],
+)
+def test_year_equality_invalid_other(other: Any) -> None:
+    """Tests the equality of year against any other type."""
+    # Should raise for every non Year type
+    with pytest.raises(NotImplementedError, match="Unable to compare Year and "):
+
+
+        _ = temporal.Year(2024) == other
 
 
 class TestSharedParams:

--- a/tests/types/test_temporal.py
+++ b/tests/types/test_temporal.py
@@ -3,7 +3,6 @@
 # Standard
 import contextlib
 import datetime
-import re
 
 # Third-Party
 import pytest
@@ -180,8 +179,6 @@ def test_year_equality_invalid_other(other: Any) -> None:
     """Tests the equality of year against any other type."""
     # Should raise for every non Year type
     with pytest.raises(NotImplementedError, match="Unable to compare Year and "):
-
-
         _ = temporal.Year(2024) == other
 
 


### PR DESCRIPTION
Probably the biggest change is no longer returning None when retrieving datum uris. The thought here is that previously when these were directly retrieved from within the mapping methods, that there were no protections against the vocab error that would be thrown as well as the fact that the data that is expected to hit this method is already expected to have been validated through the enum check of the `geodeticDatum` fields. A chained exception is raised in its place.

Also renamed non-uppercase comment "note" with "NOTE" to help IDEs identify better.
