### PR TITLE
BDRSPS-1117: Move registries out of the classes they register

### DIFF
--- a/abis_mapping/__init__.py
+++ b/abis_mapping/__init__.py
@@ -3,4 +3,4 @@
 # Local
 from . import plugins  # Ensure plugins are loaded
 from .base import loader  # Dynamically load the template mappers
-from .base.mapper import get_mapper, get_mappers
+from .base.mapper import register_mapper, get_mapper, registered_ids

--- a/abis_mapping/models/schema.py
+++ b/abis_mapping/models/schema.py
@@ -158,6 +158,34 @@ class Field(pydantic.BaseModel):
 
         return utils.vocabs.get_vocab(self.vocabularies[0])
 
+    def get_flexible_vocab(
+        self,
+        name: str | None = None,
+    ) -> Type[utils.vocabs.FlexibleVocabulary]:
+        """Retrieves the flexible vocab for the field.
+
+        Args:
+            name: The name of the vocab to retrieve. Will return first flexible vocab if not provided.
+
+        Returns:
+            Returns FlexibleVocabulary for the field.
+
+        Raises:
+            ValueError: If name is not within the vocabularies field,
+                or if the field has no flexible vocabs.
+        """
+        all_vocabs = (utils.vocabs.get_vocab(name) for name in self.vocabularies)
+        try:
+            return next(
+                vocab_class
+                for vocab_class in all_vocabs
+                if issubclass(vocab_class, utils.vocabs.FlexibleVocabulary)
+                and (name is None or vocab_class.vocab_id == name)
+            )
+        except StopIteration:
+            name_note = "" if name is None else f" '{name}'"
+            raise ValueError(f"Flexible vocab{name_note} not found for field {self.name}") from None
+
     @property
     def publishable_vocabularies(self) -> list[str]:
         """Returns a list of only those vocabularies that are publishable.

--- a/abis_mapping/models/spatial.py
+++ b/abis_mapping/models/spatial.py
@@ -109,7 +109,7 @@ class Geometry:
         vocab = utils.vocabs.get_vocab("GEODETIC_DATUM")
         try:
             # Init with dummy graph and return corresponding URI
-            return vocab(graph=rdflib.Graph()).get(self.original_datum_name)
+            return vocab().get(self.original_datum_name)
         except utils.vocabs.VocabularyError as exc:
             raise GeometryError(
                 f"CRS {self.original_datum_name} is " "not defined for the GEODETIC_DATUM fixed vocabulary."
@@ -144,7 +144,7 @@ class Geometry:
 
         try:
             # Init with dummy graph and return corresponding uri
-            return vocab(graph=rdflib.Graph()).get(default_crs)
+            return vocab().get(default_crs)
         except utils.vocabs.VocabularyError as exc:
             raise GeometryError(
                 f"Default CRS {default_crs} is not defined for the GEODETIC_DATUM fixed vocabulary."

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -1005,7 +1005,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             uri=conservation_authority_value,
             conservation_authority=conservation_authority,
             graph=graph,
-            base_iri=base_iri,
         )
 
         # Add conservation Authority Collection
@@ -1128,7 +1127,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         date_identified: models.temporal.Timestamp = row["dateIdentified"] or row["eventDateStart"]
 
         # Retrieve vocab for field
-        vocab = self.fields()["identificationMethod"].get_vocab()
+        vocab = self.fields()["identificationMethod"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
@@ -1197,7 +1196,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         foi = sample_specimen if has_specimen(row) else provider_record_id_occurrence
 
         # Retrieve vocab for field
-        vocab = self.fields()["identificationMethod"].get_vocab()
+        vocab = self.fields()["identificationMethod"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
@@ -1412,7 +1411,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(id_qualifier)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["identificationQualifier"].get_vocab()
+            vocab = self.fields()["identificationQualifier"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(id_qualifier)
             # Identification Qualifier Value
@@ -1831,7 +1830,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["kingdom"].get_vocab("KINGDOM_SPECIMEN")
+        vocab = self.fields()["kingdom"].get_flexible_vocab("KINGDOM_SPECIMEN")
 
         # Retrieve Vocab or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["kingdom"])
@@ -2002,7 +2001,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(taxon_rank)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["taxonRank"].get_vocab()
+            vocab = self.fields()["taxonRank"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(taxon_rank)
             # Taxon Rank Value
@@ -2294,7 +2293,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["organismQuantityType"].get_vocab()
+        vocab = self.fields()["organismQuantityType"].get_flexible_vocab()
 
         # Get term or create on the fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(organism_qty_type)
@@ -2366,7 +2365,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(habitat)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["habitat"].get_vocab()
+            vocab = self.fields()["habitat"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(habitat)
             # Add value
@@ -2467,7 +2466,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(basis_of_record)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["basisOfRecord"].get_vocab()
+            vocab = self.fields()["basisOfRecord"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(basis_of_record)
             # Add value
@@ -2618,7 +2617,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["occurrenceStatus"].get_vocab()
+        vocab = self.fields()["occurrenceStatus"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["occurrenceStatus"])
@@ -2688,7 +2687,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(preparations)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["preparations"].get_vocab()
+            vocab = self.fields()["preparations"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(preparations)
             # Add value
@@ -2810,7 +2809,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["establishmentMeans"].get_vocab()
+        vocab = self.fields()["establishmentMeans"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["establishmentMeans"])
@@ -2904,7 +2903,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["lifeStage"].get_vocab()
+        vocab = self.fields()["lifeStage"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["lifeStage"])
@@ -2997,7 +2996,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["sex"].get_vocab()
+        vocab = self.fields()["sex"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sex"])
@@ -3091,7 +3090,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["reproductiveCondition"].get_vocab()
+        vocab = self.fields()["reproductiveCondition"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["reproductiveCondition"])
@@ -3215,7 +3214,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         )
 
         # Retrieve vocab for field
-        vocab = self.fields()["sequencingMethod"].get_vocab()
+        vocab = self.fields()["sequencingMethod"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sequencingMethod"])
@@ -3357,7 +3356,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         )
 
         # Retrieve vocab for field
-        vocab = self.fields()["threatStatusCheckProtocol"].get_vocab()
+        vocab = self.fields()["threatStatusCheckProtocol"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["threatStatusCheckProtocol"])
@@ -3421,7 +3420,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         value = f"{row['conservationAuthority']}/{row['threatStatus']}"
 
         # Retrieve vocab for field
-        vocab = self.fields()["threatStatus"].get_vocab()
+        vocab = self.fields()["threatStatus"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
@@ -3469,7 +3468,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef | None,
         conservation_authority: str | None,
         graph: rdflib.Graph,
-        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Conservation Authority Value to the Graph
 
@@ -3477,7 +3475,6 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             uri: URI to use for this node
             conservation_authority: conservationAuthority value from the CSV
             graph: Graph to add to
-            base_iri: Namespace used to construct IRIs)
         """
         # Check Existence
         if uri is None:
