### PR TITLE
BDRSPS-1028 Add internal siteID validation for relatedSiteID when relationship is `partOf`

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,6 +27,9 @@ ignore_missing_imports = True
 [mypy-pyshacl.*]
 ignore_missing_imports = True
 
+[mypy-simpleeval.*]
+ignore_missing_imports = True
+
 [mypy-numpy.*]
 follow_imports = skip
 follow_imports_for_stubs = True

--- a/abis_mapping/plugins/__init__.py
+++ b/abis_mapping/plugins/__init__.py
@@ -12,6 +12,7 @@ from . import lookup_match
 from . import mutual_exclusion
 from . import mutual_inclusion
 from . import required
+from . import row_constraint
 from . import sites_geometry
 from . import tabular
 from . import timestamp

--- a/abis_mapping/plugins/lookup_match.py
+++ b/abis_mapping/plugins/lookup_match.py
@@ -11,7 +11,7 @@ from typing import Iterator, Mapping
 
 @attrs.define(kw_only=True, repr=False)
 class VLookupMatch(frictionless.Check):
-    """Takes the as a key, the value of one column to perform a VLOOKUP style check.
+    """Takes as a key, the value of one column to perform a VLOOKUP style check.
 
     Validation fails if the cell value for `key_field` does not match any keys of the provided
     map. If a null value for key is encountered then check is bypassed.

--- a/abis_mapping/plugins/row_constraint.py
+++ b/abis_mapping/plugins/row_constraint.py
@@ -1,0 +1,80 @@
+"""Provides more generic custom implementations of the row_constraint check"""
+
+# Third-party
+import attrs
+import frictionless
+import frictionless.checks
+import frictionless.errors
+import simpleeval
+
+# Typing
+from typing import Any, Mapping, Iterable
+
+
+class SideInputError(frictionless.errors.TableError):
+    type = "side-input"
+    title = "Side Input Error"
+    description = "This error can happen if there is issue with provided side input data."
+    template = "The side input data does not comply with requirements: {note}"
+
+
+@attrs.define(kw_only=True, repr=False)
+class RowConstraintSideInput(frictionless.checks.row_constraint):
+    """Implementation of row_constraint providing a side input.
+
+    A way of providing simplistic forms of custom validation on a
+    row-wise basis, through provision of a formula as a string.
+
+    Attributes:
+        side_inputs: Map of names and extra values to provide to
+            formula.
+        original_schema: Optional schema to limit the names that can
+            be used by the formula, preventing extra fields being
+            injected into validation.
+        _field_names: List of field names included in the schema to be
+            used by the check. Populated at the start of validation.
+    """
+
+    Errors = [frictionless.errors.RowConstraintError, SideInputError]
+    side_inputs: Mapping[str, Any]
+    original_schema: frictionless.Schema | None = None
+    _field_names: list[str] = attrs.field(factory=list, alias="field_names")
+
+    def validate_start(self) -> Iterable[SideInputError]:
+        """Start of validation
+
+        Yields:
+            If there is an unresolvable name clash between the side
+                inputs and the row fieldnames.
+        """
+        # Determine which schema to use
+        schema = self.original_schema or self.resource.schema
+        # Assign field names to be used in later validations
+        self._field_names = [*schema.field_names]
+        clashes: set[str] = set(self.side_inputs).intersection(set(self._field_names))
+        if clashes:
+            yield SideInputError(note=f"Name clashes between side inputs and schema: {clashes}")
+
+    def validate_row(self, row: frictionless.Row) -> Iterable[frictionless.Error]:
+        """Validate row (every row).
+
+        Args:
+            row: Row of data to be validated.
+
+        Yields:
+            Errors encountered, if any
+        """
+        try:
+            # Check original_schema
+            # Filter names based on schema originally supplied - no additional columns can be used
+            names: dict[str, object] = {k: v for k, v in row.items() if k in self._field_names}
+            # Concatenate the the side inputs
+            names.update(self.side_inputs)
+            # This call should be considered as a safe expression evaluation
+            evalclass = simpleeval.EvalWithCompoundTypes
+            assert evalclass(names=names).eval(self.formula)  # noqa: S101
+        except Exception:
+            yield frictionless.errors.RowConstraintError.from_row(
+                row,
+                note='the row constraint to conform is "%s"' % self.formula,
+            )

