### PR TITLE
BDRSPS-1177 Update abis:Project mapping when new metadata v2 form is being used

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -55,6 +55,7 @@ class ABISMapper(abc.ABC):
         dataset_iri: rdflib.URIRef,
         base_iri: rdflib.Namespace,
         submission_iri: rdflib.URIRef | None,
+        project_iri: rdflib.URIRef | None,
         **kwargs: Any,
     ) -> Iterator[rdflib.Graph]:
         """Applies Mapping from Raw Data to ABIS conformant RDF.
@@ -65,6 +66,7 @@ class ABISMapper(abc.ABC):
             dataset_iri: IRI of the Dataset this raw data is part of.
             base_iri: Namespace to use when generating new IRIs as part of this mapping.
             submission_iri: Optional submission IRI
+            project_iri: The abis:Project IRI if there is one.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -114,6 +116,7 @@ class ABISMapper(abc.ABC):
                     extra_schema=extra_schema,
                     base_iri=base_iri,
                     submission_iri=submission_iri,
+                    project_iri=project_iri,
                     **kwargs,
                 )
                 graph_has_rows = True
@@ -167,6 +170,7 @@ class ABISMapper(abc.ABC):
         extra_schema: frictionless.Schema,
         base_iri: rdflib.Namespace,
         submission_iri: rdflib.URIRef | None,
+        project_iri: rdflib.URIRef | None,
         **kwargs: Any,
     ) -> None:
         """Applies Mapping for a Row in the template by mutating the passed Graph.
@@ -179,6 +183,7 @@ class ABISMapper(abc.ABC):
             base_iri: Base IRI namespace to use for mapping.
             kwargs: Additional keyword arguments.
             submission_iri: Optional submission IRI
+            project_iri: The abis:Project IRI if there is one.
         """
 
     def add_geometry_supplied_as(

--- a/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v2/examples/minimal.ttl
@@ -34,11 +34,8 @@
     schema:name "Survey Collection - Target Taxonomic Scope - Insecta" ;
     tern:hasAttribute <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribute/targetTaxonomicScope/Insecta> .
 
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/project/SSD-Survey-Project/1> a abis:Project ;
-    schema:hasPart <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL1> ;
-    schema:identifier "COL1" ;
-    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:name "Disentangling the effects of farmland use, habitat edges, and vegetation structure on ground beetle morphological traits - Summer" .
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/project> a abis:Project ;
+    schema:hasPart <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL1> .
 
 <https://linked.data.gov.au/dataset/bdr/datatypes/surveyID/CSIRO> a rdfs:Datatype ;
     skos:prefLabel "surveyID source" ;

--- a/abis_mapping/templates/survey_metadata_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v3/examples/minimal.ttl
@@ -43,17 +43,9 @@
     schema:name "Survey Collection - Target Taxonomic Scope - Insecta" ;
     tern:hasAttribute <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribute/targetTaxonomicScope/Insecta> .
 
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/project/SSD-Survey-Project/1> a abis:Project ;
-    schema:hasPart <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL1> ;
-    schema:identifier "COL1" ;
-    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:name "Disentangling the effects of farmland use, habitat edges, and vegetation structure on ground beetle morphological traits - Summer" .
-
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/project/SSD-Survey-Project/2> a abis:Project ;
-    schema:hasPart <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL2> ;
-    schema:identifier "COL2" ;
-    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:name "Disentangling the effects of farmland use, habitat edges, and vegetation structure on ground beetle morphological traits - Winter" .
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/project> a abis:Project ;
+    schema:hasPart <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL1>,
+        <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL2> .
 
 <https://linked.data.gov.au/dataset/bdr/datatypes/surveyID/CSIRO> a rdfs:Datatype ;
     skos:prefLabel "surveyID source" ;

--- a/abis_mapping/templates/survey_metadata_v3/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v3/mapping.py
@@ -145,6 +145,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
         extra_schema: frictionless.Schema,
         base_iri: rdflib.Namespace,
         submission_iri: rdflib.URIRef | None,
+        project_iri: rdflib.URIRef | None,
         **kwargs: Any,
     ) -> None:
         """Applies mapping for a row in the `survey_metadata.csv` template.
