### PR TITLE
BDRSPS-1029 Refactor so that extra_fields_schema is only called once per template mapping

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -187,16 +187,18 @@ class ABISMapper(abc.ABC):
         subject_uri: rdflib.URIRef,
         row: frictionless.Row,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
     ) -> None:
         """Adds additional fields data to graph as JSON if values exist.
 
         Args:
-            subject_uri (rdflib.URIRef): Node for the JSON data to be attached.
-            row (frictionless.Row): Row containing all data including extras.
-            graph (rdflib.Graph): Graph to be modified.
+            subject_uri: Node for the JSON data to be attached.
+            row: Row containing all data including extras.
+            graph: Graph to be modified.
+            extra_schema: Schema of extra fields. From calling extra_fields_schema(..., full_schema=False).
         """
         # Extract fields and determine if any values
-        extra_fields = cls.extract_extra_fields(row)
+        extra_fields = cls.extract_extra_fields(row, extra_schema)
         if extra_fields == {}:
             return
 
@@ -212,18 +214,17 @@ class ABISMapper(abc.ABC):
     def extract_extra_fields(
         cls,
         row: frictionless.Row,
+        extra_schema: frictionless.Schema,
     ) -> dict[str, Any]:
         """Extracts extra values from a row not in template schema.
 
         Args:
-            row (frictionless.Row): Row of data including extra rows.
+            row: Row of data including extra rows.
+            extra_schema: Schema of extra fields. From calling extra_fields_schema(..., full_schema=False).
 
         Returns:
             dict[str, Any]: Dictionary containing extra values, if any.
         """
-        # Get schema consisting of extra fields
-        extra_schema = cls.extra_fields_schema(row)
-
         # Create dictionary consisting row data from extra fields only
         return {field: row[field] for field in extra_schema.field_names if row[field] is not None}
 

--- a/abis_mapping/templates/incidental_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v2/mapping.py
@@ -169,6 +169,10 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -213,6 +217,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                     dataset=dataset_iri,
                     terminal_foi=terminal_foi,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                 )
 
@@ -235,6 +240,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         terminal_foi: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace] = None,
     ) -> rdflib.Graph:
         """Applies Mapping for a Row in the `incidental_occurrence_data.csv` Template
@@ -244,6 +250,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             dataset (rdflib.URIRef): Dataset uri this row is apart of.
             terminal_foi (rdflib.URIRef): Terminal feature of interest.
             graph (rdflib.Graph): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI namespace
                 to use for mapping.
 
@@ -857,6 +864,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             subject_uri=sampling_field,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
         # Return

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -171,6 +171,10 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -204,6 +208,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                     row=row,
                     dataset=dataset_iri,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                 )
 
@@ -225,6 +230,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace] = None,
     ) -> rdflib.Graph:
         """Applies Mapping for a Row in the `incidental_occurrence_data.csv` Template
@@ -233,6 +239,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to be processed in the dataset.
             dataset (rdflib.URIRef): Dataset uri this row is apart of.
             graph (rdflib.Graph): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI namespace
                 to use for mapping.
 
@@ -1149,6 +1156,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             subject_uri=provider_record_id_occurrence,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
         # Return

--- a/abis_mapping/templates/survey_metadata/mapping.py
+++ b/abis_mapping/templates/survey_metadata/mapping.py
@@ -138,6 +138,10 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -171,6 +175,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
                     row=row,
                     dataset=dataset_iri,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                 )
 
@@ -181,6 +186,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace] = None,
     ) -> None:
         """Applies mapping for a row in the `survey_metadata.csv` template.
@@ -189,6 +195,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to be processed in the dataset.
             dataset (rdflib.URIRef): Dataset IRI this row is a part of.
             graph (rdflib.URIRef): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI
                 to use for mapping.
         """
@@ -392,6 +399,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             subject_uri=survey,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
     def add_project(

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -129,6 +129,10 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -162,6 +166,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
                     row=row,
                     dataset=dataset_iri,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                 )
 
@@ -172,6 +177,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace] = None,
     ) -> None:
         """Applies mapping for a row in the `survey_metadata.csv` template.
@@ -180,6 +186,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to be processed in the dataset.
             dataset (rdflib.URIRef): Dataset IRI this row is a part of.
             graph (rdflib.URIRef): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI
                 to use for mapping.
         """
@@ -402,6 +409,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             subject_uri=survey,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
     def add_project(

--- a/abis_mapping/templates/survey_occurrence_data/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data/mapping.py
@@ -239,6 +239,10 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -283,6 +287,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                     dataset=dataset_iri,
                     terminal_foi=terminal_foi,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                     site_id_geometry_map=site_id_geometry_map,
                 )
@@ -306,6 +311,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         terminal_foi: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace] = None,
         site_id_geometry_map: dict[str, str] | None = None,
     ) -> rdflib.Graph:
@@ -316,6 +322,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             dataset (rdflib.URIRef): Dataset uri this row is a part of.
             terminal_foi (rdflib.URIRef): Terminal feature of interest.
             graph (rdflib.Graph): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI namespace
                 to use for mapping.
             site_id_geometry_map (dict[str, str] | None): Optional site id to geometry
@@ -973,6 +980,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             subject_uri=sampling_field,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
         # Return

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -294,6 +294,10 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -327,6 +331,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                     row=row,
                     dataset=dataset_iri,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                     site_id_geometry_map=site_id_geometry_map,
                     site_visit_id_temporal_map=site_visit_id_temporal_map,
