### PR TITLE
Start development of v6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abis-mapping"
-version = "5.0.0"
+version = "6.0.0-alpha0"
 description = "Provides templates and mappings to translate tabular data to ABIS rdf"
 authors = ["Gaia Resources <dev@gaiaresources.com.au>"]
 


### PR DESCRIPTION
This is mainly so the staging env shows abis-mapping as v6 