### PR TITLE
BDRSPS-1088 Swap `schema:identifier` for `schema:name` for attribute Collections

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -101,6 +101,7 @@ jobs:
     needs: [poetry-lock]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:

--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -12,127 +12,127 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://createme.org/OccurrenceCollection/basisOfRecord/HumanObservation> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Basis Of Record - HumanObservation" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/14> ;
+    schema:name "Occurrence Collection - Basis Of Record - HumanObservation" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/HumanObservation> .
 
 <http://createme.org/OccurrenceCollection/basisOfRecord/PreservedSpecimen> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/13>,
         <http://createme.org/sample/specimen/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/PreservedSpecimen> .
 
 <http://createme.org/OccurrenceCollection/basisOfRecord/new-basis-of-record> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Basis Of Record - new basis of record" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/ABC123> ;
+    schema:name "Occurrence Collection - Basis Of Record - new basis of record" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/new-basis-of-record> .
 
 <http://createme.org/OccurrenceCollection/conservationAuthority/WA> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Conservation Authority - WA" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/threatStatus/8022FSJMJ079c5cf>,
         <http://createme.org/observation/threatStatus/ABC123> ;
+    schema:name "Occurrence Collection - Conservation Authority - WA" ;
     tern:hasAttribute <http://createme.org/attribute/conservationAuthority/WA> .
 
 <http://createme.org/OccurrenceCollection/dataGeneralizations/Coordinates-generalised> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/ABC123> ;
+    schema:name "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> .
 
 <http://createme.org/OccurrenceCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/14>,
         <http://createme.org/occurrence/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
 
 <http://createme.org/OccurrenceCollection/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
     tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
 <http://createme.org/OccurrenceCollection/habitat/new-habitat> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Habitat - new habitat" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/ABC123> ;
+    schema:name "Occurrence Collection - Habitat - new habitat" ;
     tern:hasAttribute <http://createme.org/attribute/habitat/new-habitat> .
 
 <http://createme.org/OccurrenceCollection/identificationQualifier/> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Qualifier - ?" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/11>,
         <http://createme.org/observation/scientificName/14> ;
+    schema:name "Occurrence Collection - Identification Qualifier - ?" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/> .
 
 <http://createme.org/OccurrenceCollection/identificationQualifier/new-identification-qualifier> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Qualifier - new identification qualifier" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/ABC123> ;
+    schema:name "Occurrence Collection - Identification Qualifier - new identification qualifier" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/new-identification-qualifier> .
 
 <http://createme.org/OccurrenceCollection/identificationQualifier/species-incerta> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Qualifier - species incerta" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Identification Qualifier - species incerta" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/species-incerta> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - Could not confirm the ID due to damaged flower" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/14> ;
+    schema:name "Occurrence Collection - Identification Remarks - Could not confirm the ID due to damaged flower" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - One unopened flower when recorded and one leaf only. ID not confirmed" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/11> ;
+    schema:name "Occurrence Collection - Identification Remarks - One unopened flower when recorded and one leaf only. ID not confirmed" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/new-remarks> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - new remarks" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/ABC123> ;
+    schema:name "Occurrence Collection - Identification Remarks - new remarks" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/new-remarks> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/no-flowers-present> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - no flowers present" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Identification Remarks - no flowers present" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/no-flowers-present> .
 
 <http://createme.org/OccurrenceCollection/preparations/Wet-in-ethanol-or-some-other-preservative> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
     tern:hasAttribute <http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
 <http://createme.org/OccurrenceCollection/preparations/new-preparations> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Preparations - new preparations" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/ABC123> ;
+    schema:name "Occurrence Collection - Preparations - new preparations" ;
     tern:hasAttribute <http://createme.org/attribute/preparations/new-preparations> .
 
 <http://createme.org/OccurrenceCollection/sensitivityCategory/Category-1> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Sensitivity Category - Category 1" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/biodiversityRecord/ABC123> ;
