### PR TITLE
BDRSPS-1186 Always include Site schema:identifier in mapping when siteID field is available

### DIFF
--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -1424,6 +1424,7 @@
 <https://linked.data.gov.au/dataset/bdr/site/WAM/MR-S1> a tern:FeatureOfInterest,
         tern:Site ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
+    schema:identifier "MR-S1"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/MR-R1> a tern:Survey ;

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
@@ -50,8 +50,17 @@
     skos:prefLabel "Gaia Resources recordID" ;
     prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/Gaia-Resources/resourceProvider> .
 
+<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/TERN> a rdfs:Datatype ;
+    skos:definition "An identifier for the site" ;
+    skos:prefLabel "TERN Site ID" ;
+    prov:qualifiedAttribution <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/TERN/resourceProvider> .
+
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/Gaia-Resources/resourceProvider> a prov:Attribution ;
     prov:agent <https://linked.data.gov.au/dataset/bdr/org/Gaia-Resources> ;
+    prov:hadRole <https://linked.data.gov.au/def/data-roles/resourceProvider> .
+
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/attribution/TERN/resourceProvider> a prov:Attribution ;
+    prov:agent <https://linked.data.gov.au/dataset/bdr/org/TERN> ;
     prov:hadRole <https://linked.data.gov.au/def/data-roles/resourceProvider> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/result/organismQuantity/0-05> a tern:Float,
@@ -72,9 +81,13 @@
 <https://linked.data.gov.au/dataset/bdr/org/Gaia-Resources> a prov:Agent ;
     schema:name "Gaia Resources" .
 
+<https://linked.data.gov.au/dataset/bdr/org/TERN> a prov:Agent ;
+    schema:name "TERN" .
+
 <https://linked.data.gov.au/dataset/bdr/site/TERN/P1> a tern:FeatureOfInterest,
         tern:Site ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
+    schema:identifier "P1"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/TERN> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/A0010> a dwc:Occurrence,

--- a/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
@@ -573,9 +573,9 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         else:
             site = None
 
-        # When both existingBDRSiteIRI and siteID+siteIDSource are provided,
+        # When siteID+siteIDSource are provided,
         # the site gets a schema:identifier with this datatype.
-        if existing_site_iri and site_id and site_id_source:
+        if site_id and site_id_source:
             site_id_datatype = utils.iri_patterns.datatype_iri("siteID", site_id_source)
             site_id_datatype_attribution = utils.iri_patterns.attribution_iri(
                 base_iri, "resourceProvider", site_id_source

--- a/abis_mapping/templates/survey_site_data_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v3/examples/minimal.ttl
@@ -86,6 +86,7 @@
         _:N9466fd6e9e4c9aa92b83d28000000003 ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
+    schema:identifier "P3"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
     schema:name "Plot 3" ;
     schema:sameAs <https://linked.data.gov.au/dataset/bdr/site/WAM/P2> ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
@@ -101,6 +102,7 @@
         _:N9466fd6e9e4c9aa92b83d28000000002 ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
+    schema:identifier "P2"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
     schema:name "Plot 2" ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:locationDescription "Cowaramup Bay Road" .

--- a/abis_mapping/templates/survey_site_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v3/mapping.py
@@ -267,9 +267,9 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         else:
             raise ValueError("Invalid row missing SiteID and existingBDRSiteIRI")
 
-        # When both existingBDRSiteIRI and siteID+siteIDSource are provided,
+        # When siteID+siteIDSource are provided,
         # the site gets a schema:identifier with this datatype.
-        if existing_site_iri and site_id and site_id_src:
+        if site_id and site_id_src:
             site_id_datatype = utils.iri_patterns.datatype_iri("siteID", site_id_src)
             site_id_agent = utils.iri_patterns.agent_iri("org", site_id_src)
             site_id_attribution = utils.iri_patterns.attribution_iri(base_iri, "resourceProvider", site_id_src)
@@ -466,8 +466,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
         # Add type
         graph.add((uri, a, utils.namespaces.TERN.Site))
 
-        # Add siteID schema:identifier property, only when both existingBDRSiteIRI
-        # and siteID+siteIDSource are provided.
+        # Add siteID schema:identifier property, when siteID+siteIDSource are provided.
         site_id: str | None = row["siteID"]
         if site_id and site_id_datatype is not None:
             graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(site_id, datatype=site_id_datatype)))

--- a/abis_mapping/templates/survey_site_visit_data_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_visit_data_v3/examples/minimal.ttl
@@ -174,7 +174,8 @@
         prov:Person ;
     schema:name "ORCID00003" .
 
-<https://linked.data.gov.au/dataset/bdr/site/WAM/P3> a tern:Site .
+<https://linked.data.gov.au/dataset/bdr/site/WAM/P3> a tern:Site ;
+    schema:identifier "P3"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/SiteVisit/TIS-24-03-P1-01> a tern:SiteVisit ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;

--- a/abis_mapping/templates/survey_site_visit_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v3/mapping.py
@@ -275,9 +275,9 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         # URI for the Site Visit Plan
         uri_site_visit_plan = utils.iri_patterns.plan_iri(base_iri, "visit", row_site_visit_id)
 
-        # When both existingBDRSiteIRI and siteID+siteIDSource are provided,
+        # When siteID+siteIDSource are provided,
         # the site gets a schema:identifier with this datatype.
-        if row_existing_site_iri and row_site_id and row_site_id_source:
+        if row_site_id and row_site_id_source:
             uri_site_id_datatype = utils.iri_patterns.datatype_iri("siteID", row_site_id_source)
             uri_site_id_datatype_attribution = utils.iri_patterns.attribution_iri(
                 base_iri, "resourceProvider", row_site_id_source
@@ -587,8 +587,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
         # Add class
         graph.add((uri, a, utils.namespaces.TERN.Site))
 
-        # Add siteID schema:identifier property, only when both existingBDRSiteIRI
-        # and siteID+siteIDSource are provided.
+        # Add siteID schema:identifier property, when siteID+siteIDSource are provided.
         row_site_id: str | None = row["siteID"]
         if row_site_id and uri_site_id_datatype is not None:
             graph.add((uri, rdflib.SDO.identifier, rdflib.Literal(row_site_id, datatype=uri_site_id_datatype)))


### PR DESCRIPTION
Previously it was only added when the existingBDRSiteIRI field was provided, due to a misinterpretation of the spec.