@@ -156,12 +157,17 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             extra_schema (frictionless.Schema): Schema of extra fields.
             base_iri (rdflib.Namespace): Base IRI to use for mapping.
             submission_iri: The Submission IRI to use for mapping.
+            project_iri: The abis:Project IRI if there is one.
         """
         # Set the row number to start from the data, excluding header
         row_num = row.row_number - 1
 
-        # Create BDR project IRI
-        project = utils.rdf.uri(f"project/SSD-Survey-Project/{row_num}", base_iri)
+        if submission_iri is None:
+            # Legacy: When using the metadata form v1, Create BDR project IRI
+            project_iri = utils.rdf.uri(f"project/SSD-Survey-Project/{row_num}", base_iri)
+        else:
+            # When using metadata form v2, Use project_iri as-is, Can be None when no Project in Form.
+            pass
 
         # Create TERN survey IRI from surveyID field
         survey_id: str = row["surveyID"]
@@ -232,9 +238,10 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
         # Add BDR project
         self.add_project(
-            uri=project,
+            uri=project_iri,
             survey=survey,
             dataset=dataset,
+            submission_iri=submission_iri,
             graph=graph,
             row=row,
         )
@@ -398,35 +405,42 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
     def add_project(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         survey: rdflib.URIRef,
         dataset: rdflib.URIRef,
+        submission_iri: rdflib.URIRef | None,
         graph: rdflib.Graph,
         row: frictionless.Row,
     ) -> None:
         """Adds the ABIS project to the graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