+    schema:name "Occurrence Collection - Sensitivity Category - Category 1" ;
     tern:hasAttribute <http://createme.org/attribute/sensitivityCategory/Category-1> .
 
 <http://createme.org/OccurrenceCollection/taxonRank/new-taxon-rank> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Taxon Rank - new taxon rank" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/ABC123> ;
+    schema:name "Occurrence Collection - Taxon Rank - new taxon rank" ;
     tern:hasAttribute <http://createme.org/attribute/taxonRank/new-taxon-rank> .
 
 <http://createme.org/OccurrenceCollection/taxonRank/species> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Taxon Rank - species" ;
     schema:isPartOf <http://createme.org/dataset/Example-Incidental-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Taxon Rank - species" ;
     tern:hasAttribute <http://createme.org/attribute/taxonRank/species> .
 
 <http://createme.org/biodiversityRecord/1> a abis:BiodiversityRecord ;

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -1539,7 +1539,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Identification Qualifier - {id_qualifier}"),
                 )
             )
@@ -1635,7 +1635,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Identification Remarks - {id_remarks}"),
                 )
             )
@@ -2018,7 +2018,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(
                         f"Occurrence Collection - Data Generalizations - {data_generalizations}",
                     ),
@@ -2129,7 +2129,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Taxon Rank - {taxon_rank}"),
                 )
             )
@@ -2490,7 +2490,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         graph.add((uri, a, rdflib.SDO.Collection))
         # Add identifier
         if habitat:
-            graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(f"Occurrence Collection - Habitat - {habitat}")))
+            graph.add((uri, rdflib.SDO.name, rdflib.Literal(f"Occurrence Collection - Habitat - {habitat}")))
         # Add link to dataset
         graph.add((uri, rdflib.SDO.isPartOf, dataset))
         # add link to the sample field
@@ -2601,7 +2601,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Basis Of Record - {basis_of_record}"),
                 )
             )
@@ -2814,7 +2814,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Preparations - {preparations}"),
                 )
             )
@@ -3618,7 +3618,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Conservation Authority - {conservation_authority}"),
                 )
             )
@@ -3736,7 +3736,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Sensitivity Category - {sensitivity_category}"),
                 )
             )

--- a/abis_mapping/templates/incidental_occurrence_data_v3/validators/validator.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/validators/validator.ttl
@@ -143,7 +143,7 @@ bdrsh:GeneralCollectionShape
 		sh:class tern:Dataset ;
 	] ;
 	sh:property [
-		sh:path schema:identifier ;
+		sh:path schema:name ;
 		sh:nodeKind sh:Literal ;
 		sh:pattern "^Occurrence Collection - (?:Identification Qualifier|Identification Remarks|Data Generalizations|Taxon Rank|Habitat|Basis Of Record|Preparations|Conservation Authority) - " ;
 		sh:datatype xsd:string ;
@@ -169,7 +169,7 @@ bdrsh:SensitivityCategoryCollectionShape
 		sh:class tern:Dataset ;
 	] ;
 	sh:property [
-		sh:path schema:identifier ;
+		sh:path schema:name ;
 		sh:nodeKind sh:Literal ;
 		sh:pattern "^Occurrence Collection - Sensitivity Category - " ;
 		sh:datatype xsd:string ;

--- a/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
@@ -11,27 +11,27 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://createme.org/SurveyCollection/surveyType/Wet-pitfall-trapping> a schema:Collection ;
-    schema:identifier "Survey Collection - Survey Type - Wet pitfall trapping" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
     schema:member <http://createme.org/survey/plan/COL1> ;
+    schema:name "Survey Collection - Survey Type - Wet pitfall trapping" ;
     tern:hasAttribute <http://createme.org/attribute/surveyType/Wet-pitfall-trapping> .
 
 <http://createme.org/SurveyCollection/targetHabitatScope/Woodland> a schema:Collection ;
-    schema:identifier "Survey Collection - Target Habitat Scope - Woodland" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
     schema:member <http://createme.org/survey/plan/COL1> ;
+    schema:name "Survey Collection - Target Habitat Scope - Woodland" ;
     tern:hasAttribute <http://createme.org/attribute/targetHabitatScope/Woodland> .
 
 <http://createme.org/SurveyCollection/targetTaxonomicScope/Coleoptera> a schema:Collection ;
-    schema:identifier "Survey Collection - Target Taxonomic Scope - Coleoptera" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
     schema:member <http://createme.org/survey/plan/COL1> ;
+    schema:name "Survey Collection - Target Taxonomic Scope - Coleoptera" ;
     tern:hasAttribute <http://createme.org/attribute/targetTaxonomicScope/Coleoptera> .
 
 <http://createme.org/SurveyCollection/targetTaxonomicScope/Insecta> a schema:Collection ;
-    schema:identifier "Survey Collection - Target Taxonomic Scope - Insecta" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Metadata-Dataset> ;
     schema:member <http://createme.org/survey/plan/COL1> ;
+    schema:name "Survey Collection - Target Taxonomic Scope - Insecta" ;
     tern:hasAttribute <http://createme.org/attribute/targetTaxonomicScope/Insecta> .
 
 <http://createme.org/datatype/datasetID/Gaia-Resources> a rdfs:Datatype ;

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -761,7 +761,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Survey Collection - Survey Type - {row_survey_type}"),
                 )
             )