@@ -350,6 +355,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace] = None,
         site_id_geometry_map: dict[str, str] | None = None,
         site_visit_id_temporal_map: dict[str, str] | None = None,
@@ -360,6 +366,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to be processed in the dataset.
             dataset (rdflib.URIRef): Dataset uri this row is a part of.
             graph (rdflib.Graph): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI namespace
                 to use for mapping.
             site_id_geometry_map (dict[str, str] | None): Optional site id to geometry
@@ -1336,6 +1343,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             subject_uri=provider_record_id_occurrence,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
         # Return

--- a/abis_mapping/templates/survey_site_data/mapping.py
+++ b/abis_mapping/templates/survey_site_data/mapping.py
@@ -218,6 +218,10 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -251,6 +255,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
                     row=row,
                     dataset=dataset_iri,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                 )
 
@@ -261,6 +266,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace],
     ) -> None:
         """Applies mapping for a row in the `survey_site_data.csv` template.
@@ -269,6 +275,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to be processed in the dataset.
             dataset (rdflib.URIRef): Dataset IRI this row is a part of.
             graph (rdflib.URIRef): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI
                 to use for mapping.
         """
@@ -452,6 +459,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             subject_uri=site,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
     def add_site(

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -211,6 +211,10 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             data=data,
             full_schema=True,
         )
+        extra_schema = self.extra_fields_schema(
+            data=data,
+            full_schema=False,
+        )
 
         # Construct Resource
         resource = frictionless.Resource(
@@ -244,6 +248,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
                     row=row,
                     dataset=dataset_iri,
                     graph=graph,
+                    extra_schema=extra_schema,
                     base_iri=base_iri,
                 )
 
@@ -254,6 +259,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
         base_iri: Optional[rdflib.Namespace],
     ) -> None:
         """Applies mapping for a row in the `survey_site_data.csv` template.
@@ -262,6 +268,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             row (frictionless.Row): Row to be processed in the dataset.
             dataset (rdflib.URIRef): Dataset IRI this row is a part of.
             graph (rdflib.URIRef): Graph to map row into.
+            extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (Optional[rdflib.Namespace]): Optional base IRI
                 to use for mapping.
         """
@@ -431,6 +438,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             subject_uri=site,
             row=row,
             graph=graph,
+            extra_schema=extra_schema,
         )
 
     def add_site(

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -291,6 +291,8 @@ def test_extract_extra_fields(mocker: pytest_mock.MockerFixture) -> None:
 
     # Construct schema (includes extra fields)
     schema = base.mapper.ABISMapper.extra_fields_schema(csv_data, full_schema=True)
+    # construct schema just for extra fields
+    extra_schema = base.mapper.ABISMapper.extra_fields_schema(csv_data, full_schema=False)
 
     # Construct resource
     resource = frictionless.Resource(
@@ -304,7 +306,7 @@ def test_extract_extra_fields(mocker: pytest_mock.MockerFixture) -> None:
     with resource.open() as r:
         # Iterate over rows and expected outputs for validation.
         for row, expected in zip(r.row_stream, overall_expected, strict=True):
-            assert base.mapper.ABISMapper.extract_extra_fields(row) == expected
+            assert base.mapper.ABISMapper.extract_extra_fields(row, extra_schema) == expected
 
 
 def test_add_extra_fields_json(mocker: pytest_mock.MockerFixture) -> None:
@@ -331,6 +333,9 @@ def test_add_extra_fields_json(mocker: pytest_mock.MockerFixture) -> None:
     # Mock out the schema method to return the above descriptor
     mocker.patch.object(base.mapper.ABISMapper, "schema").return_value = descriptor
 
+    # construct schema just for extra fields
+    extra_schema = base.mapper.ABISMapper.extra_fields_schema(csv_data, full_schema=False)
+
     # Expected json as dictionary
     expected_json = {"extraInformation2": "some more info", "extraInformation1": "some additional info"}
 
@@ -354,6 +359,7 @@ def test_add_extra_fields_json(mocker: pytest_mock.MockerFixture) -> None:
         subject_uri=base_uri,
         row=row,
         graph=graph,
+        extra_schema=extra_schema,
     )
 
     # Assert
@@ -384,6 +390,9 @@ def test_add_extra_fields_json_no_data(mocker: pytest_mock.MockerFixture) -> Non
     # Mock out the schema method to return the above descriptor
     mocker.patch.object(base.mapper.ABISMapper, "schema").return_value = descriptor
 
+    # construct schema just for extra fields
+    extra_schema = base.mapper.ABISMapper.extra_fields_schema(csv_data, full_schema=False)
+
     # Create resource from raw data with derived schema
     resource = frictionless.Resource(
         source=csv_data,
@@ -404,6 +413,7 @@ def test_add_extra_fields_json_no_data(mocker: pytest_mock.MockerFixture) -> Non
         subject_uri=base_uri,
         row=row,
         graph=graph,
+        extra_schema=extra_schema,
     )
 
     # Should have no triples


### PR DESCRIPTION
Call `extra_fields_schema(..., full_schema=False)` once per template, rather than once per row.

This is an expensive function, so this should give a noticeable performance improvement.
My testing locally shows a 13% speedup when mapping a incidental v3 template with 1000 rows.

Since all the rows of a template have the same extra fields, this is a safe refactor.