### PR TITLE
BDRSPS-1038 Ensure that every chunk has a dataset type triple

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -188,8 +188,11 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         graph = utils.rdf.create_graph()
 
         # Check if Dataset IRI Supplied
-        if not dataset_iri:
-            # Create Dataset IRI
+        if dataset_iri:
+            # If supplied, add just the dataset type.
+            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
+        else:
+            # If not supplied, create example "default" Dataset IRI
             dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
 
             # Add Example Default Dataset if not Supplied
@@ -221,6 +224,8 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
                     # Initialise New Graph
                     graph = utils.rdf.create_graph()
+                    # Every chunk should have this node
+                    graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
 
             # Yield
             yield graph

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -146,8 +146,11 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         graph = utils.rdf.create_graph()
 
         # Check if Dataset IRI Supplied
-        if not dataset_iri:
-            # Create Dataset IRI
+        if dataset_iri:
+            # If supplied, add just the dataset type.
+            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
+        else:
+            # If not supplied, create example "default" Dataset IRI
             dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
 
             # Add the default dataset

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -311,8 +311,11 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         graph = utils.rdf.create_graph()
 
         # Check if Dataset IRI Supplied
-        if not dataset_iri:
-            # Create Dataset IRI
+        if dataset_iri:
+            # If supplied, add just the dataset type.
+            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
+        else:
+            # If not supplied, create example "default" Dataset IRI
             dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
 
             # Add Example Default Dataset if not Supplied
@@ -346,6 +349,8 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
                     # Initialise New Graph
                     graph = utils.rdf.create_graph()
+                    # Every chunk should have this node
+                    graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
 
             # Yield
             yield graph

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -228,8 +228,11 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         graph = utils.rdf.create_graph()
 
         # Check if Dataset IRI Supplied
-        if not dataset_iri:
-            # Create Dataset IRI
+        if dataset_iri:
+            # If supplied, add just the dataset type.
+            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
+        else:
+            # If not supplied, create example "default" Dataset IRI
             dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
 
             # Add the default dataset

--- a/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
@@ -249,8 +249,11 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         graph_has_data: bool = False
 
         # Check if Dataset IRI Supplied
-        if not dataset_iri:
-            # Create Dataset IRI
+        if dataset_iri:
+            # If supplied, add just the dataset type.
+            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
+        else:
+            # If not supplied, create example "default" Dataset IRI
             dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
 
             # Add the default dataset
@@ -280,6 +283,8 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
                     # Initialise New Graph for next chunk
                     graph = utils.rdf.create_graph()
                     graph_has_data = False
+                    # Every chunk should have this node
+                    graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
 
             # yield final chunk, or whole graph if not chunking.
             if chunk_size is None or graph_has_data:


### PR DESCRIPTION
Every chunk of RDF output should include a `<...> a tern:Dataset` triple, to make them valid RDF