@@ -860,7 +860,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         graph.add(
             (
                 uri,
-                rdflib.SDO.identifier,
+                rdflib.SDO.name,
                 rdflib.Literal(f"Survey Collection - Target Habitat Scope - {raw_value}"),
             )
         )
@@ -959,7 +959,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         graph.add(
             (
                 uri,
-                rdflib.SDO.identifier,
+                rdflib.SDO.name,
                 rdflib.Literal(f"Survey Collection - Target Taxonomic Scope - {raw_value}"),
             )
         )

--- a/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -12,128 +12,128 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://createme.org/OccurrenceCollection/basisOfRecord/HumanObservation> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Basis Of Record - HumanObservation" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/14> ;
+    schema:name "Occurrence Collection - Basis Of Record - HumanObservation" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/HumanObservation> .
 
 <http://createme.org/OccurrenceCollection/basisOfRecord/PreservedSpecimen> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/13>,
         <http://createme.org/sample/specimen/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Basis Of Record - PreservedSpecimen" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/PreservedSpecimen> .
 
 <http://createme.org/OccurrenceCollection/basisOfRecord/new-basis-of-record> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Basis Of Record - new basis of record" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/ABC123> ;
+    schema:name "Occurrence Collection - Basis Of Record - new basis of record" ;
     tern:hasAttribute <http://createme.org/attribute/basisOfRecord/new-basis-of-record> .
 
 <http://createme.org/OccurrenceCollection/conservationAuthority/WA> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Conservation Authority - WA" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/threatStatus/8022FSJMJ079c5cf>,
         <http://createme.org/observation/threatStatus/ABC123> ;
+    schema:name "Occurrence Collection - Conservation Authority - WA" ;
     tern:hasAttribute <http://createme.org/attribute/conservationAuthority/WA> .
 
 <http://createme.org/OccurrenceCollection/dataGeneralizations/Coordinates-generalised> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/ABC123> ;
+    schema:name "Occurrence Collection - Data Generalizations - Coordinates generalised" ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-generalised> .
 
 <http://createme.org/OccurrenceCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/14>,
         <http://createme.org/occurrence/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
 
 <http://createme.org/OccurrenceCollection/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Habitat - Closed forest of Melaleuca lanceolata. White, grey or brown sand, sandy loam." ;
     tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest-of-Melaleuca-lanceolata-White-grey-or-brown-sand-sandy-loam> .
 
 <http://createme.org/OccurrenceCollection/habitat/new-habitat> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Habitat - new habitat" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/occurrence/ABC123> ;
