### PR TITLE
BDRSPS-966 IRI patterns for flexible vocab Concepts

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -571,6 +571,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             provider_record_id_occurrence=provider_record_id_occurrence,
             catalog_number_datatype=catalog_number_datatype,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add catalog number datatype
@@ -636,6 +637,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             id_qualifier=id_qualifier,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Identification Qualifier Collection
@@ -691,6 +693,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             sample_specimen=sample_specimen,
             scientific_name=text_scientific_name,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Observation for Verbatim ID
@@ -703,6 +706,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             sample_specimen=sample_specimen,
             verbatim_id=text_verbatim_id,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Data Generalizations Attribute
@@ -746,6 +750,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             taxon_rank=taxon_rank,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Taxon Rank collection
@@ -807,6 +812,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             habitat=habitat,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add habitat attribute sample collection
@@ -834,6 +840,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             basis_of_record=basis_of_record,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Basis of Record Sample Collection
@@ -871,6 +878,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Preparations Attribute
@@ -888,6 +896,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             preparations=preparations,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Preparations attribute Sample Collection
@@ -916,6 +925,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Life Stage Observation
@@ -935,6 +945,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Sex Observation
@@ -954,6 +965,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Reproductive Condition Observation
@@ -973,6 +985,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Accepted Name Usage Observation
@@ -1001,6 +1014,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             feature_of_interest=sample_specimen,
             sample_sequence=sample_sequence,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Sample Sequence
@@ -1030,6 +1044,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             threat_status_value=threat_status_value,
             determined_by=provider_determined_by,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Threat Status Value
@@ -1038,6 +1053,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Conservation Authority Attribute
@@ -1054,6 +1070,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             uri=conservation_authority_value,
             conservation_authority=conservation_authority,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add conservation Authority Collection
@@ -1081,6 +1098,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Sensitivity Category Collection
@@ -1155,6 +1173,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         sample_specimen: rdflib.URIRef,
         scientific_name: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Observation Scientific Name to the Graph
 
@@ -1170,6 +1189,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             scientific_name (rdflib.URIRef): Scientific Name associated with
                 this node
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Get Timestamp
         date_identified: types.temporal.Timestamp = row["dateIdentified"] or row["eventDateStart"]
@@ -1183,7 +1203,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["identificationMethod"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["identificationMethod"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Observation))
@@ -1219,6 +1239,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         sample_specimen: rdflib.URIRef,
         verbatim_id: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Observation Verbatim ID to the Graph
 
@@ -1233,6 +1254,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                 this node
             verbatim_id (rdflib.URIRef): Verbatim ID associated with this node
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check for verbatimIdentification
         if not row["verbatimIdentification"]:
@@ -1250,7 +1272,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["identificationMethod"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["identificationMethod"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Observation))
@@ -1439,6 +1461,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         id_qualifier: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Identification Qualifier Value to the Graph
 
@@ -1447,6 +1470,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             id_qualifier: identificationQualifier value from the template
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check node should be created
         if uri is None:
@@ -1462,7 +1486,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["identificationQualifier"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(id_qualifier)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(id_qualifier)
             # Identification Qualifier Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -1856,6 +1880,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_occurrence: rdflib.URIRef,
         catalog_number_datatype: rdflib.URIRef | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sample Specimen to the Graph
 
@@ -1870,6 +1895,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             catalog_number_datatype (rdflib.URIRef): Catalog number source
                 datatype.
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check if Row has a Specimen
         if not has_specimen(row):
@@ -1879,7 +1905,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["kingdom"].get_vocab("KINGDOM_SPECIMEN")
 
         # Retrieve Vocab or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["kingdom"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["kingdom"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.FeatureOfInterest))
@@ -2040,6 +2066,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         taxon_rank: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Taxon Rank Value to the Graph
 
@@ -2048,6 +2075,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             taxon_rank: taxonRank value from the template.
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -2063,7 +2091,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["taxonRank"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(taxon_rank)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(taxon_rank)
             # Taxon Rank Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2297,6 +2325,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         habitat: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Habitat Value to the Graph
 
@@ -2305,6 +2334,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             habitat: Habitat from the CSV
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -2320,7 +2350,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["habitat"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(habitat)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(habitat)
             # Add value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2396,6 +2426,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         basis_of_record: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Basis of Record Value to the Graph
 
@@ -2404,6 +2435,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             basis_of_record: basisOfRecord value from the CSV
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -2419,7 +2451,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["basisOfRecord"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(basis_of_record)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(basis_of_record)
             # Add value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2552,6 +2584,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Occurrence Status Value to the Graph
 
@@ -2560,6 +2593,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["occurrenceStatus"]:
@@ -2569,7 +2603,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["occurrenceStatus"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["occurrenceStatus"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["occurrenceStatus"])
 
         # Occurrence Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -2613,6 +2647,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         preparations: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Preparations Value to the Graph
 
@@ -2621,6 +2656,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             preparations: preparations value from the CSV
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -2636,7 +2672,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["preparations"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(preparations)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(preparations)
             # Add value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2740,6 +2776,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Establishment Means Value to the Graph
 
@@ -2748,6 +2785,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["establishmentMeans"]:
@@ -2757,7 +2795,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["establishmentMeans"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["establishmentMeans"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["establishmentMeans"])
 
         # Establishment Means Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -2832,6 +2870,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Life Stage Value to the Graph
 
@@ -2840,6 +2879,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["lifeStage"]:
@@ -2849,7 +2889,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["lifeStage"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["lifeStage"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["lifeStage"])
 
         # Life Stage Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -2923,6 +2963,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sex Value to the Graph
 
@@ -2931,6 +2972,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["sex"]:
@@ -2940,7 +2982,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["sex"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["sex"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sex"])
 
         # Sex Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3015,6 +3057,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Reproductive Condition Value to the Graph
 
@@ -3023,6 +3066,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["reproductiveCondition"]:
@@ -3032,7 +3076,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["reproductiveCondition"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["reproductiveCondition"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["reproductiveCondition"])
 
         # Reproductive Condition Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3124,6 +3168,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         feature_of_interest: rdflib.URIRef,
         sample_sequence: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sampling Sequencing to the Graph
 
@@ -3136,6 +3181,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             sample_sequence (rdflib.URIRef): Sample Sequence associated with
                 this node
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Extract values from row
         event_date: types.temporal.Timestamp = row["eventDateStart"]
@@ -3154,7 +3200,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["sequencingMethod"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["sequencingMethod"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sequencingMethod"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Sampling))
@@ -3267,6 +3313,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         threat_status_value: rdflib.URIRef,
         determined_by: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Threat Status Observation to the Graph
 
@@ -3283,6 +3330,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             determined_by (rdflib.URIRef): Determined By Provider associated
                 with this node
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["threatStatus"]:
@@ -3303,7 +3351,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["threatStatusCheckProtocol"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["threatStatusCheckProtocol"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["threatStatusCheckProtocol"])
 
         # Threat Status Observation
         graph.add((uri, a, utils.namespaces.TERN.Observation))
@@ -3345,6 +3393,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Threat Status Value to the Graph
 
@@ -3353,6 +3402,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs)
         """
         # Check Existence
         if not row["threatStatus"]:
@@ -3365,7 +3415,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["threatStatus"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
 
         # Threat Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3410,6 +3460,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef | None,
         conservation_authority: str | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Conservation Authority Value to the Graph
 
@@ -3417,6 +3468,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             uri: URI to use for this node
             conservation_authority: conservationAuthority value from the CSV
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -3432,7 +3484,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["conservationAuthority"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph).get(conservation_authority)
+            term = vocab(graph=graph, base_iri=base_iri).get(conservation_authority)
             # Conservation Authority Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -3515,6 +3567,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sensitivity Category Value to the Graph
 
@@ -3523,6 +3576,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row: Row to retrieve data from
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -3530,7 +3584,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
         # Retrieve vocab for field
         vocab = self.fields()["sensitivityCategory"].get_vocab()
-        vocab_instance = vocab(graph=graph, source=dataset)
+        vocab_instance = vocab(graph=graph, source=dataset, base_iri=base_iri)
 
         # Set the scope note to use if a new term is created on the fly.
         scope_note = f"Under the authority of {row['sensitivityAuthority']}"

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -327,6 +327,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             row_survey_type=row_survey_type,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add survey type collection node
@@ -356,6 +357,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
                 dataset=dataset,
                 raw_value=th_obj.raw,
                 graph=graph,
+                base_iri=base_iri,
             )
 
             # Add target habitat scope collection
@@ -385,6 +387,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
                 dataset=dataset,
                 raw_value=tt_obj.raw,
                 graph=graph,
+                base_iri=base_iri,
             )
 
             # Add target taxonomic scope collection node
@@ -683,6 +686,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         row_survey_type: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds the survey type value node to graph.
 
@@ -691,6 +695,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             row_survey_type: Raw value from the template for surveyType
             dataset: Dataset raw data belongs.
             graph: Graph to be modified.
+            base_iri: Namespace used to construct IRIs
         """
         # Return no value IRI
         if uri is None:
@@ -708,7 +713,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             vocab = self.fields()["surveyType"].get_vocab()
 
             # Add value
-            term = vocab(graph=graph, source=dataset).get(row_survey_type)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_survey_type)
             graph.add((uri, rdflib.RDF.value, term))
 
     def add_survey_type_collection(
@@ -790,6 +795,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         raw_value: str,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Add the target habitat scope value node.
 
@@ -798,6 +804,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             dataset (rdflib.URIRef): Dataset raw data belongs.
             raw_value (str): Raw data.
             graph (rdflib.Graph): Graph to be modified.
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Add types
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -810,7 +817,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         vocab = self.fields()["targetHabitatScope"].get_vocab()
 
         # Add value
-        term = vocab(graph=graph, source=dataset).get(raw_value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(raw_value)
         graph.add((uri, rdflib.RDF.value, term))
 
     def add_target_habitat_collection(
@@ -887,6 +894,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         raw_value: str,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds the target toxonomic scope value node.
 
@@ -895,6 +903,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             dataset (rdflib.URIRef): Dataset raw data belongs.
             raw_value (str): Raw data provided.
             graph (rdflib.Graph): Graph to be modified.
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Add types
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -907,7 +916,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         vocab = self.fields()["targetTaxonomicScope"].get_vocab()
 
         # Add value
-        term = vocab(graph=graph, source=dataset).get(raw_value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(raw_value)
         graph.add((uri, rdflib.RDF.value, term))
 
     def add_target_taxonomic_scope_collection(

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -743,6 +743,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             provider_record_id_occurrence=provider_record_id_occurrence,
             catalog_number_datatype=catalog_number_datatype,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add catalog number datatype
@@ -810,6 +811,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             id_qualifier=id_qualifier,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Identification Qualifier Collection
@@ -866,6 +868,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             scientific_name=text_scientific_name,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Observation for Verbatim ID
@@ -879,6 +882,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             verbatim_id=text_verbatim_id,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Data Generalizations Attribute
@@ -922,6 +926,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             taxon_rank=taxon_rank,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Taxon Rank collection
@@ -985,6 +990,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             habitat=habitat,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add habitat attribute sample collection
@@ -1012,6 +1018,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             basis_of_record=basis_of_record,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Basis of Record Sample Collection
@@ -1050,6 +1057,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Preparations Attribute
@@ -1067,6 +1075,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             preparations=preparations,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Preparations attribute Sample Collection
@@ -1096,6 +1105,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Life Stage Observation
@@ -1116,6 +1126,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Sex Observation
@@ -1136,6 +1147,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Reproductive Condition Observation
@@ -1156,6 +1168,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Accepted Name Usage Observation
@@ -1187,6 +1200,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_id_geometry_map=site_id_geometry_map,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Sample Sequence
@@ -1217,6 +1231,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             determined_by=provider_determined_by,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Threat Status Value
@@ -1225,6 +1240,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Conservation Authority Attribute
@@ -1241,6 +1257,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri=conservation_authority_value,
             conservation_authority=conservation_authority,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add conservation Authority Collection
@@ -1270,6 +1287,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             dataset=dataset,
             row=row,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add site
@@ -1294,6 +1312,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add Sensitivity Category Collection
@@ -1329,6 +1348,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_id_geometry_map=site_id_geometry_map,
             row=row,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add extra fields JSON
@@ -1463,6 +1483,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         scientific_name: rdflib.URIRef,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Observation Scientific Name to the Graph
 
@@ -1480,6 +1501,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_visit_id_temporal_map (dict[str, str] | None): Map
                 of site visit ids to default temporal entity to use if requlred.
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Get Timestamps
         date_identified: types.temporal.Timestamp | None = row["dateIdentified"] or row["eventDateStart"]
@@ -1493,7 +1515,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["identificationMethod"].get_vocab()
 
         # Retrieve Vocab or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["identificationMethod"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Observation))
@@ -1546,6 +1568,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         verbatim_id: rdflib.URIRef,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Observation Verbatim ID to the Graph
 
@@ -1562,6 +1585,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_visit_id_temporal_map (dict[str, str] | None): Map of site
                 visit ids to default temporal entity rdf.
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check for verbatimIdentification
         if not row["verbatimIdentification"]:
@@ -1579,7 +1603,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["identificationMethod"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["identificationMethod"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Observation))
@@ -1779,6 +1803,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         id_qualifier: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Identification Qualifier Value to the Graph
 
@@ -1787,6 +1812,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             id_qualifier: identificationQualifier value from the template
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check node should be created
         if uri is None:
@@ -1802,7 +1828,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["identificationQualifier"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(id_qualifier)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(id_qualifier)
             # Identification Qualifier Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2233,6 +2259,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_occurrence: rdflib.URIRef,
         catalog_number_datatype: rdflib.URIRef | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sample Specimen to the Graph
 
@@ -2247,6 +2274,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             catalog_number_datatype (rdflib.URIRef | None): Catalog number source
                 datatype.
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check if Row has a Specimen
         if not has_specimen(row):
@@ -2256,7 +2284,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["kingdom"].get_vocab("KINGDOM_SPECIMEN")
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["kingdom"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["kingdom"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.FeatureOfInterest))
@@ -2417,6 +2445,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         taxon_rank: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Taxon Rank Value to the Graph
 
@@ -2425,6 +2454,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             taxon_rank: taxonRank value from the template.
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if uri is None:
@@ -2440,7 +2470,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["taxonRank"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(taxon_rank)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(taxon_rank)
             # Taxon Rank Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2713,6 +2743,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         habitat: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Habitat Value to the Graph
 
@@ -2721,6 +2752,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             habitat: Habitat from the CSV
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs
         """
         # Check Existence
         if uri is None:
@@ -2736,7 +2768,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["habitat"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(habitat)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(habitat)
             # Add value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2812,6 +2844,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         basis_of_record: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Basis of Record Value to the Graph
 
@@ -2820,6 +2853,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             basis_of_record: basisOfRecord value from the CSV
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs
         """
         # Check Existence
         if uri is None:
@@ -2835,7 +2869,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["basisOfRecord"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(basis_of_record)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(basis_of_record)
             # Add value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -2988,6 +3022,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Occurrence Status Value to the Graph
 
@@ -2996,6 +3031,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["occurrenceStatus"]:
@@ -3005,7 +3041,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["occurrenceStatus"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["occurrenceStatus"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["occurrenceStatus"])
 
         # Occurrence Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3049,6 +3085,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         preparations: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Preparations Value to the Graph
 
@@ -3057,6 +3094,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             preparations: preparations value from the CSV
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs
         """
         # Check Existence
         if uri is None:
@@ -3072,7 +3110,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["preparations"].get_vocab()
             # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, source=dataset).get(preparations)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(preparations)
             # Add value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -3195,6 +3233,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Establishment Means Value to the Graph
 
@@ -3203,6 +3242,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["establishmentMeans"]:
@@ -3212,7 +3252,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["establishmentMeans"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["establishmentMeans"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["establishmentMeans"])
 
         # Establishment Means Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3307,6 +3347,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Life Stage Value to the Graph
 
@@ -3315,6 +3356,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["lifeStage"]:
@@ -3324,7 +3366,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["lifeStage"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["lifeStage"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["lifeStage"])
 
         # Life Stage Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3417,6 +3459,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sex Value to the Graph
 
@@ -3425,6 +3468,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["sex"]:
@@ -3434,7 +3478,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["sex"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["sex"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sex"])
 
         # Sex Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3528,6 +3572,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Reproductive Condition Value to the Graph
 
@@ -3536,6 +3581,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["reproductiveCondition"]:
@@ -3545,7 +3591,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["reproductiveCondition"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["reproductiveCondition"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["reproductiveCondition"])
 
         # Reproductive Condition Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3659,6 +3705,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         site_id_geometry_map: dict[str, str] | None,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sampling Sequencing to the Graph
 
@@ -3675,6 +3722,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_visit_id_temporal_map (dict[str, str] | None): Map of site visit
                 id to default temporal entity rdf.
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["associatedSequences"]:
@@ -3707,7 +3755,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["sequencingMethod"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["sequencingMethod"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sequencingMethod"])
 
         # Add to Graph
         graph.add((uri, a, utils.namespaces.TERN.Sampling))
@@ -3836,6 +3884,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         determined_by: rdflib.URIRef,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Threat Status Observation to the Graph
 
@@ -3854,6 +3903,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_visit_id_temporal_map (dict[str, str] | None): Map of site visit
                 id to default temporal entity as rdf.
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["threatStatus"]:
@@ -3874,7 +3924,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["threatStatusCheckProtocol"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(row["threatStatusCheckProtocol"])
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["threatStatusCheckProtocol"])
 
         # Threat Status Observation
         graph.add((uri, a, utils.namespaces.TERN.Observation))
@@ -3930,6 +3980,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Threat Status Value to the Graph
 
@@ -3938,6 +3989,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
             graph (rdflib.Graph): Graph to add to
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Check Existence
         if not row["threatStatus"]:
@@ -3950,7 +4002,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["threatStatus"].get_vocab()
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset).get(value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
 
         # Threat Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -3995,6 +4047,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef | None,
         conservation_authority: str | None,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Conservation Authority Value to the Graph
 
@@ -4002,6 +4055,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri: URI to use for this node
             conservation_authority: conservationAuthority value from the CSV
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs
         """
         # Check Existence
         if uri is None:
@@ -4017,7 +4071,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["conservationAuthority"].get_vocab()
             # Retrieve term
-            term = vocab(graph=graph).get(conservation_authority)
+            term = vocab(graph=graph, base_iri=base_iri).get(conservation_authority)
             # Conservation Authority Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -4154,6 +4208,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         row: frictionless.Row,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds organism quantity value to graph.
 
@@ -4163,6 +4218,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             dataset (rdflib.URIRef): Dataset this is a part of.
             row (frictionless.Row): Row to retrieve data from.
             graph (rdflib.Graph): Graph to be modified.
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Extract values if any
         organism_qty = row["organismQuantity"]
@@ -4176,7 +4232,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         vocab = self.fields()["organismQuantityType"].get_vocab()
 
         # Get term or create on the fly
-        term = vocab(graph=graph, source=dataset).get(organism_qty_type)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(organism_qty_type)
 
         # Add to graph
         graph.add((organism_qty_observation, rdflib.SOSA.hasResult, uri))
@@ -4246,6 +4302,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Sensitivity Category Value to the Graph
 
@@ -4254,6 +4311,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row: Row to retrieve data from
             dataset: Dataset this belongs to
             graph: Graph to add to
+            base_iri: Namespace used to construct IRIs
         """
         # Check Existence
         if uri is None:
@@ -4261,7 +4319,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
         # Retrieve vocab for field
         vocab = self.fields()["sensitivityCategory"].get_vocab()
-        vocab_instance = vocab(graph=graph, source=dataset)
+        vocab_instance = vocab(graph=graph, source=dataset, base_iri=base_iri)
 
         # Set the scope note to use if a new term is created on the fly.
         scope_note = f"Under the authority of {row['sensitivityAuthority']}"
@@ -4367,6 +4425,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         site_id_geometry_map: dict[str, str] | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds occurrence node to the graph.
 
@@ -4383,6 +4442,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             site_id_geometry_map: Map for default geometry for a given siteID.
             row: Raw data from the row.
             graph: Graph to be modified.
+            base_iri: Namespace used to construct IRIs
         """
         # Create geometry
         # Extract values
@@ -4428,7 +4488,13 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
         # Add feature type from vocab
         kingdom_vocab = self.fields()["kingdom"].get_vocab("KINGDOM_OCCURRENCE")
-        graph.add((uri, utils.namespaces.TERN.featureType, kingdom_vocab(graph=graph).get(row["kingdom"])))
+        graph.add(
+            (
+                uri,
+                utils.namespaces.TERN.featureType,
+                kingdom_vocab(graph=graph, base_iri=base_iri).get(row["kingdom"]),
+            )
+        )
 
         # Add geometry
         geometry_node = rdflib.BNode()
@@ -4474,7 +4540,13 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
         # Add procedure from vocab
         protocol_vocab = self.fields()["samplingProtocol"].get_vocab()
-        graph.add((uri, rdflib.SOSA.usedProcedure, protocol_vocab(graph=graph).get(row["samplingProtocol"])))
+        graph.add(
+            (
+                uri,
+                rdflib.SOSA.usedProcedure,
+                protocol_vocab(graph=graph, base_iri=base_iri).get(row["samplingProtocol"]),
+            )
+        )
 
         # Add location description if provided
         if locality := row["locality"]:

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -333,6 +333,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             related_site=related_site,
             row=row,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add site id datatype
@@ -374,6 +375,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
                 dataset=dataset,
                 raw=habitat_object.raw,
                 graph=graph,
+                base_iri=base_iri,
             )
 
             # Add habitat attribute Collection
@@ -440,6 +442,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         related_site: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds site to the graph.
 
@@ -451,6 +454,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             related_site:
             row: Row to retrieve data from.
             graph: Graph to be modified.
+            base_iri: Namespace used to construct IRIs
         """
         # Extract relevant values
         site_id = row["siteID"]
@@ -474,7 +478,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             relationship_to_related_site_vocab = self.fields()["relationshipToRelatedSite"].get_vocab()
             # Retrieve term
-            relationship_to_related_site_term = relationship_to_related_site_vocab(graph=graph).get(
+            relationship_to_related_site_term = relationship_to_related_site_vocab(graph=graph, base_iri=base_iri).get(
                 relationship_to_related_site
             )
             graph.add((uri, relationship_to_related_site_term, related_site))
@@ -486,7 +490,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         site_type_vocab = self.fields()["siteType"].get_vocab()
 
         # Retrieve term or create on the fly
-        site_type_term = site_type_vocab(graph=graph, source=dataset).get(site_type)
+        site_type_term = site_type_vocab(graph=graph, source=dataset, base_iri=base_iri).get(site_type)
 
         # Add to site type graph
         graph.add((uri, rdflib.SDO.additionalType, site_type_term))
@@ -622,6 +626,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         raw: str,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Add a habitat value node to graph.
 
@@ -630,6 +635,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             dataset (rdflib.URIRef): Dataset data belongs.
             raw (str): Raw data provided.
             graph (rdflib.Graph): Graph to be modified.
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         # Add type
         graph.add((uri, a, utils.namespaces.TERN.IRI))
@@ -642,7 +648,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         vocab = self.fields()["habitat"].get_vocab()
 
         # Add flexible vocab term
-        term = vocab(graph=graph, source=dataset).get(raw)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(raw)
         graph.add((uri, rdflib.RDF.value, term))
 
     def add_habitat_collection(

--- a/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
@@ -492,6 +492,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             row=row,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
 
         # Add targetTaxonomicScope Attribute, Value and Collection
@@ -507,6 +508,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             row_target_taxonomic_scope=row_target_taxonomic_scope,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
         self.add_target_taxonomic_scope_collection(
             uri=uri_target_taxonomic_scope_collection,
@@ -531,6 +533,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             row_sampling_effort_unit=row_sampling_effort_unit,
             dataset=dataset,
             graph=graph,
+            base_iri=base_iri,
         )
         self.add_sampling_effort_collection(
             uri=uri_sampling_effort_collection,
@@ -729,7 +732,17 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
+        """Add a site visit prov:Plan node to the graph.
+
+        Args:
+            uri: The URI for the site visit plan
+            row: Raw row from the template.
+            dataset: Dataset raw data belongs to.
+            graph: The graph to be modified.
+            base_iri: Namespace used to construct IRIs
+        """
         # Add subject type
         graph.add((uri, a, rdflib.PROV.Plan))
 
@@ -744,7 +757,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["protocolName"].get_vocab()
             # get or create term IRI
-            term = vocab(graph=graph, source=dataset).get(row_protocol_name)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_protocol_name)
             # Add link to term
             graph.add((uri, rdflib.SOSA.usedProcedure, term))
 
@@ -792,6 +805,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         row_target_taxonomic_scope: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds the target taxonomic scope Attribute Value node.
 
@@ -800,6 +814,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             row_target_taxonomic_scope: Raw data in the targetTaxonomicScope field.
             dataset: Dataset raw data belongs.
             graph: Graph to be modified.
+            base_iri: Namespace used to construct IRIs
         """
         # check subject is provided
         if uri is None:
@@ -814,7 +829,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             vocab = self.fields()["targetTaxonomicScope"].get_vocab()
 
             # Add value
-            term = vocab(graph=graph, source=dataset).get(row_target_taxonomic_scope)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_target_taxonomic_scope)
             graph.add((uri, rdflib.RDF.value, term))
 
     def add_target_taxonomic_scope_collection(
@@ -904,6 +919,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         row_sampling_effort_unit: str | None,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds sampling effort Attribute Value node.
 
@@ -913,6 +929,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             row_sampling_effort_unit: Value from the samplingEffortUnit field.
             dataset (rdflib.URIRef): URI of the dataset this belongs to.
             graph (rdflib.Graph): Graph to be modified.
+            base_iri (rdflib.Namespace | None): Namespace used to construct IRIs
         """
         if uri is None:
             return
@@ -930,7 +947,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["samplingEffortUnit"].get_vocab()
             # Add value
-            term = vocab(graph=graph, source=dataset).get(row_sampling_effort_unit)
+            term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_sampling_effort_unit)
             graph.add((uri, utils.namespaces.TERN.unit, term))
 
     def add_sampling_effort_collection(

--- a/abis_mapping/utils/vocabs.py
+++ b/abis_mapping/utils/vocabs.py
@@ -100,20 +100,22 @@ class Vocabulary(abc.ABC):
 
     def __init__(
         self,
+        *,
         graph: rdflib.Graph,
         source: Optional[rdflib.URIRef] = None,
+        base_iri: Optional[rdflib.Namespace] = None,
     ):
         """Vocabulary constructor.
 
         Args:
-            graph (rdflib.Graph): Graph to reference
-                within vocabulary
-            source (Optional[rdflib.URIRef]): Optional source URI to attribute
-                a new vocabulary term to.
+            graph: Graph to reference within vocabulary
+            source: Optional source URI to attribute a new vocabulary term to.
+            base_iri: Optional namespace to use when creating the IRI for a new vocabulary term.
         """
         # Assign instance variables
         self.graph = graph
         self.source: Optional[rdflib.URIRef] = source
+        self.base_iri = base_iri
 
         # Generate Dictionary Mapping from Terms
         self._mapping: dict[str | None, rdflib.URIRef | None] = {}
@@ -191,7 +193,7 @@ class FlexibleVocabulary(Vocabulary):
     Attributes:
         definition (rdflib.Literal): Definition to use when creating a new
             vocabulary term 'on the fly'.
-        base_ns (rdflib.URIRef): Base IRI namespace to use when creating a new
+        base (str): Base of the path to use when creating a new
             vocabulary term 'on the fly'.
         scheme (rdflib.URIRef): Scheme IRI to use when creating a new
             vocabulary term 'on the fly'.
@@ -207,7 +209,7 @@ class FlexibleVocabulary(Vocabulary):
 
     # Declare attributes applicable to a flexible vocab
     definition: rdflib.Literal
-    base: rdflib.URIRef
+    base: str
     scheme: rdflib.URIRef
     broader: Optional[rdflib.URIRef]
     scope_note: Optional[rdflib.Literal] = None
@@ -215,22 +217,20 @@ class FlexibleVocabulary(Vocabulary):
 
     def __init__(
         self,
+        *,
         graph: rdflib.Graph,
         source: Optional[rdflib.URIRef] = None,
+        base_iri: Optional[rdflib.Namespace] = None,
     ):
         """Flexible Vocabulary constructor.
 
         Args:
-            graph (rdflib.Graph): Graph to reference
-                within vocabulary
-            source (Optional[rdflib.URIRef]): Optional source URI to attribute
-                a new vocabulary term to.
+            graph: Graph to reference within vocabulary
+            source: Optional source URI to attribute a new vocabulary term to.
+            base_iri: Optional namespace to use when creating the IRI for a new vocabulary term.
         """
         # Call parent constructor
-        super().__init__(graph=graph, source=source)
-
-        # Set Instance Variables
-        self.base_ns = rdflib.Namespace(self.base)  # Cast to a Namespace
+        super().__init__(graph=graph, source=source, base_iri=base_iri)
 
         # Add Default mapping if Applicable
         if self.default:
@@ -291,7 +291,7 @@ class FlexibleVocabulary(Vocabulary):
             raise VocabularyError("Value not supplied for vocabulary with no default")
 
         # Create our Own Concept IRI
-        iri = rdf.uri(value, namespace=self.base_ns)
+        iri = rdf.uri(self.base + value, namespace=self.base_iri)
 
         # Add to Graph
         self.graph.add((iri, a, rdflib.SKOS.Concept))

--- a/abis_mapping/vocabs/basis_of_record.py
+++ b/abis_mapping/vocabs/basis_of_record.py
@@ -55,7 +55,7 @@ MATERIAL_SAMPLE = utils.vocabs.Term(
 class BasisOfRecord(utils.vocabs.FlexibleVocabulary):
     vocab_id = "BASIS_OF_RECORD"
     definition = rdflib.Literal("A type of basisOfRecord.")
-    base = utils.rdf.uri("bdr-cv/attribute/basisOfRecord/")
+    base = "bdr-cv/attribute/basisOfRecord/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/attribute/basisOfRecord", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, omitted if not provided

--- a/abis_mapping/vocabs/check_protocol.py
+++ b/abis_mapping/vocabs/check_protocol.py
@@ -19,7 +19,7 @@ UNSPECIFIED = utils.vocabs.Term(
 class CheckProtocol(utils.vocabs.FlexibleVocabulary):
     vocab_id = "CHECK_PROTOCOL"
     definition = rdflib.Literal("A type of threatStatusCheckProtocol.")
-    base = utils.rdf.uri("bdr-cv/methods/threatStatusCheckProtocol/")
+    base = "bdr-cv/methods/threatStatusCheckProtocol/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c")
     broader = utils.rdf.uri(
         "bdr-cv/methods/threatStatusCheckProtocol", utils.namespaces.EXAMPLE

--- a/abis_mapping/vocabs/establishment_means.py
+++ b/abis_mapping/vocabs/establishment_means.py
@@ -68,7 +68,7 @@ VAGRANT = utils.vocabs.Term(
 class EstablishmentMeans(utils.vocabs.FlexibleVocabulary):
     vocab_id = "ESTABLISHMENT_MEANS"
     definition = rdflib.Literal("A type of establishmentMeans.")
-    base = utils.rdf.uri("bdr-cv/parameter/establishmentMeans/")
+    base = "bdr-cv/parameter/establishmentMeans/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e")
     broader = utils.rdf.uri("bdr-cv/parameter/establishmentMeans", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, omitted if not provided

--- a/abis_mapping/vocabs/identification_method.py
+++ b/abis_mapping/vocabs/identification_method.py
@@ -19,7 +19,7 @@ UNDEFINED = utils.vocabs.Term(
 class IdentificationMethod(utils.vocabs.FlexibleVocabulary):
     vocab_id = "IDENTIFICATION_METHOD"
     definition = rdflib.Literal("A type of identificationMethod.")
-    base = utils.rdf.uri("bdr-cv/methods/identificationMethod/")
+    base = "bdr-cv/methods/identificationMethod/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c")
     broader = utils.rdf.uri("bdr-cv/methods/identificationMethod", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = UNDEFINED

--- a/abis_mapping/vocabs/identification_qualifier.py
+++ b/abis_mapping/vocabs/identification_qualifier.py
@@ -230,7 +230,7 @@ SUBSPECIES = utils.vocabs.Term(
 class IdentificationQualifier(utils.vocabs.FlexibleVocabulary):
     vocab_id = "IDENTIFICATION_QUALIFIER"
     definition = rdflib.Literal("A type of identificationQualifier.")
-    base = utils.rdf.uri("bdr-cv/attribute/identificationQualifier/")
+    base = "bdr-cv/attribute/identificationQualifier/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri(
         "bdr-cv/attribute/identificationQualifier", utils.namespaces.EXAMPLE

--- a/abis_mapping/vocabs/kingdom.py
+++ b/abis_mapping/vocabs/kingdom.py
@@ -73,7 +73,7 @@ class Kingdom(utils.vocabs.FlexibleVocabulary):
 
     vocab_id = "KINGDOM"
     definition = rdflib.Literal("A type of kingdom.")
-    base = utils.rdf.uri("bdr-cv/attribute/kingdom/")
+    base = "bdr-cv/attribute/kingdom/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/attribute/kingdom", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, kingdom is required in the CSV
@@ -85,7 +85,7 @@ class KingdomOccurrence(utils.vocabs.FlexibleVocabulary):
     definition = rdflib.Literal(
         "The existence of the organism from this kingdom sampled at a particular place at a particular time."
     )
-    base = utils.rdf.uri("bdr-cv/featureType/occurrence/kingdom/")
+    base = "bdr-cv/featureType/occurrence/kingdom/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d")
     broader = None  # No broader, top level concept
     default = None  # No default, kingdom is required in the CSV
@@ -109,7 +109,7 @@ class KingdomOccurrence(utils.vocabs.FlexibleVocabulary):
 class KingdomSpecimen(utils.vocabs.FlexibleVocabulary):
     vocab_id = "KINGDOM_SPECIMEN"
     definition = rdflib.Literal("A specimen sampled from an organism of this kingdom.")
-    base = utils.rdf.uri("bdr-cv/featureType/specimen/kingdom/")
+    base = "bdr-cv/featureType/specimen/kingdom/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d")
     broader = None  # No broader, top level concept
     default = None  # No default, kingdom is required in the CSV

--- a/abis_mapping/vocabs/life_stage.py
+++ b/abis_mapping/vocabs/life_stage.py
@@ -213,7 +213,7 @@ ZYGOTE = utils.vocabs.Term(
 class LifeStage(utils.vocabs.FlexibleVocabulary):
     vocab_id = "LIFE_STAGE"
     definition = rdflib.Literal("A type of lifeStage.")
-    base = utils.rdf.uri("bdr-cv/parameter/lifeStage/")
+    base = "bdr-cv/parameter/lifeStage/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e")
     broader = utils.rdf.uri("bdr-cv/parameter/lifeStage", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, omitted if not provided

--- a/abis_mapping/vocabs/occurrence_status.py
+++ b/abis_mapping/vocabs/occurrence_status.py
@@ -24,7 +24,7 @@ ABSENT = utils.vocabs.Term(
 class OccurrenceStatus(utils.vocabs.FlexibleVocabulary):
     vocab_id = "OCCURRENCE_STATUS"
     definition = rdflib.Literal("A type of occurrenceStatus.")
-    base = utils.rdf.uri("bdr-cv/parameter/occurrenceStatus/")
+    base = "bdr-cv/parameter/occurrenceStatus/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e")
     broader = utils.rdf.uri("bdr-cv/parameter/occurrenceStatus", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, ommitted if not provided

--- a/abis_mapping/vocabs/organism_quantity_type.py
+++ b/abis_mapping/vocabs/organism_quantity_type.py
@@ -145,7 +145,7 @@ BIOVOLUME_ML = utils.vocabs.Term(
 class OrganismQuantityType(utils.vocabs.FlexibleVocabulary):
     vocab_id = "ORGANISM_QUANTITY_TYPE"
     definition = rdflib.Literal("A type of organism quantity.")
-    base = utils.rdf.uri("bdr-cv/concept/organismQuantityType")
+    base = "bdr-cv/concept/organismQuantityType/"
     scheme = rdflib.URIRef("http://rs.gbif.org/vocabulary/gbif/quantityType")
     broader = utils.rdf.uri("bdr-cv/concept/organismQuantityType", utils.namespaces.EXAMPLE)
     default = None  # No default, ommitted if not provided.

--- a/abis_mapping/vocabs/preparations.py
+++ b/abis_mapping/vocabs/preparations.py
@@ -84,7 +84,7 @@ REFRIGERATED = utils.vocabs.Term(
 class Preparations(utils.vocabs.FlexibleVocabulary):
     vocab_id = "PREPARATIONS"
     definition = rdflib.Literal("A type of preparations.")
-    base = utils.rdf.uri("bdr-cv/attribute/preparations/")
+    base = "bdr-cv/attribute/preparations/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/attribute/preparations", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, ommitted if not provided

--- a/abis_mapping/vocabs/reproductive_condition.py
+++ b/abis_mapping/vocabs/reproductive_condition.py
@@ -11,7 +11,7 @@ from abis_mapping import utils
 class ReproductiveCondition(utils.vocabs.FlexibleVocabulary):
     vocab_id = "REPRODUCTIVE_CONDITION"
     definition = rdflib.Literal("A type of reproductiveCondition.")
-    base = utils.rdf.uri("bdr-cv/parameter/reproductiveCondition/")
+    base = "bdr-cv/parameter/reproductiveCondition/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e")
     broader = utils.rdf.uri("bdr-cv/parameter/reproductiveCondition", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, ommitted if not provided

--- a/abis_mapping/vocabs/sampling_effort_unit.py
+++ b/abis_mapping/vocabs/sampling_effort_unit.py
@@ -67,7 +67,7 @@ class SamplingEffortUnit(utils.vocabs.FlexibleVocabulary):
             "gives an indication of the effort applied to the specified protocol."
         ),
     )
-    base = utils.rdf.uri("bdr-cv/attribute/samplingEffortUnit/")
+    base = "bdr-cv/attribute/samplingEffortUnit/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = None
     default = None

--- a/abis_mapping/vocabs/sampling_protocol.py
+++ b/abis_mapping/vocabs/sampling_protocol.py
@@ -297,7 +297,7 @@ WET_PITFALL_TRAP = utils.vocabs.Term(
 class SamplingProtocol(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SAMPLING_PROTOCOL"
     definition = rdflib.Literal("A type of samplingProtocol.")
-    base = utils.rdf.uri("bdr-cv/methods/samplingProtocol/")
+    base = "bdr-cv/methods/samplingProtocol/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c")
     broader = rdflib.URIRef("https://linked.data.gov.au/def/nrm/f1592e71-cc16-4b81-90c4-06b418a5a766")
     default = NO_STATED_METHOD

--- a/abis_mapping/vocabs/sensitivity_authority.py
+++ b/abis_mapping/vocabs/sensitivity_authority.py
@@ -12,7 +12,7 @@ from abis_mapping import utils
 class SensitivityAuthority(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SENSITIVITY_AUTHORITY"
     definition = rdflib.Literal("A type of sensitivityAuthority.")
-    base = utils.rdf.uri("bdr-cv/attribute/sensitivityAuthority/")
+    base = "bdr-cv/attribute/sensitivityAuthority/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/attribute/sensitivityAuthority", utils.namespaces.EXAMPLE)
     default = None  # No default, omitted if not provided

--- a/abis_mapping/vocabs/sensitivity_category.py
+++ b/abis_mapping/vocabs/sensitivity_category.py
@@ -12,7 +12,7 @@ from abis_mapping import utils
 class SensitivityCategory(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SENSITIVITY_CATEGORY"
     definition = rdflib.Literal("A type of sensitivityCategory.")
-    base = utils.rdf.uri("bdr-cv/attribute/sensitivityCategory/")
+    base = "bdr-cv/attribute/sensitivityCategory/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/attribute/sensitivityCategory", utils.namespaces.EXAMPLE)
     default = None  # No default, omitted if not provided

--- a/abis_mapping/vocabs/sequencing_method.py
+++ b/abis_mapping/vocabs/sequencing_method.py
@@ -19,7 +19,7 @@ UNDEFINED = utils.vocabs.Term(
 class SequencingMethod(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SEQUENCING_METHOD"
     definition = rdflib.Literal("A type of sequencingMethod.")
-    base = utils.rdf.uri("bdr-cv/methods/sequencingMethod/")
+    base = "bdr-cv/methods/sequencingMethod/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c")
     broader = utils.rdf.uri("bdr-cv/methods/sequencingMethod", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = UNDEFINED

--- a/abis_mapping/vocabs/sex.py
+++ b/abis_mapping/vocabs/sex.py
@@ -58,7 +58,7 @@ UNDETERMINED = utils.vocabs.Term(
 class Sex(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SEX"
     definition = rdflib.Literal("A type of sex.")
-    base = utils.rdf.uri("bdr-cv/parameter/sex/")
+    base = "bdr-cv/parameter/sex/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e")
     broader = utils.rdf.uri("bdr-cv/parameter/sex", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, ommitted if not provided

--- a/abis_mapping/vocabs/site_type.py
+++ b/abis_mapping/vocabs/site_type.py
@@ -43,7 +43,7 @@ TRANSECT = utils.vocabs.Term(
 class SiteType(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SITE_TYPE"
     definition = rdflib.Literal("A type of site.")
-    base = utils.rdf.uri("bdr-cv/concept/siteType/")
+    base = "bdr-cv/concept/siteType/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/74aa68d3-28fd-468d-8ff5-7e791d9f7159")
     broader = utils.rdf.uri("bdr-cv/concept/siteType", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = SITE

--- a/abis_mapping/vocabs/survey_type.py
+++ b/abis_mapping/vocabs/survey_type.py
@@ -24,7 +24,7 @@ WET_PITFALL_TRAPPING = utils.vocabs.Term(
 class SurveyType(utils.vocabs.FlexibleVocabulary):
     vocab_id = "SURVEY_TYPE"
     definition = rdflib.Literal("A type of surveyType")
-    base = utils.rdf.uri("bdr-cv/attribute/surveyType/")
+    base = "bdr-cv/attribute/surveyType/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/concept/surveyType", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None

--- a/abis_mapping/vocabs/target_habitat_scope.py
+++ b/abis_mapping/vocabs/target_habitat_scope.py
@@ -987,7 +987,7 @@ WOODLAND = utils.vocabs.Term(
 class TargetHabitatScope(utils.vocabs.FlexibleVocabulary):
     vocab_id = "TARGET_HABITAT_SCOPE"
     definition = rdflib.Literal("A type of targetHabitatScope")
-    base = utils.rdf.uri("bdr-cv/attribute/targetHabitatScope/")
+    base = "bdr-cv/attribute/targetHabitatScope/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = rdflib.URIRef("https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f")
     default = None

--- a/abis_mapping/vocabs/target_taxonomic_scope.py
+++ b/abis_mapping/vocabs/target_taxonomic_scope.py
@@ -83,7 +83,7 @@ VASCULAR_PLANT = utils.vocabs.Term(
 class TargetTaxonomicScope(utils.vocabs.FlexibleVocabulary):
     vocab_id = "TARGET_TAXONOMIC_SCOPE"
     definition = rdflib.Literal("A type of targetTaxonomicScope")
-    base = utils.rdf.uri("bdr-cv/attribute/targetTaxonomicScope/")
+    base = "bdr-cv/attribute/targetTaxonomicScope/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = rdflib.URIRef("https://linked.data.gov.au/def/nrm/7ea12fed-6b87-4c20-9ab4-600b32ce15ec")
     default = None

--- a/abis_mapping/vocabs/taxon_rank.py
+++ b/abis_mapping/vocabs/taxon_rank.py
@@ -235,7 +235,7 @@ VARIETY = utils.vocabs.Term(
 class TaxonRank(utils.vocabs.FlexibleVocabulary):
     vocab_id = "TAXON_RANK"
     definition = rdflib.Literal("A type of taxonRank.")
-    base = utils.rdf.uri("bdr-cv/attribute/taxonRank/")
+    base = "bdr-cv/attribute/taxonRank/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924")
     broader = utils.rdf.uri("bdr-cv/attribute/taxonRank", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, ommitted if not provided

--- a/abis_mapping/vocabs/threat_status.py
+++ b/abis_mapping/vocabs/threat_status.py
@@ -763,7 +763,7 @@ WA_VU = utils.vocabs.Term(
 class ThreatStatus(utils.vocabs.FlexibleVocabulary):
     vocab_id = "THREAT_STATUS"
     definition = rdflib.Literal("A type of threatStatus.")
-    base = utils.rdf.uri("bdr-cv/parameter/threatStatus/")
+    base = "bdr-cv/parameter/threatStatus/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e")
     broader = utils.rdf.uri("bdr-cv/parameter/threatStatus", utils.namespaces.EXAMPLE)  # TODO -> Need real URI
     default = None  # No default, ommitted if not provided

--- a/abis_mapping/vocabs/visit_protocol_name.py
+++ b/abis_mapping/vocabs/visit_protocol_name.py
@@ -237,7 +237,7 @@ WET_PITFALL_TRAP = utils.vocabs.Term(
 class VisitProtocolName(utils.vocabs.FlexibleVocabulary):
     vocab_id = "VISIT_PROTOCOL_NAME"
     definition = rdflib.Literal("A type of protocolName")
-    base = utils.rdf.uri("bdr-cv/attribute/protocolName/")
+    base = "bdr-cv/attribute/protocolName/"
     scheme = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c")
     broader = rdflib.URIRef("https://linked.data.gov.au/def/nrm/f1592e71-cc16-4b81-90c4-06b418a5a766")
     default = NO_STATED_METHOD

--- a/tests/types/test_spatial.py
+++ b/tests/types/test_spatial.py
@@ -278,12 +278,12 @@ def test_geometry_to_rdf_literal() -> None:
         (
             "POINT (571666.4475041276 5539109.815175673)",
             "EPSG:26917",
-            f"<{vocabs.geodetic_datum.GeodeticDatum(rdflib.Graph()).get(settings.Settings().DEFAULT_TARGET_CRS)}> POINT (50 -80)",
+            f"<{vocabs.geodetic_datum.GeodeticDatum(graph=rdflib.Graph()).get(settings.Settings().DEFAULT_TARGET_CRS)}> POINT (50 -80)",
         ),
         (
             "LINESTRING (1 2, 3 4)",
             "WGS84",
-            f"<{vocabs.geodetic_datum.GeodeticDatum(rdflib.Graph()).get(settings.Settings().DEFAULT_TARGET_CRS)}> LINESTRING (2 1, 4 3)",
+            f"<{vocabs.geodetic_datum.GeodeticDatum(graph=rdflib.Graph()).get(settings.Settings().DEFAULT_TARGET_CRS)}> LINESTRING (2 1, 4 3)",
         ),
     ],
 )

--- a/tests/utils/test_vocabs.py
+++ b/tests/utils/test_vocabs.py
@@ -8,6 +8,7 @@ import pytest
 import rdflib
 
 # Local
+import abis_mapping.utils.namespaces
 import abis_mapping.utils.vocabs
 
 
@@ -76,7 +77,7 @@ def test_vocabs_flexible_vocab() -> None:
     class Vocab(abis_mapping.utils.vocabs.FlexibleVocabulary):
         vocab_id = "TEST_FLEX"
         definition = rdflib.Literal("definition")
-        base = rdflib.URIRef("base/")
+        base = "base/"
         scheme = rdflib.URIRef("scheme")
         broader = rdflib.URIRef("broader")
         default = None
@@ -97,7 +98,7 @@ def test_vocabs_flexible_vocab() -> None:
     graph = rdflib.Graph()
 
     # Initialize vocab
-    vocab = Vocab(graph=graph)
+    vocab = Vocab(graph=graph, base_iri=abis_mapping.utils.namespaces.EXAMPLE)
 
     # Assert Existing Values
     assert vocab.get("a") == rdflib.URIRef("A")
@@ -107,7 +108,7 @@ def test_vocabs_flexible_vocab() -> None:
 
     # Assert New Values
     vocab.source = rdflib.URIRef("D")
-    assert vocab.get("C") == rdflib.URIRef("base/C")
+    assert vocab.get("C") == rdflib.URIRef("http://example.com/base/C")
     assert (
         graph.serialize(format="ttl").strip()
         == textwrap.dedent(
@@ -116,7 +117,7 @@ def test_vocabs_flexible_vocab() -> None:
         @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <base/C> a skos:Concept ;
+        <http://example.com/base/C> a skos:Concept ;
             skos:broader <broader> ;
             skos:definition "definition" ;
             skos:inScheme <scheme> ;


### PR DESCRIPTION
Change the flexible vocab term IRIs to be generated from the `base_iri`.
These are the IRIs used for the `skos:Concept` nodes

The generated IRIs are now effectively 
`{base_iri} + {base string from vocab class} + {value from template}`

e.g.
`{https://linked.data.gov.au/dataset/bdr/01a4205e-6ba5-45b6-bebd-10fa85a260d4/} + {bdr-cv/methods/samplingProtocol/} + {some new protocol}`