### PR TITLE
BDRSPS-1199 Relax occurrence geometry/site validation when using existingBDRSiteIRI

### DIFF
--- a/abis_mapping/plugins/__init__.py
+++ b/abis_mapping/plugins/__init__.py
@@ -6,6 +6,7 @@ from . import chronological
 from . import coordinates
 from . import default_lookup
 from . import empty
+from . import geometry_validation
 from . import list_field
 from . import logical_or
 from . import lookup_match

--- a/abis_mapping/plugins/geometry_validation.py
+++ b/abis_mapping/plugins/geometry_validation.py
@@ -60,6 +60,12 @@ class GeometryValidation(frictionless.Check):
             )
             return
 
+        # If the Site is referenced by existingBDRSiteIRI, then don't validate any further,
+        # the geometry is allowed to be missing, because it should already exist on an existing Site.
+        # i.e. The Site can be omitted from the site template, or present in the site template with no geometry.
+        if site_identifier.existing_bdr_site_iri is not None:
+            return
+
         # Determine if default geometry exists for site, if so, all good
         if site_identifier in self.site_id_geometry_map:
             return

--- a/abis_mapping/plugins/geometry_validation.py
+++ b/abis_mapping/plugins/geometry_validation.py
@@ -1,0 +1,72 @@
+"""Provides frictionless check for validating the geometry on an Occurrence."""
+
+# Standard Library
+import decimal
+
+# Third-party
+import attrs
+import frictionless
+import frictionless.errors
+
+# Local
+from abis_mapping import models
+
+# Typing
+from collections.abc import Iterator, Mapping
+
+
+@attrs.define(kw_only=True, repr=False)
+class GeometryValidation(frictionless.Check):
+    """Validate an Occurrence has geometry, or a fallback in the geometry map."""
+
+    # Check attributes
+    type = "geometry-validation"
+    Errors = [frictionless.errors.RowConstraintError]
+
+    # Attributes specific to this check
+    # Default map from a Site Identifier to the geometry for that site
+    site_id_geometry_map: Mapping[models.identifier.SiteIdentifier, str]
+
+    def validate_row(self, row: frictionless.Row) -> Iterator[frictionless.Error]:
+        """Called to validate given row (on every row)
+
+        Args:
+            row (frictionless.Row): The row to check defaults for
+
+        Yields::
+           frictionless.Error: When the default lookup fails
+        """
+        # Determine if regular geometry fields have a value
+        latitude: decimal.Decimal | None = row["decimalLatitude"]
+        longitude: decimal.Decimal | None = row["decimalLongitude"]
+        geodetic_datum: str | None = row["geodeticDatum"]
+        # All geometry fields have a value, all good.
+        if latitude is not None and longitude is not None and geodetic_datum is not None:
+            return
+        # Partially complete geometry fields are checked by a separate MutuallyInclusive check.
+
+        # Otherwise no geometry, check if there is a Site with geometry.
+
+        site_identifier = models.identifier.SiteIdentifier.from_row(row)
+
+        # If no Site identifier (and not all geometry fields), that's an error
+        if site_identifier is None:
+            yield frictionless.errors.RowConstraintError.from_row(
+                row=row,
+                note=(
+                    "decimalLatitude, decimalLongitude and geodeticDatum must be provided, "
+                    "or siteID and siteIDSource, or existingBDRSiteIRI, must be provided to use the geometry of a Site."
+                ),
+            )
+            return
+
+        # Determine if default geometry exists for site, if so, all good
+        if site_identifier in self.site_id_geometry_map:
+            return
+
+        # Otherwise that's an error
+        yield frictionless.errors.RowConstraintError.from_row(
+            row=row,
+            note=f"Could not find a Site with {site_identifier} and geometry to use for Occurrence geometry.",
+        )
+        return

--- a/abis_mapping/plugins/sites_geometry.py
+++ b/abis_mapping/plugins/sites_geometry.py
@@ -59,6 +59,9 @@ class SitesGeometry(frictionless.Check):
         # it doesn't matter the location here is missing.
         # On the other hand, if any of the Occurrences don't have their own valid location,
         # An error will be raised on them when they fail to fall back to this Site's location.
