### PR TITLE
BDRSPS-1118 Refactor `apply_mapping` method by moving it to the base mapper class

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -15,7 +15,7 @@ from abis_mapping import models
 from abis_mapping import vocabs
 
 # Typing
-from typing import Iterator, Optional, Any
+from typing import Any
 
 
 # Constants and Shortcuts
@@ -141,104 +141,16 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         # Return Validation Report
         return report
 
-    def apply_mapping(
-        self,
-        data: base.types.ReadableType,
-        dataset_iri: Optional[rdflib.URIRef] = None,
-        base_iri: Optional[rdflib.Namespace] = None,
-        **kwargs: Any,
-    ) -> Iterator[rdflib.Graph]:
-        """Applies Mapping for the `incidental_occurrence_data.csv` Template
-
-        Args:
-            data (base.types.ReadableType): Valid raw data to be mapped.
-            dataset_iri (Optional[rdflib.URIRef]): Optional dataset IRI.
-            base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
-
-        Keyword Args:
-            chunk_size (Optional[int]): How many rows of the original data to
-                ingest before yielding a graph. `None` will ingest all rows.
-
-        Yields:
-            rdflib.Graph: ABIS Conformant RDF Sub-Graph from Raw Data Chunk.
-        """
-        # Extract keyword arguments
-        chunk_size = kwargs.get("chunk_size")
-        if not isinstance(chunk_size, int) or chunk_size < 1:
-            chunk_size = None
-
-        # Construct Schema
-        schema = self.extra_fields_schema(
-            data=data,
-            full_schema=True,
-        )
-        extra_schema = self.extra_fields_schema(
-            data=data,
-            full_schema=False,
-        )
-
-        # Construct Resource
-        resource = frictionless.Resource(
-            source=data,
-            format="csv",  # TODO -> Hardcoded to csv for now
-            schema=schema,
-            encoding="utf-8",
-        )
-
-        # Initialise Graph
-        graph = utils.rdf.create_graph()
-
-        # Check if Dataset IRI Supplied
-        if dataset_iri:
-            # If supplied, add just the dataset type.
-            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
-        else:
-            # If not supplied, create example "default" Dataset IRI
-            dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
-
-            # Add Example Default Dataset if not Supplied
-            self.add_default_dataset(
-                uri=dataset_iri,
-                base_iri=base_iri,
-                graph=graph,
-            )
-
-        # Open the Resource to allow row streaming
-        with resource.open() as r:
-            # Loop through Rows
-            for row in r.row_stream:
-                # Map Row
-                self.apply_mapping_row(
-                    row=row,
-                    dataset=dataset_iri,
-                    graph=graph,
-                    extra_schema=extra_schema,
-                    base_iri=base_iri,
-                )
-
-                # Check Whether to Yield a Chunk
-                # The row_number needs to be reduced by one as the numbering of rows
-                # in a Resource includes the header
-                if chunk_size is not None and (row.row_number - 1) % chunk_size == 0:
-                    # Yield Chunk
-                    yield graph
-
-                    # Initialise New Graph
-                    graph = utils.rdf.create_graph()
-                    # Every chunk should have this node
-                    graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
-
-            # Yield
-            yield graph
-
     def apply_mapping_row(
         self,
+        *,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
         extra_schema: frictionless.Schema,
-        base_iri: Optional[rdflib.Namespace] = None,
-    ) -> rdflib.Graph:
+        base_iri: rdflib.Namespace | None,
+        **kwargs: Any,
+    ) -> None:
         """Applies Mapping for a Row in the `incidental_occurrence_data.csv` Template
 
         Args:
@@ -1165,9 +1077,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph=graph,
             extra_schema=extra_schema,
         )
-
-        # Return
-        return graph
 
     def add_provider_identified(
         self,

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -19,7 +19,7 @@ from abis_mapping import utils
 from abis_mapping import vocabs
 
 # Typing
-from typing import Any, Optional, Iterator, Literal
+from typing import Any, Literal
 
 
 # Constants and shortcuts
@@ -218,85 +218,15 @@ class SurveySiteMapper(base.mapper.ABISMapper):
 
             return result
 
-    def apply_mapping(
-        self,
-        data: base.types.ReadableType,
-        dataset_iri: Optional[rdflib.URIRef] = None,
-        base_iri: Optional[rdflib.Namespace] = None,
-        **kwargs: Any,
-    ) -> Iterator[rdflib.Graph]:
-        """Applies Mapping for the `survey_site_data.csv` Template.
-
-        Args:
-            data (base.types.ReadableType): Valid raw data to be mapped.
-            dataset_iri (Optional[rdflib.URIRef]): Optional dataset IRI.
-            base_iri (Optional[rdflib.Namespace]): Optional mapping base IRI.
-
-        Keyword Args:
-            chunk_size (Optional[int]): How many rows of the original data to
-                ingest before yielding a graph. `None` will ingest all rows.
-
-        Yields:
-            rdflib.Graph: ABIS Conformant RDF Sub-Graph from Raw Data Chunk.
-        """
-        # Construct Schema
-        schema = self.extra_fields_schema(
-            data=data,
-            full_schema=True,
-        )
-        extra_schema = self.extra_fields_schema(
-            data=data,
-            full_schema=False,
-        )
-
-        # Construct Resource
-        resource = frictionless.Resource(
-            source=data,
-            format="csv",  # TODO -> Hardcoded to csv for now
-            schema=schema,
-            encoding="utf-8",
-        )
-
-        # Initialise Graph
-        graph = utils.rdf.create_graph()
-
-        # Check if Dataset IRI Supplied
-        if dataset_iri:
-            # If supplied, add just the dataset type.
-            graph.add((dataset_iri, a, utils.namespaces.TERN.Dataset))
-        else:
-            # If not supplied, create example "default" Dataset IRI
-            dataset_iri = utils.rdf.uri(f"dataset/{self.DATASET_DEFAULT_NAME}", base_iri)
-
-            # Add the default dataset
-            self.add_default_dataset(
-                uri=dataset_iri,
-                base_iri=base_iri,
-                graph=graph,
-            )
-
-        # Open the Resource to allow row streaming
-        with resource.open() as r:
-            # Loop through rows
-            for row in r.row_stream:
-                # Map row
-                self.apply_mapping_row(
-                    row=row,
-                    dataset=dataset_iri,
-                    graph=graph,
-                    extra_schema=extra_schema,
-                    base_iri=base_iri,
-                )
-
-            yield graph
-
     def apply_mapping_row(
         self,
+        *,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
         graph: rdflib.Graph,
         extra_schema: frictionless.Schema,
-        base_iri: Optional[rdflib.Namespace],
+        base_iri: rdflib.Namespace | None,
+        **kwargs: Any,
     ) -> None:
         """Applies mapping for a row in the `survey_site_data.csv` template.
 