-            survey (rdflib.URIRef): BDR survey uri.
-            dataset (rdflib.URIRef): Dataset uri.
-            graph (rdflib.Graph): Graph to add to.
-            row (frictionless.Row): Row to be processed in dataset.
+            uri: URI to use for this node, None if the node should not be created.
+            survey: BDR survey uri.
+            dataset: Dataset uri.
+            submission_iri: The Submission IRI to use for mapping.
+            graph: Graph to add to.
+            row: Row to be processed in dataset.
         """
-        # Extract relevant values from row
-        project_id: str = row["surveyID"]
-        project_name = row["surveyName"]
+        # Check if Project should be created
+        if uri is None:
+            return
 
-        # Add type and attach to dataset
+        # Add type and attach to Survey
         graph.add((uri, a, utils.namespaces.ABIS.Project))
-        graph.add((uri, rdflib.SDO.isPartOf, dataset))
-
-        # Add (required) project name, id (not required) and purpose (not required).
-        graph.add((uri, rdflib.SDO.name, rdflib.Literal(project_name)))
-        graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(project_id)))
-
-        # Attach survey
         graph.add((uri, rdflib.SDO.hasPart, survey))
+
+        # Legacy: If using the metadata form v1, Also map these properties.
+        # When using the v2 metadata form, these properties are added by the form's mapping.
+        if submission_iri is None:
+            # Extract relevant values from row
+            project_id: str = row["surveyID"]
+            project_name: str = row["surveyName"]
+            # Attach to dataset
+            graph.add((uri, rdflib.SDO.isPartOf, dataset))
+            # Add project name and identifier
+            graph.add((uri, rdflib.SDO.name, rdflib.Literal(project_name)))
+            graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(project_id)))
 
     def add_survey(
         self,

--- a/abis_mapping/templates/survey_site_visit_data_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_visit_data_v3/examples/minimal.ttl
@@ -49,9 +49,6 @@
     skos:prefLabel "WAM Site ID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/WAM/resourceProvider> .
 
-<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
-    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
-
 <https://example.com/site/P1> a tern:Site ;
     schema:identifier "P1"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> .
 
@@ -224,6 +221,9 @@
 <https://linked.data.gov.au/dataset/bdr/org/WAM> a prov:Agent,
         prov:Organization ;
     schema:name "WAM" .
+
+<https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> a tern:RDFDataset ;
+    schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> a tern:Dataset .
 

--- a/scripts/generate_example_ttl_files.py
+++ b/scripts/generate_example_ttl_files.py
@@ -88,6 +88,7 @@ def main() -> None:
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
                 submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+                project_iri=tests.helpers.TEST_PROJECT_IRI,
             )
         )
         if len(graphs) != 1:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,6 +20,7 @@ TEST_BASE_NAMESPACE = rdflib.Namespace("https://linked.data.gov.au/dataset/bdr/0
 TEST_SUBMISSION_IRI = rdflib.URIRef(
     "https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000"
 )
+TEST_PROJECT_IRI = rdflib.URIRef("https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/project")
 
 
 @contextlib.contextmanager

--- a/tests/templates/test_mapping.py
+++ b/tests/templates/test_mapping.py
@@ -41,6 +41,7 @@ def test_apply_mapping(template_id: str, test_params: conftest.MappingParameters
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
             submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+            project_iri=tests.helpers.TEST_PROJECT_IRI,
         )
     )
 
@@ -96,6 +97,7 @@ def test_against_shacl(template_id: str, test_params: conftest.MappingParameters
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
             submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+            project_iri=tests.helpers.TEST_PROJECT_IRI,
         )
     )
 
@@ -143,6 +145,7 @@ def test_apply_mapping_chunking(template_id: str, test_params: conftest.Chunking
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
             submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+            project_iri=tests.helpers.TEST_PROJECT_IRI,
         )
     )
 

--- a/tests/templates/test_survey_occurrence_data_v2.py
+++ b/tests/templates/test_survey_occurrence_data_v2.py
@@ -291,6 +291,7 @@ class TestDefaultGeometryMap:
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
                 submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+                project_iri=tests.helpers.TEST_PROJECT_IRI,
             )
         )
         assert len(graphs) == 1
@@ -313,6 +314,7 @@ class TestDefaultGeometryMap:
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
                 submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+                project_iri=tests.helpers.TEST_PROJECT_IRI,
                 site_id_geometry_map=default_map,
             )
         )
@@ -438,6 +440,7 @@ class TestDefaultTemporalMap:
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
             submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+            project_iri=tests.helpers.TEST_PROJECT_IRI,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
         )
         res_g = next(graphs)

--- a/tests/templates/test_survey_occurrence_data_v3.py
+++ b/tests/templates/test_survey_occurrence_data_v3.py
@@ -309,6 +309,7 @@ class TestDefaultGeometryMap:
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
                 submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+                project_iri=tests.helpers.TEST_PROJECT_IRI,
             )
         )
         assert len(graphs) == 1
@@ -331,6 +332,7 @@ class TestDefaultGeometryMap:
                 dataset_iri=tests.helpers.TEST_DATASET_IRI,
                 base_iri=tests.helpers.TEST_BASE_NAMESPACE,
                 submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+                project_iri=tests.helpers.TEST_PROJECT_IRI,
                 site_id_geometry_map=default_map,
             )
         )
@@ -455,6 +457,7 @@ class TestDefaultTemporalMap:
             dataset_iri=tests.helpers.TEST_DATASET_IRI,
             base_iri=tests.helpers.TEST_BASE_NAMESPACE,
             submission_iri=tests.helpers.TEST_SUBMISSION_IRI,
+            project_iri=tests.helpers.TEST_PROJECT_IRI,
             site_visit_id_temporal_map=site_visit_id_temporal_map,
         )
         res_g = next(graphs)


### PR DESCRIPTION
When the metadata form v2 is being used (`submission_iri` is not None):
* Don't create a new project IRI, use the one from metadata form v2 mapping.
* Don't add properties to the project that are created in the metadata form v2 mapping
* Omit mapping the project all together if there is no project in the metadata form v2 mapping.

This uses a new `project_iri` argument which receives the project iri from the metadata form v2 mapping