### PR TITLE
Make CI run on release branches and PRs into release branches

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     branches:
       - main
+      - 'release/**'
 permissions:
   contents: write
 env:
@@ -40,7 +42,7 @@ jobs:
         run: poetry run poe generate-instructions
 
       - name: Build and deploy dev documentation
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         run: poetry run mike deploy --push --branch=${{ env.DOCS_BRANCH }} dev
 
       - name: Build and deploy published tag documentation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     branches:
       - main
+      - 'release/**'
 env:
   PYTHON_VERSION: "3.11"
   POETRY_VERSION: "1.8.4"


### PR DESCRIPTION
This is needed so CI continues to run for PRs that target the `release/v5` branch