--- a/scripts/generate_example_ttl_files.py
+++ b/scripts/generate_example_ttl_files.py
@@ -80,7 +80,7 @@ def main() -> None:
             raise RuntimeError(f"Mapper not found for {template_id}")
         # Map data
         data = input_csv_file_path.read_bytes()
-        graphs = list(mapper().apply_mapping(data))
+        graphs = list(mapper().apply_mapping(data=data, chunk_size=None))
         if len(graphs) != 1:
             raise RuntimeError("apply_mapping did not produce exactly 1 graph")
         # Write to output file

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -18,7 +18,7 @@ from abis_mapping import base
 from abis_mapping import utils
 
 # Typing
-from typing import Any, Optional, Iterator
+from typing import Any
 
 from abis_mapping.base import types as base_types
 
@@ -35,14 +35,17 @@ class ContextualStringIO(io.StringIO):
 
 
 class StubMapper(base.mapper.ABISMapper):
-    def apply_mapping(
+    def apply_mapping_row(
         self,
-        data: base_types.ReadableType,
-        dataset_iri: Optional[rdflib.URIRef] = None,
-        base_iri: Optional[rdflib.Namespace] = None,
+        *,
+        row: frictionless.Row,
+        dataset: rdflib.URIRef,
+        graph: rdflib.Graph,
+        extra_schema: frictionless.Schema,
+        base_iri: rdflib.Namespace | None,
         **kwargs: Any,
-    ) -> Iterator[rdflib.Graph]:
-        yield from []
+    ) -> None:
+        pass
 
     def apply_validation(  # type: ignore[empty-body]
         self, data: base_types.ReadableType, **kwargs: Any

--- a/tests/templates/test_mapping.py
+++ b/tests/templates/test_mapping.py
@@ -34,7 +34,7 @@ def test_apply_mapping(template_id: str, test_params: conftest.MappingParameters
     assert mapper
 
     # Map
-    graphs = list(mapper().apply_mapping(data))
+    graphs = list(mapper().apply_mapping(data=data, chunk_size=None))
 
     # Assert
     assert len(graphs) == 1
@@ -81,7 +81,7 @@ def test_against_shacl(template_id: str, test_params: conftest.MappingParameters
     assert mapper
 
     # Map
-    graphs = list(mapper().apply_mapping(data))
+    graphs = list(mapper().apply_mapping(data=data, chunk_size=None))
 
     # Assert
     assert len(graphs) == 1
@@ -120,7 +120,7 @@ def test_apply_mapping_chunking(template_id: str, test_params: conftest.Chunking
     assert mapper
 
     # Map
-    graphs = list(mapper().apply_mapping(data, chunk_size=test_params.chunk_size))
+    graphs = list(mapper().apply_mapping(data=data, chunk_size=test_params.chunk_size))
 
     # Assert
     assert len(graphs) == test_params.yield_count

--- a/tests/templates/test_survey_occurrence_data_v2.py
+++ b/tests/templates/test_survey_occurrence_data_v2.py
@@ -284,7 +284,7 @@ class TestDefaultGeometryMap:
         ).read_text()
 
         # Resulting graph doesn't match expected when no lat/long provided
-        graphs = list(mapper.apply_mapping(csv_data))
+        graphs = list(mapper.apply_mapping(data=csv_data, chunk_size=None))
         assert len(graphs) == 1
         assert not conftest.compare_graphs(graphs[0], expected)
 
@@ -301,6 +301,7 @@ class TestDefaultGeometryMap:
         graphs = list(
             mapper.apply_mapping(
                 data=csv_data,
+                chunk_size=None,
                 site_id_geometry_map=default_map,
             )
         )
@@ -422,6 +423,7 @@ class TestDefaultTemporalMap:
         # Invoke
         graphs = mapper.apply_mapping(
             data=df.to_csv(index=False).encode("utf-8"),
+            chunk_size=None,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
         )
         res_g = next(graphs)


### PR DESCRIPTION
Each mapper class previously had very similar versions of the `apply_mapping` method. 
This has been refactored to a single method on the base class.
Now `apply_mapping_row` is the abstract method each subclass must implement