@@ -3492,8 +3489,8 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
             # Retrieve vocab for field
             vocab = self.fields()["conservationAuthority"].get_vocab()
-            # Retrieve term or Create on the Fly
-            term = vocab(graph=graph, base_iri=base_iri).get(conservation_authority)
+            # Retrieve term
+            term = vocab().get(conservation_authority)
             # Conservation Authority Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -3592,7 +3589,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["sensitivityCategory"].get_vocab()
+        vocab = self.fields()["sensitivityCategory"].get_flexible_vocab()
         vocab_instance = vocab(graph=graph, source=dataset, base_iri=base_iri)
 
         # Set the scope note to use if a new term is created on the fly.
@@ -3734,7 +3731,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             )
 
         # Add feature type from vocab
-        kingdom_vocab = self.fields()["kingdom"].get_vocab("KINGDOM_OCCURRENCE")
+        kingdom_vocab = self.fields()["kingdom"].get_flexible_vocab("KINGDOM_OCCURRENCE")
         kingdom_term = kingdom_vocab(graph=graph, base_iri=base_iri).get(row["kingdom"])
         graph.add((uri, utils.namespaces.TERN.featureType, kingdom_term))
 
@@ -3787,7 +3784,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
                 graph.add((temporal_entity, rdflib.TIME.hasEnd, end_instant))
 
         # Add procedure from vocab
-        protocol_vocab = self.fields()["samplingProtocol"].get_vocab()
+        protocol_vocab = self.fields()["samplingProtocol"].get_flexible_vocab()
         protocol_term = protocol_vocab(graph=graph, base_iri=base_iri).get(row["samplingProtocol"])
         graph.add((uri, rdflib.SOSA.usedProcedure, protocol_term))
 

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -3860,4 +3860,4 @@ def has_specimen(row: frictionless.Row) -> bool:
 
 
 # Register mapper
-base.mapper.ABISMapper.register_mapper(IncidentalOccurrenceMapper)
+base.mapper.register_mapper(IncidentalOccurrenceMapper)

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -905,4 +905,4 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-base.mapper.ABISMapper.register_mapper(SurveyMetadataMapper)
+base.mapper.register_mapper(SurveyMetadataMapper)

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -657,7 +657,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(row_survey_type)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["surveyType"].get_vocab()
+            vocab = self.fields()["surveyType"].get_flexible_vocab()
 
             # Add value
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_survey_type)
@@ -761,7 +761,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         graph.add((uri, rdflib.RDFS.label, rdflib.Literal(raw_value)))
 
         # Retrieve vocab for field
