### PR TITLE
BDRSPS-980 Added model documentation check to ci

### DIFF
--- a/.github/actions/setup-python-and-dependencies/action.yml
+++ b/.github/actions/setup-python-and-dependencies/action.yml
@@ -3,12 +3,15 @@ inputs:
   python-version:
     required: true
     description: Version of Python to use
+  poetry-version:
+    required: true
+    description: Version of poetry to use
 runs:
   using: composite
   steps:
     - name: Install Poetry
       shell: bash
-      run: pipx install poetry==1.8.4
+      run: pipx install poetry==${{ inputs.poetry-version }} 
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,9 @@ on:
       - main
 permissions:
   contents: write
+env:
+  PYTHON_VERSION: "3.11"
+  POETRY_VERSION: "1.8.4"
 jobs:
   documentation:
     env:
@@ -30,8 +33,8 @@ jobs:
 
       - uses: ./.github/actions/setup-python-and-dependencies
         with:
-          python-version: "3.11"
-          poetry-version: "1.8.4"
+          python-version: ${{ env.PYTHON_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Generate markdown
         run: poetry run poe generate-instructions

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: ./.github/actions/setup-python-and-dependencies
         with:
           python-version: "3.11"
+          poetry-version: "1.8.4"
 
       - name: Generate markdown
         run: poetry run poe generate-instructions

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "Checking if locking dependencies has created any diff in the lock file..."
           if 
-            git diff --exit-code -- poetry.lock 
+            git diff --exit-code -- poetry.lock
           then
             echo "No changes to poetry.lock detected"
           else

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+      - BDRSPS-980
   pull_request:
     branches:
       - main
+env:
+  PYTHON_VERSION: "3.11"
+  POETRY_VERSION: "1.8.4"
 jobs:
   poetry-lock:
     # Job to check poetry lock file is present, up-to-date with pyproject.toml,
@@ -14,10 +18,12 @@ jobs:
     steps:
       # Setup steps
       - uses: actions/checkout@v4
+      - name: Install Poetry
+        shell: bash
+        run: pipx install poetry==${{ env.POETRY_VERSION }} 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-      - run: pipx install poetry==1.8.4 --python "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       # Do checks
       - run: poetry check
       - run: poetry check --lock
@@ -26,15 +32,37 @@ jobs:
       - name: Check resolving dependencies did not change the lock file
         run: |
           echo "Checking if locking dependencies has created any diff in the lock file..."
-          if 
-            git diff --exit-code -- poetry.lock
-          then
-            echo "No changes to poetry.lock detected"
-          else
+          set +e
+          git diff --exit-code -- poetry.lock > /dev/null
+          if [ $? -ne 0 ] ; then
             echo "Changes to poetry.lock detected!"
             echo "You probably should run 'poetry lock --no-update' and add the result to your PR"
+            set -e
             exit 1
           fi
+
+  model-docs:
+    # Job to check that update to models' documentation is not required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-and-dependencies
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - run: poetry run poe generate-model-docs
+      - name: Check model changes left undocumented
+        run: |
+          echo "Checking if model changes left undocumented"
+          set +e
+          git diff --exit-code -- docs/* > /dev/null
+          if [ $? -ne 0 ] ; then
+            echo "There was an undocumented change in models detected"
+            echo "Make necessary changes and commit them (e.g. run 'poe generate-model-docs')"
+            set -e
+            exit 1
+          fi
+    needs: [poetry-lock]
 
   format:
     runs-on: ubuntu-latest
@@ -42,8 +70,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-and-dependencies
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe format-check
+    needs: [poetry-lock]
 
   lint:
     runs-on: ubuntu-latest
@@ -51,8 +81,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-and-dependencies
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe lint
+    needs: [poetry-lock]
 
   mypy:
     runs-on: ubuntu-latest
@@ -60,8 +92,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-and-dependencies
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe typecheck
+    needs: [poetry-lock]
 
   pytest:
     runs-on: ubuntu-latest
@@ -73,4 +107,6 @@ jobs:
       - uses: ./.github/actions/setup-python-and-dependencies
         with:
           python-version: ${{ matrix.python-version }}
+          poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe test
+    needs: [poetry-lock]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - BDRSPS-980
   pull_request:
     branches:
       - main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,12 +17,11 @@ jobs:
     steps:
       # Setup steps
       - uses: actions/checkout@v4
-      - name: Install Poetry
-        shell: bash
-        run: pipx install poetry==${{ env.POETRY_VERSION }} 
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Poetry
+        run: pipx install poetry==${{ env.POETRY_VERSION }} --python=${{ env.PYTHON_VERSION }}
       # Do checks
       - run: poetry check
       - run: poetry check --lock
@@ -31,17 +30,19 @@ jobs:
       - name: Check resolving dependencies did not change the lock file
         run: |
           echo "Checking if locking dependencies has created any diff in the lock file..."
-          set +e
-          git diff --exit-code -- poetry.lock > /dev/null
-          if [ $? -ne 0 ] ; then
+          if 
+            git diff --exit-code -- poetry.lock 
+          then
+            echo "No changes to poetry.lock detected"
+          else
             echo "Changes to poetry.lock detected!"
             echo "You probably should run 'poetry lock --no-update' and add the result to your PR"
-            set -e
             exit 1
           fi
 
   model-docs:
     # Job to check that update to models' documentation is not required
+    needs: [poetry-lock]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,17 +54,18 @@ jobs:
       - name: Check model changes left undocumented
         run: |
           echo "Checking if model changes left undocumented"
-          set +e
-          git diff --exit-code -- docs/* > /dev/null
-          if [ $? -ne 0 ] ; then
+          if 
+            git diff --exit-code -- docs/* > /dev/null 
+          then
+            echo "No model changes detected"
+          else
             echo "There was an undocumented change in models detected"
             echo "Make necessary changes and commit them (e.g. run 'poe generate-model-docs')"
-            set -e
             exit 1
           fi
-    needs: [poetry-lock]
 
   format:
+    needs: [poetry-lock]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,9 +74,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe format-check
-    needs: [poetry-lock]
 
   lint:
+    needs: [poetry-lock]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -83,9 +85,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe lint
-    needs: [poetry-lock]
 
   mypy:
+    needs: [poetry-lock]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -94,9 +96,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe typecheck
-    needs: [poetry-lock]
 
   pytest:
+    needs: [poetry-lock]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -108,4 +110,3 @@ jobs:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ env.POETRY_VERSION }}
       - run: poetry run poe test
-    needs: [poetry-lock]


### PR DESCRIPTION
Made all jobs depend on `poetry-lock` due to a test that revealed all would fail on a common issue of lockfile out of sync with pyproject.toml. Added env variables for poetry and python versions. 