+    schema:name "Occurrence Collection - Habitat - new habitat" ;
     tern:hasAttribute <http://createme.org/attribute/habitat/new-habitat> .
 
 <http://createme.org/OccurrenceCollection/identificationQualifier/> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Qualifier - ?" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/11>,
         <http://createme.org/observation/scientificName/14> ;
+    schema:name "Occurrence Collection - Identification Qualifier - ?" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/> .
 
 <http://createme.org/OccurrenceCollection/identificationQualifier/new-identification-qualifier> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Qualifier - new identification qualifier" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/ABC123> ;
+    schema:name "Occurrence Collection - Identification Qualifier - new identification qualifier" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/new-identification-qualifier> .
 
 <http://createme.org/OccurrenceCollection/identificationQualifier/species-incerta> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Qualifier - species incerta" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Identification Qualifier - species incerta" ;
     tern:hasAttribute <http://createme.org/attribute/identificationQualifier/species-incerta> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - Could not confirm the ID due to damaged flower" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/14> ;
+    schema:name "Occurrence Collection - Identification Remarks - Could not confirm the ID due to damaged flower" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/Could-not-confirm-the-ID-due-to-damaged-flower> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - One unopened flower when recorded and one leaf only. ID not confirmed" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/11> ;
+    schema:name "Occurrence Collection - Identification Remarks - One unopened flower when recorded and one leaf only. ID not confirmed" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/One-unopened-flower-when-recorded-and-one-leaf-only-ID-not-confirmed> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/new-remarks> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - new remarks" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/ABC123> ;
+    schema:name "Occurrence Collection - Identification Remarks - new remarks" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/new-remarks> .
 
 <http://createme.org/OccurrenceCollection/identificationRemarks/no-flowers-present> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Identification Remarks - no flowers present" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Identification Remarks - no flowers present" ;
     tern:hasAttribute <http://createme.org/attribute/identificationRemarks/no-flowers-present> .
 
 <http://createme.org/OccurrenceCollection/preparations/Wet-in-ethanol-or-some-other-preservative> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Preparations - Wet (in ethanol or some other preservative)" ;
     tern:hasAttribute <http://createme.org/attribute/preparations/Wet-in-ethanol-or-some-other-preservative> .
 
 <http://createme.org/OccurrenceCollection/preparations/new-preparations> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Preparations - new preparations" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/sample/specimen/ABC123> ;
+    schema:name "Occurrence Collection - Preparations - new preparations" ;
     tern:hasAttribute <http://createme.org/attribute/preparations/new-preparations> .
 
 <http://createme.org/OccurrenceCollection/sensitivityCategory/Category-1> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Sensitivity Category - Category 1" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/biodiversityRecord/8022FSJMJ079c5cf>,
         <http://createme.org/biodiversityRecord/ABC123> ;
+    schema:name "Occurrence Collection - Sensitivity Category - Category 1" ;
     tern:hasAttribute <http://createme.org/attribute/sensitivityCategory/Category-1> .
 
 <http://createme.org/OccurrenceCollection/taxonRank/new-taxon-rank> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Taxon Rank - new taxon rank" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/ABC123> ;
+    schema:name "Occurrence Collection - Taxon Rank - new taxon rank" ;
     tern:hasAttribute <http://createme.org/attribute/taxonRank/new-taxon-rank> .
 
 <http://createme.org/OccurrenceCollection/taxonRank/species> a schema:Collection ;
-    schema:identifier "Occurrence Collection - Taxon Rank - species" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Occurrence-Dataset> ;
     schema:member <http://createme.org/observation/scientificName/8022FSJMJ079c5cf> ;