-        vocab = self.fields()["targetHabitatScope"].get_vocab()
+        vocab = self.fields()["targetHabitatScope"].get_flexible_vocab()
 
         # Add value
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(raw_value)
@@ -860,7 +860,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         graph.add((uri, rdflib.RDFS.label, rdflib.Literal(raw_value)))
 
         # Retrieve vocab for field
-        vocab = self.fields()["targetTaxonomicScope"].get_vocab()
+        vocab = self.fields()["targetTaxonomicScope"].get_flexible_vocab()
 
         # Add value
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(raw_value)

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -1153,7 +1153,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri=conservation_authority_value,
             conservation_authority=conservation_authority,
             graph=graph,
-            base_iri=base_iri,
         )
 
         # Add conservation Authority Collection
@@ -1390,7 +1389,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         date_identified: models.temporal.Timestamp | None = row["dateIdentified"] or row["eventDateStart"]
 
         # Retrieve vocab for field
-        vocab = self.fields()["identificationMethod"].get_vocab()
+        vocab = self.fields()["identificationMethod"].get_flexible_vocab()
 
         # Retrieve Vocab or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
@@ -1478,7 +1477,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         foi = sample_specimen if has_specimen(row) else provider_record_id_occurrence
 
         # Retrieve vocab for field
-        vocab = self.fields()["identificationMethod"].get_vocab()
+        vocab = self.fields()["identificationMethod"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["identificationMethod"])
@@ -1704,7 +1703,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(id_qualifier)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["identificationQualifier"].get_vocab()
+            vocab = self.fields()["identificationQualifier"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(id_qualifier)
             # Identification Qualifier Value
@@ -2160,7 +2159,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field (multiple exists for kingdom)
-        vocab = self.fields()["kingdom"].get_vocab("KINGDOM_SPECIMEN")
+        vocab = self.fields()["kingdom"].get_flexible_vocab("KINGDOM_SPECIMEN")
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["kingdom"])
@@ -2331,7 +2330,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(taxon_rank)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["taxonRank"].get_vocab()
+            vocab = self.fields()["taxonRank"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(taxon_rank)
             # Taxon Rank Value
@@ -2629,7 +2628,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(habitat)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["habitat"].get_vocab()
+            vocab = self.fields()["habitat"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(habitat)
             # Add value
@@ -2730,7 +2729,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(basis_of_record)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["basisOfRecord"].get_vocab()
+            vocab = self.fields()["basisOfRecord"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(basis_of_record)
             # Add value
@@ -2901,7 +2900,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["occurrenceStatus"].get_vocab()
+        vocab = self.fields()["occurrenceStatus"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["occurrenceStatus"])
@@ -2971,7 +2970,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((uri, rdflib.RDFS.label, rdflib.Literal(preparations)))
 
             # Retrieve vocab for field
-            vocab = self.fields()["preparations"].get_vocab()
+            vocab = self.fields()["preparations"].get_flexible_vocab()
             # Retrieve term or Create on the Fly
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(preparations)
             # Add value
@@ -3112,7 +3111,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["establishmentMeans"].get_vocab()
+        vocab = self.fields()["establishmentMeans"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["establishmentMeans"])
@@ -3226,7 +3225,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["lifeStage"].get_vocab()
+        vocab = self.fields()["lifeStage"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["lifeStage"])
@@ -3338,7 +3337,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["sex"].get_vocab()
+        vocab = self.fields()["sex"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sex"])
@@ -3451,7 +3450,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["reproductiveCondition"].get_vocab()
+        vocab = self.fields()["reproductiveCondition"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["reproductiveCondition"])
@@ -3615,7 +3614,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["sequencingMethod"].get_vocab()
+        vocab = self.fields()["sequencingMethod"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["sequencingMethod"])
@@ -3776,7 +3775,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         )
 
         # Retrieve vocab for field
-        vocab = self.fields()["threatStatusCheckProtocol"].get_vocab()
+        vocab = self.fields()["threatStatusCheckProtocol"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row["threatStatusCheckProtocol"])
@@ -3854,7 +3853,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         value = f"{row['conservationAuthority']}/{row['threatStatus']}"
 
         # Retrieve vocab for field
-        vocab = self.fields()["threatStatus"].get_vocab()
+        vocab = self.fields()["threatStatus"].get_flexible_vocab()
 
         # Retrieve term or Create on the Fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
@@ -3902,7 +3901,6 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef | None,
         conservation_authority: str | None,
         graph: rdflib.Graph,
-        base_iri: rdflib.Namespace | None,
     ) -> None:
         """Adds Conservation Authority Value to the Graph
 
@@ -3926,7 +3924,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             vocab = self.fields()["conservationAuthority"].get_vocab()
             # Retrieve term
-            term = vocab(graph=graph, base_iri=base_iri).get(conservation_authority)
+            term = vocab().get(conservation_authority)
             # Conservation Authority Value
             graph.add((uri, rdflib.RDF.value, term))
 
@@ -4084,7 +4082,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["organismQuantityType"].get_vocab()
+        vocab = self.fields()["organismQuantityType"].get_flexible_vocab()
 
         # Get term or create on the fly
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(organism_qty_type)
@@ -4173,7 +4171,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             return
 
         # Retrieve vocab for field
-        vocab = self.fields()["sensitivityCategory"].get_vocab()
+        vocab = self.fields()["sensitivityCategory"].get_flexible_vocab()
         vocab_instance = vocab(graph=graph, source=dataset, base_iri=base_iri)
 
         # Set the scope note to use if a new term is created on the fly.
@@ -4368,7 +4366,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             )
 
         # Add feature type from vocab
-        kingdom_vocab = self.fields()["kingdom"].get_vocab("KINGDOM_OCCURRENCE")
+        kingdom_vocab = self.fields()["kingdom"].get_flexible_vocab("KINGDOM_OCCURRENCE")
         graph.add(
             (
                 uri,
@@ -4420,7 +4418,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 graph.add((temporal_entity, rdflib.TIME.hasEnd, end_instant))
 
         # Add procedure from vocab
-        protocol_vocab = self.fields()["samplingProtocol"].get_vocab()
+        protocol_vocab = self.fields()["samplingProtocol"].get_flexible_vocab()
         graph.add(
             (
                 uri,

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -4534,4 +4534,4 @@ def has_specimen(row: frictionless.Row) -> bool:
 
 
 # Register Mapper
-base.mapper.ABISMapper.register_mapper(SurveyOccurrenceMapper)
+base.mapper.register_mapper(SurveyOccurrenceMapper)

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -858,4 +858,4 @@ class SurveySiteMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-base.mapper.ABISMapper.register_mapper(SurveySiteMapper)
+base.mapper.register_mapper(SurveySiteMapper)

--- a/abis_mapping/templates/survey_site_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v2/mapping.py
@@ -261,7 +261,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         if related_site_id and relationship_to_related_site:
             # Get vocab to conditionally create related site
             rtor_site_vocab = self.fields()["relationshipToRelatedSite"].get_vocab()
-            if rtor_site_vocab(graph=rdflib.Graph()).get(relationship_to_related_site) == rdflib.SDO.isPartOf:
+            if rtor_site_vocab().get(relationship_to_related_site) == rdflib.SDO.isPartOf:
                 # Related site is defined internal to the dataset
                 related_site = utils.iri_patterns.site_iri(base_iri, related_site_id)
             else:
@@ -456,9 +456,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             # Retrieve vocab for field
             relationship_to_related_site_vocab = self.fields()["relationshipToRelatedSite"].get_vocab()
             # Retrieve term
-            relationship_to_related_site_term = relationship_to_related_site_vocab(graph=graph, base_iri=base_iri).get(
-                relationship_to_related_site
-            )
+            relationship_to_related_site_term = relationship_to_related_site_vocab().get(relationship_to_related_site)
             graph.add((uri, relationship_to_related_site_term, related_site))
 
         # Add site tern featuretype
@@ -466,7 +464,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
 
         if site_type:
             # Retrieve vocab for field
-            site_type_vocab = self.fields()["siteType"].get_vocab()
+            site_type_vocab = self.fields()["siteType"].get_flexible_vocab()
 
             # Retrieve term or create on the fly
             site_type_term = site_type_vocab(graph=graph, source=dataset, base_iri=base_iri).get(site_type)
@@ -621,7 +619,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         graph.add((uri, rdflib.RDFS.label, rdflib.Literal(raw)))
 
         # Retrieve vocab for field
-        vocab = self.fields()["habitat"].get_vocab()
+        vocab = self.fields()["habitat"].get_flexible_vocab()
 
         # Add flexible vocab term
         term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(raw)

--- a/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
@@ -717,7 +717,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         row_protocol_name: str | None = row["protocolName"]
         if row_protocol_name:
             # Retrieve vocab for field
-            vocab = self.fields()["protocolName"].get_vocab()
+            vocab = self.fields()["protocolName"].get_flexible_vocab()
             # get or create term IRI
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_protocol_name)
             # Add link to term
@@ -788,7 +788,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
 
         if row_target_taxonomic_scope:
             # Retrieve vocab for field
-            vocab = self.fields()["targetTaxonomicScope"].get_vocab()
+            vocab = self.fields()["targetTaxonomicScope"].get_flexible_vocab()
 
             # Add value
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_target_taxonomic_scope)
@@ -907,7 +907,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         # Add Unit
         if row_sampling_effort_unit:
             # Retrieve vocab for field
-            vocab = self.fields()["samplingEffortUnit"].get_vocab()
+            vocab = self.fields()["samplingEffortUnit"].get_flexible_vocab()
             # Add value
             term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(row_sampling_effort_unit)
             graph.add((uri, utils.namespaces.TERN.unit, term))

--- a/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v2/mapping.py
@@ -956,4 +956,4 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
 
 
 # Register Mapper
-base.mapper.ABISMapper.register_mapper(SurveySiteVisitMapper)
+base.mapper.register_mapper(SurveySiteVisitMapper)

--- a/abis_mapping/vocabs/basis_of_record.py
+++ b/abis_mapping/vocabs/basis_of_record.py
@@ -71,4 +71,4 @@ class BasisOfRecord(utils.vocabs.FlexibleVocabulary):
 
 
 # Register vocabulary
-utils.vocabs.Vocabulary.register(BasisOfRecord)
+utils.vocabs.register(BasisOfRecord)

--- a/abis_mapping/vocabs/check_protocol.py
+++ b/abis_mapping/vocabs/check_protocol.py
@@ -30,4 +30,4 @@ class CheckProtocol(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(CheckProtocol)
+utils.vocabs.register(CheckProtocol)

--- a/abis_mapping/vocabs/conservation_authority.py
+++ b/abis_mapping/vocabs/conservation_authority.py
@@ -63,4 +63,4 @@ class ConservationAuthority(utils.vocabs.RestrictedVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(ConservationAuthority)
+utils.vocabs.register(ConservationAuthority)

--- a/abis_mapping/vocabs/establishment_means.py
+++ b/abis_mapping/vocabs/establishment_means.py
@@ -76,4 +76,4 @@ class EstablishmentMeans(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(EstablishmentMeans)
+utils.vocabs.register(EstablishmentMeans)

--- a/abis_mapping/vocabs/geodetic_datum.py
+++ b/abis_mapping/vocabs/geodetic_datum.py
@@ -42,4 +42,4 @@ class GeodeticDatum(utils.vocabs.RestrictedVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(GeodeticDatum)
+utils.vocabs.register(GeodeticDatum)

--- a/abis_mapping/vocabs/identification_method.py
+++ b/abis_mapping/vocabs/identification_method.py
@@ -28,4 +28,4 @@ class IdentificationMethod(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(IdentificationMethod)
+utils.vocabs.register(IdentificationMethod)

--- a/abis_mapping/vocabs/identification_qualifier.py
+++ b/abis_mapping/vocabs/identification_qualifier.py
@@ -256,4 +256,4 @@ class IdentificationQualifier(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(IdentificationQualifier)
+utils.vocabs.register(IdentificationQualifier)

--- a/abis_mapping/vocabs/kingdom.py
+++ b/abis_mapping/vocabs/kingdom.py
@@ -131,6 +131,6 @@ class KingdomSpecimen(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(Kingdom)
-utils.vocabs.Vocabulary.register(KingdomOccurrence)
-utils.vocabs.Vocabulary.register(KingdomSpecimen)
+utils.vocabs.register(Kingdom)
+utils.vocabs.register(KingdomOccurrence)
+utils.vocabs.register(KingdomSpecimen)

--- a/abis_mapping/vocabs/life_stage.py
+++ b/abis_mapping/vocabs/life_stage.py
@@ -232,4 +232,4 @@ class LifeStage(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(LifeStage)
+utils.vocabs.register(LifeStage)

--- a/abis_mapping/vocabs/occurrence_status.py
+++ b/abis_mapping/vocabs/occurrence_status.py
@@ -32,4 +32,4 @@ class OccurrenceStatus(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(OccurrenceStatus)
+utils.vocabs.register(OccurrenceStatus)

--- a/abis_mapping/vocabs/organism_quantity_type.py
+++ b/abis_mapping/vocabs/organism_quantity_type.py
@@ -166,4 +166,4 @@ class OrganismQuantityType(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(OrganismQuantityType)
+utils.vocabs.register(OrganismQuantityType)

--- a/abis_mapping/vocabs/preparations.py
+++ b/abis_mapping/vocabs/preparations.py
@@ -107,4 +107,4 @@ class Preparations(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(Preparations)
+utils.vocabs.register(Preparations)

--- a/abis_mapping/vocabs/relationship_to_related_site.py
+++ b/abis_mapping/vocabs/relationship_to_related_site.py
@@ -21,4 +21,4 @@ class RelationshipToRelatedSite(utils.vocabs.RestrictedVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(RelationshipToRelatedSite)
+utils.vocabs.register(RelationshipToRelatedSite)

--- a/abis_mapping/vocabs/reproductive_condition.py
+++ b/abis_mapping/vocabs/reproductive_condition.py
@@ -20,4 +20,4 @@ class ReproductiveCondition(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(ReproductiveCondition)
+utils.vocabs.register(ReproductiveCondition)

--- a/abis_mapping/vocabs/sampling_effort_unit.py
+++ b/abis_mapping/vocabs/sampling_effort_unit.py
@@ -84,4 +84,4 @@ class SamplingEffortUnit(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SamplingEffortUnit)
+utils.vocabs.register(SamplingEffortUnit)

--- a/abis_mapping/vocabs/sampling_protocol.py
+++ b/abis_mapping/vocabs/sampling_protocol.py
@@ -362,4 +362,4 @@ class SamplingProtocol(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SamplingProtocol)
+utils.vocabs.register(SamplingProtocol)

--- a/abis_mapping/vocabs/sensitivity_authority.py
+++ b/abis_mapping/vocabs/sensitivity_authority.py
@@ -21,4 +21,4 @@ class SensitivityAuthority(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SensitivityAuthority)
+utils.vocabs.register(SensitivityAuthority)

--- a/abis_mapping/vocabs/sensitivity_category.py
+++ b/abis_mapping/vocabs/sensitivity_category.py
@@ -21,4 +21,4 @@ class SensitivityCategory(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SensitivityCategory)
+utils.vocabs.register(SensitivityCategory)

--- a/abis_mapping/vocabs/sequencing_method.py
+++ b/abis_mapping/vocabs/sequencing_method.py
@@ -28,4 +28,4 @@ class SequencingMethod(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SequencingMethod)
+utils.vocabs.register(SequencingMethod)

--- a/abis_mapping/vocabs/sex.py
+++ b/abis_mapping/vocabs/sex.py
@@ -66,4 +66,4 @@ class Sex(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(Sex)
+utils.vocabs.register(Sex)

--- a/abis_mapping/vocabs/site_type.py
+++ b/abis_mapping/vocabs/site_type.py
@@ -57,4 +57,4 @@ class SiteType(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SiteType)
+utils.vocabs.register(SiteType)

--- a/abis_mapping/vocabs/survey_type.py
+++ b/abis_mapping/vocabs/survey_type.py
@@ -32,4 +32,4 @@ class SurveyType(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(SurveyType)
+utils.vocabs.register(SurveyType)

--- a/abis_mapping/vocabs/target_habitat_scope.py
+++ b/abis_mapping/vocabs/target_habitat_scope.py
@@ -1112,4 +1112,4 @@ class TargetHabitatScope(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(TargetHabitatScope)
+utils.vocabs.register(TargetHabitatScope)

--- a/abis_mapping/vocabs/target_taxonomic_scope.py
+++ b/abis_mapping/vocabs/target_taxonomic_scope.py
@@ -99,4 +99,4 @@ class TargetTaxonomicScope(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(TargetTaxonomicScope)
+utils.vocabs.register(TargetTaxonomicScope)

--- a/abis_mapping/vocabs/taxon_rank.py
+++ b/abis_mapping/vocabs/taxon_rank.py
@@ -278,4 +278,4 @@ class TaxonRank(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(TaxonRank)
+utils.vocabs.register(TaxonRank)

--- a/abis_mapping/vocabs/threat_status.py
+++ b/abis_mapping/vocabs/threat_status.py
@@ -846,4 +846,4 @@ class ThreatStatus(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(ThreatStatus)
+utils.vocabs.register(ThreatStatus)

--- a/abis_mapping/vocabs/visit_protocol_name.py
+++ b/abis_mapping/vocabs/visit_protocol_name.py
@@ -290,4 +290,4 @@ class VisitProtocolName(utils.vocabs.FlexibleVocabulary):
 
 
 # Register
-utils.vocabs.Vocabulary.register(VisitProtocolName)
+utils.vocabs.register(VisitProtocolName)

--- a/docs/contexts/incidental_occurrence_data_v3.py
+++ b/docs/contexts/incidental_occurrence_data_v3.py
@@ -36,5 +36,5 @@ def _ctx() -> dict[str, Any]:
 
 
 # Register once the mapper is also registered
-if mapper_id in base.mapper.get_mappers():
+if mapper_id in base.mapper.registered_ids():
     contexts.base.register(mapper_id, _ctx())

--- a/docs/contexts/survey_metadata_v2.py
+++ b/docs/contexts/survey_metadata_v2.py
@@ -12,7 +12,7 @@ from docs import tables
 mapper = abis_mapping.templates.survey_metadata_v2.mapping.SurveyMetadataMapper
 mapper_id = mapper().template_id
 
-if mapper_id in base.mapper.get_mappers():
+if mapper_id in base.mapper.registered_ids():
     # Create context
     _ctx = {
         "tables": {

--- a/docs/contexts/survey_occurrence_data_v2.py
+++ b/docs/contexts/survey_occurrence_data_v2.py
@@ -36,5 +36,5 @@ def _ctx() -> dict[str, Any]:
 
 
 # Register once the mapper is also registered
-if mapper_id in base.mapper.get_mappers():
+if mapper_id in base.mapper.registered_ids():
     contexts.base.register(mapper_id, _ctx())

--- a/docs/contexts/survey_site_data_v2.py
+++ b/docs/contexts/survey_site_data_v2.py
@@ -12,7 +12,7 @@ from docs import tables
 mapper = abis_mapping.templates.survey_site_data_v2.mapping.SurveySiteMapper
 mapper_id = mapper().template_id
 
-if mapper_id in base.mapper.get_mappers():
+if mapper_id in base.mapper.registered_ids():
     # Declare context
     _ctx = {
         "tables": {

--- a/docs/contexts/survey_site_visit_data_v2.py
+++ b/docs/contexts/survey_site_visit_data_v2.py
@@ -11,7 +11,7 @@ from docs import tables
 mapper = abis_mapping.templates.survey_site_visit_data_v2.mapping.SurveySiteVisitMapper
 mapper_id = mapper().template_id
 
-if mapper_id in base.mapper.get_mappers():
+if mapper_id in base.mapper.registered_ids():
     # Declare context
     _ctx = {
         "tables": {

--- a/tests/models/test_spatial.py
+++ b/tests/models/test_spatial.py
@@ -127,7 +127,7 @@ def test_geometry_transformer_datum_uri() -> None:
 
     # Assert default datum
     assert vocab is not None
-    assert geometry.transformer_datum_uri == vocab(graph=rdflib.Graph()).get(settings.SETTINGS.DEFAULT_TARGET_CRS)
+    assert geometry.transformer_datum_uri == vocab().get(settings.SETTINGS.DEFAULT_TARGET_CRS)
 
 
 def test_geometry_transformer_datum_uri_invalid() -> None:

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -384,7 +384,7 @@ TEST_CASES_ALL: list[TemplateTestParameters] = [
 ]
 
 # Filter out only those templates that are registered
-TEST_CASES = [tc for tc in TEST_CASES_ALL if tc.template_id in base.mapper.get_mappers()]
+TEST_CASES = [tc for tc in TEST_CASES_ALL if tc.template_id in base.mapper.registered_ids()]
 
 
 def mapping_test_args() -> Iterable[tuple[str, str, MappingParameters]]:

--- a/tests/templates/test_common.py
+++ b/tests/templates/test_common.py
@@ -16,9 +16,6 @@ import abis_mapping.base
 import abis_mapping.models
 from tests.templates import conftest
 
-# Typing
-from typing import Type
-
 
 @pytest.fixture(scope="module")
 def case_template_ids() -> list[str]:
@@ -28,7 +25,7 @@ def case_template_ids() -> list[str]:
 
 @pytest.mark.parametrize(
     argnames="mapper_id",
-    argvalues=[mapper_id for mapper_id in abis_mapping.get_mappers()],
+    argvalues=sorted(abis_mapping.registered_ids()),
 )
 def test_registered_has_test_case(mapper_id: str, case_template_ids: list[str]) -> None:
     """Tests all registered mapper has a corresponding test case."""
@@ -41,16 +38,12 @@ def test_registered_has_test_case(mapper_id: str, case_template_ids: list[str]) 
     ids=[tc.template_id for tc in conftest.TEST_CASES],
 )
 class TestTemplateBasicSuite:
-    @pytest.fixture(scope="class")
-    def mappers(self) -> dict[str, Type[abis_mapping.base.mapper.ABISMapper]]:
-        """Test fixture that retrieves all mappers"""
-        return abis_mapping.get_mappers()
-
     def test_template_registered(
-        self, mappers: dict[str, abis_mapping.base.mapper.ABISMapper], test_params: conftest.TemplateTestParameters
+        self,
+        test_params: conftest.TemplateTestParameters,
     ) -> None:
         """Tests that the supplied template id is registered."""
-        assert test_params.template_id in mappers
+        assert test_params.template_id in abis_mapping.registered_ids()
 
     def test_get_mapper(self, test_params: conftest.TemplateTestParameters) -> None:
         """Tests that we can retrieve a mapper based on its template ID"""

--- a/tests/utils/test_vocabs.py
+++ b/tests/utils/test_vocabs.py
@@ -134,7 +134,7 @@ def test_vocabs_flexible_vocab() -> None:
 
 def test_vocab_register_id() -> None:
     """Tests that vocabs get registered at import."""
-    assert len(abis_mapping.utils.vocabs.Vocabulary.id_registry) > 0
+    assert len(abis_mapping.utils.vocabs._id_registry) > 0
 
 
 def test_get_vocab() -> None:

--- a/tests/utils/test_vocabs.py
+++ b/tests/utils/test_vocabs.py
@@ -11,6 +11,9 @@ import rdflib
 import abis_mapping.utils.namespaces
 import abis_mapping.utils.vocabs
 
+# Typing
+from typing import assert_type
+
 
 def test_vocabs_term() -> None:
     """Tests the Term Class"""
@@ -57,7 +60,7 @@ def test_vocabs_restricted_vocab() -> None:
             ),
         )
 
-    vocab = Vocab(graph=rdflib.Graph())
+    vocab = Vocab()
 
     # Assert Existing Values
     assert vocab.get("a") == rdflib.URIRef("A")
@@ -140,11 +143,11 @@ def test_vocab_register_id() -> None:
 def test_get_vocab() -> None:
     """Tests get_vocab function."""
     # Retrieve vocab
-    v1 = abis_mapping.utils.vocabs.get_vocab("SEX")
+    datum = abis_mapping.utils.vocabs.get_vocab("GEODETIC_DATUM")
 
     # Assert exists
-    assert v1 is not None
-    assert issubclass(v1, abis_mapping.utils.vocabs.FlexibleVocabulary)
+    assert datum is not None
+    assert issubclass(datum, abis_mapping.utils.vocabs.Vocabulary)
 
 
 def test_get_vocab_invalid() -> None:
@@ -152,3 +155,35 @@ def test_get_vocab_invalid() -> None:
     # Should raise key error
     with pytest.raises(ValueError):
         abis_mapping.utils.vocabs.get_vocab("NOT_A_VOCAB")
+
+
+def test_get_flexible_vocab() -> None:
+    """Tests get_flexible_vocab function."""
+    # Retrieve vocab
+    habitat = abis_mapping.utils.vocabs.get_flexible_vocab("TARGET_HABITAT_SCOPE")
+
+    # Assert exists
+    assert habitat is not None
+    assert issubclass(habitat, abis_mapping.utils.vocabs.FlexibleVocabulary)
+    # Check mypy sees the right return type
+    assert_type(habitat, type[abis_mapping.utils.vocabs.FlexibleVocabulary])
+
+
+def test_get_flexible_vocab_with_fixed_vocab() -> None:
+    """Tests get_flexible_vocab function with a non-flexible vocab."""
+    # Retrieve vocab
+    with pytest.raises(
+        ValueError,
+        match=r"Key GEODETIC_DATUM is not a subclass of FlexibleVocabulary.",
+    ):
+        abis_mapping.utils.vocabs.get_flexible_vocab("GEODETIC_DATUM")
+
+
+def test_get_flexible_vocab_with_unknown_vocab() -> None:
+    """Tests get_flexible_vocab function with an unknown vocab."""
+    # Retrieve vocab
+    with pytest.raises(
+        ValueError,
+        match=r"Key UNKNOWN not found in registry.",
+    ):
+        abis_mapping.utils.vocabs.get_flexible_vocab("UNKNOWN")

--- a/tests/vocabs/test_organism_quantity_type.py
+++ b/tests/vocabs/test_organism_quantity_type.py
@@ -13,7 +13,7 @@ def test_get_percentage_biomass() -> None:
     graph = rdflib.Graph()
 
     # Get vocab
-    vocab = utils.vocabs.get_vocab("ORGANISM_QUANTITY_TYPE")
+    vocab = utils.vocabs.get_flexible_vocab("ORGANISM_QUANTITY_TYPE")
     assert vocab is not None
     iri = vocab(graph=graph).get("% of biomass")
 


### PR DESCRIPTION
3 commits can be viewed individually:
* Move mapper registry out of the mapper class
* Move vocab registry out of the vocab class
* Add `get_flexible_vocab` function and method, and use them where appropriate.