### PR TITLE
BDRSPS-1016 Make siteVisitStart field mandatory for site visit template

### DIFF
--- a/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal-1-row.csv
+++ b/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal-1-row.csv
@@ -1,2 +1,0 @@
-surveyID,siteID,siteIDSource,siteVisitID,siteVisitStart,siteVisitEnd,visitOrgs,visitObservers,condition,targetTaxonomicScope,protocolName,protocolDescription,samplingEffortValue,samplingEffortUnit
-S1,PLOT1,GAIA,VA-99,2024-10-01,2024-10-01,GAIA,John Smith,Burnt,Coleoptera,harpTrapping,Three conventional harp traps,20 x 12,trapDays

--- a/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.csv
+++ b/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.csv
@@ -1,4 +1,4 @@
 surveyID,siteID,siteIDSource,siteVisitID,siteVisitStart,siteVisitEnd,visitOrgs,visitObservers,condition,targetTaxonomicScope,protocolName,protocolDescription,samplingEffortValue,samplingEffortUnit
 TIS-24-03,P1,WAM,TIS-24-03-P1-01,2024-03-12,2024-04-04,WAM | DBCA,ORCID00001 | ORCID00002,dry,new_taxon,wet pitfall trap,10 x square buckets of size 20 x 20 x 15 cm. Propylene glycol.,240,trap nights
-TIS-24-03,P1,WAM,TIS-24-03-P1-02,,2024-03-12,WAM,ORCID00001,moist leaf litter after recent rain,invertebrate,litter sifting,50 cm diameter sifter with 5 mm mesh. Litter samles taken ~1 metre from each pitfall trap,10,sifts
+TIS-24-03,P1,WAM,TIS-24-03-P1-02,2024-03-12,2024-03-12,WAM,ORCID00001,moist leaf litter after recent rain,invertebrate,litter sifting,50 cm diameter sifter with 5 mm mesh. Litter samles taken ~1 metre from each pitfall trap,10,sifts
 TIS-24-03,P1,WAM,TIS-24-03-P1-03,2024-03-12,,WAM,ORCID00003,,bird,human observation,,,

--- a/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl
@@ -182,6 +182,8 @@
 <http://createme.org/SiteVisit/TIS-24-03-P1-02> a tern:SiteVisit ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Visit-Dataset> ;
     time:hasTime [ a time:TemporalEntity ;
+            time:hasBeginning [ a time:Instant ;
+                    time:inXSDDate "2024-03-12"^^xsd:date ] ;
             time:hasEnd [ a time:Instant ;
                     time:inXSDDate "2024-03-12"^^xsd:date ] ] ;
     prov:hadPlan <http://createme.org/visit/plan/TIS-24-03-P1-02> ;

--- a/abis_mapping/templates/survey_site_visit_data_v2/schema.json
+++ b/abis_mapping/templates/survey_site_visit_data_v2/schema.json
@@ -53,7 +53,7 @@
             "type": "timestamp",
             "format": "default",
             "constraints": {
-                "required": false
+                "required": true
             }
         },
         {

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -283,13 +283,13 @@ TEST_CASES_ALL: list[TemplateTestParameters] = [
                 expected=pathlib.Path("abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl"),
             ),
             MappingParameters(
-                scenario_name="missing_start_or_end_date",
+                scenario_name="missing_start_date",
                 data=pathlib.Path(
                     "abis_mapping/templates/survey_site_visit_data_v2/examples/minimal-error-no-dates.csv"
                 ),
                 expected=None,
                 should_validate=False,
-                expected_error_codes={"row-constraint"},
+                expected_error_codes={"constraint-error"},
             ),
             MappingParameters(
                 scenario_name="dates_in_wrong_order",


### PR DESCRIPTION
This has flow-on effects;
* Remove OR check for ["siteVisitStart", "siteVisitEnd"]. This is redundant since siteVisitStart is always present.
* Remove cross-validation check for "siteVisitStart OR siteVisitID in occurrence template". This is redundant since siteVisitStart is always present.