+    schema:name "Occurrence Collection - Taxon Rank - species" ;
     tern:hasAttribute <http://createme.org/attribute/taxonRank/species> .
 
 <http://createme.org/biodiversityRecord/1> a abis:BiodiversityRecord ;

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -1839,7 +1839,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Identification Qualifier - {id_qualifier}"),
                 )
             )
@@ -1935,7 +1935,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Identification Remarks - {id_remarks}"),
                 )
             )
@@ -2355,7 +2355,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(
                         f"Occurrence Collection - Data Generalizations - {data_generalizations}",
                     ),
@@ -2466,7 +2466,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Taxon Rank - {taxon_rank}"),
                 )
             )
@@ -2761,7 +2761,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         graph.add((uri, a, rdflib.SDO.Collection))
         # Add identifier
         if habitat:
-            graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(f"Occurrence Collection - Habitat - {habitat}")))
+            graph.add((uri, rdflib.SDO.name, rdflib.Literal(f"Occurrence Collection - Habitat - {habitat}")))
         # Add link to dataset
         graph.add((uri, rdflib.SDO.isPartOf, dataset))
         # add link to the sample field
@@ -2872,7 +2872,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Basis Of Record - {basis_of_record}"),
                 )
             )
@@ -3105,7 +3105,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Preparations - {preparations}"),
                 )
             )
@@ -4059,7 +4059,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Conservation Authority - {conservation_authority}"),
                 )
             )
@@ -4325,7 +4325,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Occurrence Collection - Sensitivity Category - {sensitivity_category}"),
                 )
             )

--- a/abis_mapping/templates/survey_occurrence_data_v2/validators/validator.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v2/validators/validator.ttl
@@ -143,7 +143,7 @@ bdrsh:GeneralCollectionShape
 		sh:class tern:Dataset ;
 	] ;
 	sh:property [
-		sh:path schema:identifier ;
+		sh:path schema:name ;
 		sh:nodeKind sh:Literal ;
 		sh:pattern "^Occurrence Collection - (?:Identification Qualifier|Identification Remarks|Data Generalizations|Taxon Rank|Habitat|Basis Of Record|Preparations|Conservation Authority) - " ;
 		sh:datatype xsd:string ;
@@ -169,7 +169,7 @@ bdrsh:SensitivityCategoryCollectionShape
 		sh:class tern:Dataset ;
 	] ;
 	sh:property [
-		sh:path schema:identifier ;
+		sh:path schema:name ;
 		sh:nodeKind sh:Literal ;
 		sh:pattern "^Occurrence Collection - Sensitivity Category - " ;
 		sh:datatype xsd:string ;

--- a/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
@@ -8,20 +8,20 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://createme.org/SiteCollection/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a schema:Collection ;
-    schema:identifier "Site Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     schema:member <http://createme.org/Site/P1>,
         <http://createme.org/Site/P2>,
         <http://createme.org/Site/P3> ;
+    schema:name "Site Collection - Data Generalizations - Coordinates rounded to the nearest 10 km for conservation concern" ;
     tern:hasAttribute <http://createme.org/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> .
 
 <http://createme.org/SiteCollection/habitat/Closed-forest> a schema:Collection ;
-    schema:identifier "Site Collection - Habitat - Closed forest" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Dataset> ;
     schema:member <http://createme.org/Site/P0>,
         <http://createme.org/Site/P1>,
         <http://createme.org/Site/P2>,
         <http://createme.org/Site/P3> ;
+    schema:name "Site Collection - Habitat - Closed forest" ;
     tern:hasAttribute <http://createme.org/attribute/habitat/Closed-forest> .
 
 <http://createme.org/datatype/datasetID/Gaia-Resources> a rdfs:Datatype ;

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -719,7 +719,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         # Add type
         graph.add((uri, a, rdflib.SDO.Collection))
         # Add identifier
-        graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(f"Site Collection - Habitat - {raw_habitat_value}")))
+        graph.add((uri, rdflib.SDO.name, rdflib.Literal(f"Site Collection - Habitat - {raw_habitat_value}")))
         # Add link to dataset
         graph.add((uri, rdflib.SDO.isPartOf, dataset))
         # add link to this site
