### PR TITLE
BDRSPS-1025 Changed related site uri creation logic

### DIFF
--- a/abis_mapping/templates/survey_site_data_v2/examples/minimal.csv
+++ b/abis_mapping/templates/survey_site_data_v2/examples/minimal.csv
@@ -1,3 +1,4 @@
 siteID,siteIDSource,siteType,siteName,siteDescription,habitat,relatedSiteID,relationshipToRelatedSite,locality,decimalLatitude,decimalLongitude,footprintWKT,geodeticDatum,coordinateUncertaintyInMeters,dataGeneralizations
 P0,WAM,Site,ParentSite,Footprint of study area,Closed forest,,,Cowaramup Bay Road,,,"POLYGON ((114.98 -33.85, 115.01 -33.85, 115.01 -33.87, 114.98 -33.87, 114.98 -33.85))",WGS84,50,
 P1,WAM,Plot,Plot 1,Fine woody debris.,Closed forest,P0,partOf,Cowaramup Bay Road,-33.85,114.99,"LINESTRING (114.99 -33.85, 115.00 -33.85)",WGS84,50,Coordinates rounded to the nearest 10 km for conservation concern
+P2,WAM,Plot,Plot 2,Fine woody debris.,Closed forest,http://example.com/sites/S0,sameAs,Cowaramup Bay Road,-33.85,114.99,"LINESTRING (114.99 -33.85, 115.00 -33.85)",WGS84,50,Coordinates rounded to the nearest 10 km for conservation concern

--- a/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
@@ -11,14 +11,16 @@
 <http://createme.org/SiteCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     schema:identifier "Site Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
-    schema:member <http://createme.org/Site/P1> ;
+    schema:member <http://createme.org/Site/P1>,
+        <http://createme.org/Site/P2> ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
 
 <http://createme.org/SiteCollection/habitat/Closed-forest> a schema:Collection ;
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     schema:identifier "Site Collection - Habitat - Closed forest" ;
     schema:member <http://createme.org/Site/P0>,
-        <http://createme.org/Site/P1> ;
+        <http://createme.org/Site/P1>,
+        <http://createme.org/Site/P2> ;
     tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest> .
 
 <http://createme.org/datatype/datasetID/Gaia-Resources> a rdfs:Datatype ;
@@ -81,6 +83,19 @@
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
+<http://createme.org/Site/P2> a tern:Site ;
+    void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
+    geo:hasGeometry _:N2d5e0873e8e72e68e4a9793300000001,
+        _:N53dd57c04e35e4aa3188c0b800000002 ;
+    sosa:isSampleOf <http://createme.org//location/Australia> ;
+    schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
+    schema:description "Fine woody debris." ;
+    schema:identifier "P2"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
+    schema:name "Plot 2" ;
+    schema:sameAs <http://example.com/sites/S0> ;
+    tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
+    tern:locationDescription "Cowaramup Bay Road" .
+
 <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> a tern:Dataset ;
     schema:dateCreated "2020-01-01"^^xsd:date ;
     schema:dateIssued "2020-01-01"^^xsd:date ;
@@ -107,6 +122,15 @@
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
+            geo:hasMetricSpatialAccuracy 5e+01 ] ;
+    rdf:object _:N53dd57c04e35e4aa3188c0b800000002 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/Site/P2> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.85 114.99)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
     rdf:object _:N2d5e0873e8e72e68e4a9793300000000 ;
@@ -114,7 +138,20 @@
     rdf:subject <http://createme.org/Site/P1> ;
     rdfs:comment "supplied as" .
 
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.85 114.99)"^^geo:wktLiteral ;
+            geo:hasMetricSpatialAccuracy 5e+01 ] ;
+    rdf:object _:N2d5e0873e8e72e68e4a9793300000001 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <http://createme.org/Site/P2> ;
+    rdfs:comment "supplied as" .
+
 _:N2d5e0873e8e72e68e4a9793300000000 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
+    geo:hasMetricSpatialAccuracy 5e+01 .
+
+_:N2d5e0873e8e72e68e4a9793300000001 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
@@ -123,6 +160,10 @@ _:N53dd57c04e35e4aa3188c0b800000000 a geo:Geometry ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
 _:N53dd57c04e35e4aa3188c0b800000001 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
+    geo:hasMetricSpatialAccuracy 5e+01 .
+
+_:N53dd57c04e35e4aa3188c0b800000002 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 

--- a/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
@@ -87,7 +87,6 @@
     void:inDataset <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     geo:hasGeometry _:N2d5e0873e8e72e68e4a9793300000001,
         _:N53dd57c04e35e4aa3188c0b800000002 ;
-    sosa:isSampleOf <http://createme.org//location/Australia> ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
     schema:identifier "P2"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -283,9 +283,14 @@ class SurveySiteMapper(base.mapper.ABISMapper):
 
         # Conditionally create uri dependent on relatedSiteID
         related_site_id: str | None = row["relatedSiteID"]
+        relationship_to_related_site: str | None = row["relationshipToRelatedSite"]
+        relationship_to_related_site_vocab = self.fields()["relationshipToRelatedSite"].get_vocab()
         if related_site_id:
-            # Determine related site URI based on related site string
-            if utils.rdf.uri_or_string_literal(related_site_id).datatype is None:
+            # Determine related site URI based on relationship to related site vocab
+            if (
+                relationship_to_related_site_vocab(graph=rdflib.Graph()).get(relationship_to_related_site)
+                == rdflib.SDO.isPartOf
+            ):
                 # related site URI is a site in this dataset
                 related_site = utils.iri_patterns.site_iri(base_iri, related_site_id)
             else:
@@ -450,7 +455,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             dataset: Dataset to which data belongs.
             site_id_datatype: Datatype to use for
                 the site id literal.
-            related_site:
+            related_site: Related site uri.
             row: Row to retrieve data from.
             graph: Graph to be modified.
             base_iri: Namespace used to construct IRIs


### PR DESCRIPTION
It is now dependent on the `relationshipToRelatedSite` field and if `schema:sameAs` then the related site ID is assumed to be a valid iri. 