### PR TITLE
BDRSPS-940 Fixup: Remove the isSampleOf predicate for sites

### DIFF
--- a/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
@@ -4,7 +4,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix tern: <https://w3id.org/tern/ontologies/tern/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -63,7 +62,6 @@
 <http://createme.org/Site/P0> a tern:Site ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     geo:hasGeometry _:N53dd57c04e35e4aa3188c0b800000000 ;
-    sosa:isSampleOf <http://createme.org//location/Australia> ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     schema:description "Footprint of study area" ;
     schema:identifier "P0"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
@@ -75,7 +73,6 @@
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     geo:hasGeometry _:N2d5e0873e8e72e68e4a9793300000000,
         _:N53dd57c04e35e4aa3188c0b800000001 ;
-    sosa:isSampleOf <http://createme.org//location/Australia> ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
     schema:identifier "P1"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -26,7 +26,6 @@ a = rdflib.RDF.type
 HABITAT = rdflib.URIRef("http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99")
 CONCEPT_DATA_GENERALIZATIONS = utils.rdf.uri("concept/data-generalizations", utils.namespaces.EXAMPLE)
 DATA_ROLE_RESOURCE_PROVIDER = rdflib.URIRef("https://linked.data.gov.au/def/data-roles/resourceProvider")
-LOCATION_AUSTRALIA = utils.rdf.uri("/location/Australia")
 
 
 # Dataclasses used in mapping
@@ -502,9 +501,6 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         # Add site description if available
         if site_description:
             graph.add((uri, rdflib.SDO.description, rdflib.Literal(site_description)))
-
-        # Add sample of
-        graph.add((uri, rdflib.SOSA.isSampleOf, LOCATION_AUSTRALIA))
 
         # Add locality as location description
         if locality:


### PR DESCRIPTION
Previously `<http://createme.org/location/Australia>` was the terminal featureOfInterest. This was removed when we moved to abis:BiodiversityRecord and dwc:Occurrence in #305. This link should have been removed at that time.