@@ -813,7 +813,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Site Collection - Data Generalizations - {raw_data_generalizations_value}"),
                 )
             )

--- a/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl
@@ -9,33 +9,33 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://createme.org/SiteVisitCollection/samplingEffort/10-sifts> a schema:Collection ;
-    schema:identifier "Site Visit Collection - Sampling Effort - 10 sifts" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Visit-Dataset> ;
     schema:member <http://createme.org/SiteVisit/TIS-24-03-P1-02> ;
+    schema:name "Site Visit Collection - Sampling Effort - 10 sifts" ;
     tern:hasAttribute <http://createme.org/attribute/samplingEffort/10-sifts> .
 
 <http://createme.org/SiteVisitCollection/samplingEffort/240-trap-nights> a schema:Collection ;
-    schema:identifier "Site Visit Collection - Sampling Effort - 240 trap nights" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Visit-Dataset> ;
     schema:member <http://createme.org/SiteVisit/TIS-24-03-P1-01> ;
+    schema:name "Site Visit Collection - Sampling Effort - 240 trap nights" ;
     tern:hasAttribute <http://createme.org/attribute/samplingEffort/240-trap-nights> .
 
 <http://createme.org/SiteVisitCollection/targetTaxonomicScope/bird> a schema:Collection ;
-    schema:identifier "Site Visit Collection - Target Taxonomic Scope - bird" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Visit-Dataset> ;
     schema:member <http://createme.org/SiteVisit/TIS-24-03-P1-03> ;
+    schema:name "Site Visit Collection - Target Taxonomic Scope - bird" ;
     tern:hasAttribute <http://createme.org/attribute/targetTaxonomicScope/bird> .
 
 <http://createme.org/SiteVisitCollection/targetTaxonomicScope/invertebrate> a schema:Collection ;
-    schema:identifier "Site Visit Collection - Target Taxonomic Scope - invertebrate" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Visit-Dataset> ;
     schema:member <http://createme.org/SiteVisit/TIS-24-03-P1-02> ;
+    schema:name "Site Visit Collection - Target Taxonomic Scope - invertebrate" ;
     tern:hasAttribute <http://createme.org/attribute/targetTaxonomicScope/invertebrate> .
 
 <http://createme.org/SiteVisitCollection/targetTaxonomicScope/new-taxon> a schema:Collection ;
-    schema:identifier "Site Visit Collection - Target Taxonomic Scope - new_taxon" ;
     schema:isPartOf <http://createme.org/dataset/Example-Systematic-Survey-Site-Visit-Dataset> ;
     schema:member <http://createme.org/SiteVisit/TIS-24-03-P1-01> ;
+    schema:name "Site Visit Collection - Target Taxonomic Scope - new_taxon" ;
     tern:hasAttribute <http://createme.org/attribute/targetTaxonomicScope/new-taxon> .
 
 <http://createme.org/datatype/datasetID/Gaia-Resources> a rdfs:Datatype ;

--- a/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
@@ -914,7 +914,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Site Visit Collection - Target Taxonomic Scope - {row_target_taxonomic_scope}"),
                 )
             )
@@ -1032,7 +1032,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             graph.add(
                 (
                     uri,
-                    rdflib.SDO.identifier,
+                    rdflib.SDO.name,
                     rdflib.Literal(f"Site Visit Collection - Sampling Effort - {row_sampling_effort}"),
                 )
             )


### PR DESCRIPTION
Swap predicate as per feedback.

I also tweaked the python matrix test logic.
Typically, when one fails, the others are at least 90% done, so there isn't much saving in failing fast.
I would rather see if the failure is for all py versions or just some.