+        # Also, when the Occurrence reference a Site by existingBDRSiteIRI,
+        # then both the Occurrence and Site are allowed to have no geometry,
+        # because the Site should already exist with geometry.
         if site_used_by_occurrences:
             return
 

--- a/tests/templates/test_survey_occurrence_data_v3.py
+++ b/tests/templates/test_survey_occurrence_data_v3.py
@@ -117,10 +117,18 @@ class TestDefaultGeometryMap:
             name="invalid_missing_from_default_map",
             raws=[
                 ["R2", "site1", "ORG", "", "", "", ""],
+            ],
+            default_map={},
+            expected_error_codes=["row-constraint"],
+        ),
+        Scenario(
+            name="valid_existing_site_missing_from_default_map",
+            raws=[
+                # This row with existingBDRSiteIRI is allowed to be missing.
                 ["R3", "", "", "https://example.com/SITE-IRI", "", "", ""],
             ],
             default_map={},
-            expected_error_codes=["row-constraint", "row-constraint"],
+            expected_error_codes=None,
         ),
         Scenario(
             name="invalid_no_site_occurrence_requires_latlong",

--- a/tests/templates/test_survey_occurrence_data_v3.py
+++ b/tests/templates/test_survey_occurrence_data_v3.py
@@ -98,11 +98,17 @@ class TestDefaultGeometryMap:
                 ["R2", "site1", "ORG", "", "", "", ""],
                 ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R4", "site3", "ORG", "", "-38.94", "115.21", "AGD66"],
-                ["R5", "site4", "ORG", "", "-38.94", "115.21", "EPSG:4202"],
+                ["R5", "", "", "https://example.com/SITE-IRI-1", "-38.94", "115.21", "EPSG:4202"],
+                ["R6", "", "", "https://example.com/SITE-IRI-2", "", "", ""],
             ],
             default_map={
                 (
                     models.identifier.SiteIdentifier(site_id="site1", site_id_source="ORG", existing_bdr_site_iri=None)
+                ): "something",
+                (
+                    models.identifier.SiteIdentifier(
+                        site_id=None, site_id_source=None, existing_bdr_site_iri="https://example.com/SITE-IRI-2"
+                    )
                 ): "something",
             },
             expected_error_codes=None,
@@ -110,29 +116,26 @@ class TestDefaultGeometryMap:
         Scenario(
             name="invalid_missing_from_default_map",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "site1", "ORG", "", "", "", ""],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
+                ["R3", "", "", "https://example.com/SITE-IRI", "", "", ""],
             ],
             default_map={},
-            expected_error_codes=["row-constraint"],
+            expected_error_codes=["row-constraint", "row-constraint"],
         ),
         Scenario(
-            name="invalid_survey_occurrence_requires_latlong",
+            name="invalid_no_site_occurrence_requires_latlong",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "", "", "", "", "", ""],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
             ],
             default_map={},
             expected_error_codes=["row-constraint"],
         ),
         Scenario(
-            name="valid_survey_occurrence_requires_latlong",
+            name="valid_occurrences_with_latlong",
             raws=[
                 ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
-                ["R2", "", "", "", "-38.94", "115.21", "WGS84"],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
+                ["R2", "", "", "https://example.com/SITE-IRI", "-38.94", "115.21", "WGS84"],
+                ["R3", "", "", "", "-38.94", "115.21", "WGS84"],
                 # The following show that non-url safe characters get encoded during mapping.
                 ["R4", "site a", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R5", "site/b", "ORG", "", "-38.94", "115.21", "WGS84"],
@@ -144,47 +147,51 @@ class TestDefaultGeometryMap:
         Scenario(
             name="invalid_missing_long",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "site1", "ORG", "", "-38.94", "", "WGS84"],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
+                ["R3", "", "", "https://example.com/SITE-IRI", "-38.94", "", "WGS84"],
             ],
             default_map={
                 (
                     models.identifier.SiteIdentifier(site_id="site1", site_id_source="ORG", existing_bdr_site_iri=None)
                 ): "something",
+                (
+                    models.identifier.SiteIdentifier(
+                        site_id=None, site_id_source=None, existing_bdr_site_iri="https://example.com/SITE-IRI"
+                    )
+                ): "something",
             },
-            expected_error_codes=["row-constraint"],
+            expected_error_codes=["row-constraint", "row-constraint"],
         ),
         Scenario(
             name="invalid_missing_lat",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "site1", "ORG", "", "", "115.21", "WGS84"],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
+                ["R3", "", "", "https://example.com/SITE-IRI", "", "115.21", "WGS84"],
             ],
             default_map={
                 (
                     models.identifier.SiteIdentifier(site_id="site1", site_id_source="ORG", existing_bdr_site_iri=None)
                 ): "something",
+                (
+                    models.identifier.SiteIdentifier(
+                        site_id=None, site_id_source=None, existing_bdr_site_iri="https://example.com/SITE-IRI"
+                    )
+                ): "something",
             },
