### PR TITLE
BDRSPS-1175 Add mapping for the Submission type to every chunk

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -787,6 +787,9 @@
     skos:prefLabel "Stream Environment and Water Pty Ltd recordNumber" ;
     prov:wasAttributedTo <https://linked.data.gov.au/dataset/bdr/org/Stream-Environment-and-Water-Pty-Ltd> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribute/basisOfRecord/HumanObservation> a tern:Attribute ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
     tern:attribute <http://example.com/concept/basisOfRecord> ;

--- a/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
@@ -52,6 +52,9 @@
             prov:agent <https://linked.data.gov.au/dataset/bdr/org/NSW-Department-of-Planning-Industry-and-Environment> ;
             prov:hadRole <https://linked.data.gov.au/def/data-roles/principalInvestigator> ] .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribute/surveyType/Wet-pitfall-trapping> a tern:Attribute ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
     tern:attribute <http://example.com/concept/surveyType> ;

--- a/abis_mapping/templates/survey_metadata_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v3/examples/minimal.ttl
@@ -58,6 +58,9 @@
     skos:prefLabel "surveyID source" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/NSW-Department-of-Planning-Industry-and-Environment/principalInvestigator> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribute/surveyType/Wet-pitfall-trapping> a tern:Attribute ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
     tern:attribute <http://example.com/concept/surveyType> ;

--- a/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -770,6 +770,9 @@
     skos:prefLabel "Stream Environment and Water Pty Ltd recordNumber" ;
     prov:wasAttributedTo <https://linked.data.gov.au/dataset/bdr/org/Stream-Environment-and-Water-Pty-Ltd> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/SiteVisit/MR-R1-V1> a tern:SiteVisit ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
 

--- a/abis_mapping/templates/survey_occurrence_data_v2/examples/organism_qty.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v2/examples/organism_qty.ttl
@@ -46,6 +46,9 @@
     skos:prefLabel "Gaia Resources recordID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/Gaia-Resources/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Site/P1> a tern:FeatureOfInterest,
         tern:Site ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -775,6 +775,9 @@
     skos:prefLabel "WAM Site ID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/WAM/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://example.com/site/WAM-MR-S1> a tern:FeatureOfInterest,
         tern:Site ;
     schema:identifier "MR-S1"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
@@ -46,6 +46,9 @@
     skos:prefLabel "Gaia Resources recordID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/Gaia-Resources/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/Gaia-Resources/resourceProvider> a prov:Attribution ;
     prov:agent <https://linked.data.gov.au/dataset/bdr/org/Gaia-Resources> ;
     prov:hadRole <https://linked.data.gov.au/def/data-roles/resourceProvider> .

--- a/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v2/examples/minimal.ttl
@@ -29,6 +29,9 @@
     skos:prefLabel "WAM Site ID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/WAM/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribute/dataGeneralizations/Coordinates-rounded-to-the-nearest-10-km-for-conservation-concern> a tern:Attribute ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
     tern:attribute <http://example.com/concept/data-generalizations> ;

--- a/abis_mapping/templates/survey_site_data_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v3/examples/minimal.ttl
@@ -81,8 +81,6 @@
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:locationDescription "Cowaramup Bay Road" .
 
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> a tern:Dataset .
-
 <https://linked.data.gov.au/dataset/bdr/site/WAM/P3> a tern:Site ;
     geo:hasGeometry _:N3bba75fe5be4a400a5af80dd00000002,
         _:N9466fd6e9e4c9aa92b83d28000000003 ;
@@ -92,6 +90,11 @@
     schema:sameAs <https://linked.data.gov.au/dataset/bdr/site/WAM/P2> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:locationDescription "Cowaramup Bay Road" .
+
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> a tern:Dataset .
 
 <https://linked.data.gov.au/dataset/bdr/site/WAM/P2> a tern:Site ;
     geo:hasGeometry _:N3bba75fe5be4a400a5af80dd00000001,

--- a/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_visit_data_v2/examples/minimal.ttl
@@ -43,6 +43,9 @@
     skos:prefLabel "WAM Site ID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/WAM/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/SiteVisit/TIS-24-03-P1-03> a tern:SiteVisit ;
     time:hasTime [ a time:TemporalEntity ;
             time:hasBeginning [ a time:Instant ;

--- a/abis_mapping/templates/survey_site_visit_data_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_visit_data_v3/examples/minimal.ttl
@@ -43,6 +43,9 @@
     skos:prefLabel "WAM Site ID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/WAM/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
+
 <https://example.com/site/P1> a tern:Site ;
     schema:identifier "P1"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> .
 

--- a/tests/templates/test_survey_occurrence_data_v2.py
+++ b/tests/templates/test_survey_occurrence_data_v2.py
@@ -290,7 +290,7 @@ class TestDefaultGeometryMap:
                 chunk_size=None,
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
-                submission_iri=None,
+                submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
             )
         )
         assert len(graphs) == 1
@@ -312,8 +312,8 @@ class TestDefaultGeometryMap:
                 chunk_size=None,
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
+                submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
                 site_id_geometry_map=default_map,
-                submission_iri=None,
             )
         )
         assert len(graphs) == 1
@@ -437,8 +437,8 @@ class TestDefaultTemporalMap:
             chunk_size=None,
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
+            submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
-            submission_iri=None,
         )
         res_g = next(graphs)
         # Ensure temporal entity added to graph

--- a/tests/templates/test_survey_occurrence_data_v3.py
+++ b/tests/templates/test_survey_occurrence_data_v3.py
@@ -308,7 +308,7 @@ class TestDefaultGeometryMap:
                 chunk_size=None,
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
-                submission_iri=None,
+                submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
             )
         )
         assert len(graphs) == 1
@@ -330,8 +330,8 @@ class TestDefaultGeometryMap:
                 chunk_size=None,
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
+                submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
                 site_id_geometry_map=default_map,
-                submission_iri=None,
             )
         )
         assert len(graphs) == 1
@@ -454,8 +454,8 @@ class TestDefaultTemporalMap:
             chunk_size=None,
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
+            submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
-            submission_iri=None,
         )
         res_g = next(graphs)
         # Ensure temporal entity added to graph


### PR DESCRIPTION
Full details of the submission are mapped elsewhere in the dataset.ttl output file.
This is so each chunk can be independently validated.