### PR TITLE
BDRSPS-1122 Make mapper `metadata` method return a frozen class instead of a dict

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -335,7 +335,7 @@ class ABISMapper(abc.ABC):
 
         # Template File is the name and filetype as extension from metadata
         md = cls.metadata()
-        template_file = directory / f"{md['name']}.{md['file_type'].lower()}"
+        template_file = directory / f"{md.name}.{md.file_type.lower()}"
 
         # Return
         return template_file
@@ -347,27 +347,27 @@ class ABISMapper(abc.ABC):
         Returns:
             str: template id from metadata
         """
-        return self.metadata()["id"]
+        return self.metadata().id
 
     @final
     @classmethod
     @functools.cache
-    def metadata(cls) -> dict[str, str]:
+    def metadata(cls) -> models.metadata.TemplateMetadata:
         """Retrieves and Caches the Template Metadata for this Template
 
         Returns:
-            dict[str, Any]: Template Metadata for this Template
+            Template Metadata for this Template
         """
         # Retrieve Metadata Filepath
         directory = pathlib.Path(inspect.getfile(cls)).parent
         metadata_file = directory / "metadata.json"
 
         # Read Metadata and validate
-        md_dict = json.loads(metadata_file.read_text())
-        md_class = models.metadata.TemplateMetadata.model_validate(md_dict, strict=False)
+        md_content = metadata_file.read_bytes()
+        md_class = models.metadata.TemplateMetadata.model_validate_json(md_content)
 
         # Return
-        return md_class.model_dump()
+        return md_class
 
     @final
     @classmethod
@@ -436,7 +436,7 @@ def register_mapper(mapper: type[ABISMapper]) -> None:
         mapper: Mapper class to be registered.
     """
     # Register the mapper with its template id
-    template_id = mapper.metadata()["id"]
+    template_id = mapper.metadata().id
     _registry[template_id] = mapper
 
 

--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -323,7 +323,7 @@ class ABISMapper(abc.ABC):
 
     @final
     @classmethod
-    @functools.lru_cache
+    @functools.cache
     def template(cls) -> pathlib.Path:
         """Retrieves and Caches the Template Filepath
 
@@ -349,8 +349,9 @@ class ABISMapper(abc.ABC):
         """
         return self.metadata()["id"]
 
+    @final
     @classmethod
-    @functools.lru_cache
+    @functools.cache
     def metadata(cls) -> dict[str, str]:
         """Retrieves and Caches the Template Metadata for this Template
 
@@ -370,7 +371,7 @@ class ABISMapper(abc.ABC):
 
     @final
     @classmethod
-    @functools.lru_cache
+    @functools.cache
     def schema(
         cls,
         discard_optional: bool = True,

--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -2,7 +2,6 @@
 
 # Standard
 import abc
-import csv
 import functools
 import inspect
 import json
@@ -200,25 +199,6 @@ class ABISMapper(abc.ABC):
         if spatial_accuracy is not None:
             graph.add((supplied_as, utils.namespaces.GEO.hasMetricSpatialAccuracy, spatial_accuracy))
         graph.add((top_node, utils.namespaces.GEO.hasGeometry, supplied_as))
-
-    @classmethod
-    def generate_blank_template(cls) -> None:
-        """Generates a blank csv for the template.
-
-        It is based on the schema field names and writes it to a file within
-        the template mapper's root dir. NOTE: full schema validation is not applied,
-        and metadata validation is.
-        """
-        # Retrieve Schema Filepath
-        directory = pathlib.Path(inspect.getfile(cls)).parent
-        schema_file = directory / "schema.json"
-
-        # Get raw schema
-        fields: list[dict[str, object]] = json.loads(schema_file.read_text())["fields"]
-        out_path = directory / f"{cls.metadata()['name']}.{cls.metadata()['file_type'].lower()}"
-        with out_path.open("w") as f:
-            csv_writer = csv.DictWriter(f, [field["name"] for field in fields])
-            csv_writer.writeheader()
 
     @classmethod
     def add_extra_fields_json(

--- a/abis_mapping/models/metadata.py
+++ b/abis_mapping/models/metadata.py
@@ -22,6 +22,11 @@ class TemplateMetadataLifecycleStatus(enum.StrEnum):
 class TemplateMetadata(pydantic.BaseModel):
     """Model for the template `metadata.json` file."""
 
+    model_config = pydantic.ConfigDict(
+        # Frozen because this class is returned by the cached ABISMapper.metadata() method
+        frozen=True,
+    )
+
     name: str
     label: str
     version: str

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -145,41 +145,6 @@ def test_schema(mocker: pytest_mock.MockerFixture) -> None:
     assert actual == expected
 
 
-def test_generate_blank_template(mocker: pytest_mock.MockerFixture) -> None:
-    """Tests the generate_blank_template method.
-
-    Args:
-        mocker (pytest_mock.MockerFixture): The mocker fixture.
-    """
-    # Create and assign mock for pathlib.Path.read_text method
-    return_value = {
-        "fields": [
-            {
-                "name": "col1",
-            },
-            {
-                "name": "col2",
-            },
-        ],
-    }
-    mocked_read_text = mocker.patch.object(pathlib.Path, "read_text")
-    mocked_read_text.return_value = json.dumps(return_value)
-
-    # Create and assign mock for pathlib.Path.open method
-    mocked_open = mocker.patch.object(pathlib.Path, "open")
-    output_stream = ContextualStringIO()
-    mocked_open.return_value = output_stream
-
-    # Patch the metadata method
-    mocker.patch.object(base.mapper.ABISMapper, "metadata", return_value={"name": "some_template", "file_type": "CSV"})
-
-    # Invoke
-    base.mapper.ABISMapper.generate_blank_template()
-
-    # Confirm result
-    assert output_stream.final_buffer == "col1,col2\r\n"
-
-
 def test_base_get_mapper_fake() -> None:
     """Tests that we can't retrieve a mapper with an invalid ID"""
     # Test Fake Template ID

--- a/tests/templates/test_common.py
+++ b/tests/templates/test_common.py
@@ -67,7 +67,7 @@ class TestTemplateBasicSuite:
         real_mapper = abis_mapping.base.mapper.get_mapper(test_params.template_id)
         assert real_mapper is not None
         metadata = real_mapper.metadata()
-        assert isinstance(metadata, dict)
+        assert isinstance(metadata, abis_mapping.models.metadata.TemplateMetadata)
 
     def test_metadata_id_match(self, test_params: conftest.TemplateTestParameters) -> None:
         """Tests the metadata id matches the mapper id"""
@@ -77,7 +77,7 @@ class TestTemplateBasicSuite:
 
         # Retrieve metadata
         metadata = real_mapper.metadata()
-        assert metadata.get("id") == real_mapper().template_id
+        assert metadata.id == real_mapper().template_id
 
     def test_get_schema(self, test_params: conftest.TemplateTestParameters) -> None:
         """Tests able to retrieve template schema."""
@@ -117,7 +117,7 @@ class TestTemplateBasicSuite:
         metadata = mapper().metadata()
 
         # Confirm field set correctly
-        assert metadata.get("sampling_type") == test_params.metadata_sampling_type
+        assert metadata.sampling_type == test_params.metadata_sampling_type
 
     def test_schema_is_valid(self, test_params: conftest.TemplateTestParameters) -> None:
         """Tests that the schema.json is a valid frictionless schema."""


### PR DESCRIPTION
This is important since this method is cached, we don't want to the value stored in the cache to be mutated, which would effect future calls to the function.