-            expected_error_codes=["row-constraint"],
+            expected_error_codes=["row-constraint", "row-constraint"],
         ),
         Scenario(
-            name="invalid_survey_occurrence_missing_lat",
+            name="invalid_no_site_occurrence_missing_lat",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "", "", "", "", "115.21", "WGS84"],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
             ],
             default_map={},
             expected_error_codes=["row-constraint", "row-constraint"],
         ),
         Scenario(
-            name="invalid_survey_occurrence_missing_long",
+            name="invalid_no_site_occurrence_missing_long",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "", "", "", "-38.94", "", "WGS84"],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
             ],
             default_map={},
             expected_error_codes=["row-constraint", "row-constraint"],
@@ -192,23 +199,25 @@ class TestDefaultGeometryMap:
         Scenario(
             name="invalid_missing_geodetic_datum",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "site1", "ORG", "", "-38.94", "115.21", ""],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
+                ["R3", "", "", "https://example.com/SITE-IRI", "-38.94", "115.21", ""],
             ],
             default_map={
                 (
                     models.identifier.SiteIdentifier(site_id="site1", site_id_source="ORG", existing_bdr_site_iri=None)
                 ): "something",
+                (
+                    models.identifier.SiteIdentifier(
+                        site_id=None, site_id_source=None, existing_bdr_site_iri="https://example.com/SITE-IRI"
+                    )
+                ): "something",
             },
-            expected_error_codes=["row-constraint"],
+            expected_error_codes=["row-constraint", "row-constraint"],
         ),
         Scenario(
-            name="invalid_survey_occurrence_missing_geodetic_datum",
+            name="invalid_no_site_occurrence_missing_geodetic_datum",
             raws=[
-                ["R1", "site1", "ORG", "", "-38.94", "115.21", "WGS84"],
                 ["R2", "", "", "", "-38.94", "115.21", ""],
-                ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
             ],
             default_map={},
             expected_error_codes=["row-constraint", "row-constraint"],

--- a/tests/templates/test_survey_occurrence_data_v3.py
+++ b/tests/templates/test_survey_occurrence_data_v3.py
@@ -187,7 +187,7 @@ class TestDefaultGeometryMap:
                 ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
             ],
             default_map={},
-            expected_error_codes=["row-constraint"],
+            expected_error_codes=["row-constraint", "row-constraint"],
         ),
         Scenario(
             name="invalid_missing_geodetic_datum",
@@ -211,7 +211,7 @@ class TestDefaultGeometryMap:
                 ["R3", "site2", "ORG", "", "-38.94", "115.21", "WGS84"],
             ],
             default_map={},
-            expected_error_codes=["row-constraint"],
+            expected_error_codes=["row-constraint", "row-constraint"],
         ),
     ]
 


### PR DESCRIPTION
When an occurrence uses existingBDRSiteIRI, the following are allowed:

* The Occurrence has no geometry, and
* The Site is not in the site template, and
* The Site is in the site template, but has no geometry.

This means we need to account for there being no geometry available when mapping an occurrence. In this case we just omit the geometry related-RDF from the output.