--- a/poetry.lock
+++ b/poetry.lock
@@ -2343,4 +2343,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "66fa1da7077ac329fc68b888a612e7c168d32c9d62b2aab04766874caab65702"
+content-hash = "ea51ced1ad855f40fd4520a29aa8f0e19975e9a0b17afa7151e31e83da5ca412"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pydantic = "^2.9.2"
 pydantic-settings = "^2.6.0"
 numpy = "^2.1.2"
 attrs = "^24.2.0"
+simpleeval = "^1.0.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/tests/plugins/test_row_constraint.py
+++ b/tests/plugins/test_row_constraint.py
@@ -1,0 +1,68 @@
+"""Provides tests for the custom row_constraint checks."""
+
+# Third-party
+import frictionless
+import frictionless.checks
+
+# Local
+from abis_mapping import plugins
+
+
+def test_validate_row_constraint_side_input() -> None:
+    """Tests the RowConstraintSideInput check."""
+    source = [
+        ["row", "salary", "bonus"],
+        [2, 1100, 200],
+        [3, 2600, 500],
+        [4, 1300, 500],
+        [5, 5100, 1000],
+        [6],
+    ]
+    resource = frictionless.Resource(source=source)
+    checklist = frictionless.Checklist(
+        checks=[
+            plugins.row_constraint.RowConstraintSideInput(
+                formula="salary == bonus * 5 + superannuation",
+                side_inputs={"superannuation": 100},
+            )
+        ]
+    )
+    report = resource.validate(checklist)
+    assert report.flatten(["rowNumber", "fieldNumber", "type"]) == [
+        [4, None, "row-constraint"],
+        [6, 2, "missing-cell"],
+        [6, 3, "missing-cell"],
+        [6, None, "row-constraint"],
+    ]
+
+
+def test_validate_row_constraint_list_in_formula_issue_817() -> None:
+    source = [["val"], ["one"], ["two"]]
+    resource = frictionless.Resource(source=source)
+    checklist = frictionless.Checklist(
+        checks=[
+            frictionless.checks.duplicate_row(),
+            plugins.row_constraint.RowConstraintSideInput(
+                formula="val in ['one', 'two']",
+                side_inputs={"val2": ["one"]},
+            ),
+        ],
+    )
+    report = resource.validate(checklist)
+    assert report.valid
+
+
+def test_validate_row_constraint_side_input_name_clash() -> None:
+    source = [["val"], [5], [6]]
+    resource = frictionless.Resource(source=source)
+    checklist = frictionless.Checklist(
+        checks=[
+            frictionless.checks.duplicate_row(),
+            plugins.row_constraint.RowConstraintSideInput(
+                formula="val == 5 or val == 6",
+                side_inputs={"val": 6},
+            ),
+        ],
+    )
+    report = resource.validate(checklist)
+    assert report.flatten(["type"]) == [["side-input"]]

--- a/tests/templates/test_common.py
+++ b/tests/templates/test_common.py
@@ -238,4 +238,4 @@ class TestTemplateBasicSuite:
         mocked_validate.assert_called_once()
         # The following asserts determine that the extra fields schema was used in creating the resource
         mocked_extra_fields_schema.assert_called_once()
-        mocked_resource.assert_called_with(source=data, schema=schema, format="csv", encoding="utf-8")
+        mocked_resource.assert_any_call(source=data, schema=schema, format="csv", encoding="utf-8")


### PR DESCRIPTION
created customised row constraint check to accept side inputs and app…lied that to the validation of relatedSiteID on the site template.

Please feel free to disapprove of the approach, since i see it as a step towards going away from how we have been doing things, making a separate custom checks everytime a simple-ish row constraint validation needs to be performed. Following on from this i think some of the other checks could be decommissioned e.g. LogicalOr, DefaultLookup, Vlookup.