### PR TITLE
BDRSPS-1203 Fix slugify-ing slashes in values

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -1109,7 +1109,7 @@
     skos:prefLabel "new sequencing method" ;
     schema:citation "https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000"^^xsd:anyURI .
 
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https-www-dpaw-wa-gov-au-plants-and-animals-threatened-species-and-communities-threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
     skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
     skos:definition "A type of threatStatusCheckProtocol." ;
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
@@ -1189,7 +1189,7 @@
     sosa:hasResult <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/result/threatStatus/VU> ;
     sosa:hasSimpleResult "VU" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
-    sosa:usedProcedure <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> ;
+    sosa:usedProcedure <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https-www-dpaw-wa-gov-au-plants-and-animals-threatened-species-and-communities-threatened-animals-Last-updated-13-June-2022> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/observation/threatStatus/ABC123> a tern:Observation ;

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -177,8 +177,12 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_attribution = utils.iri_patterns.attribution_iri(
             base_iri, "resourceProvider", provider_record_id_source
         )
-        provider_record_id_occurrence = utils.rdf.uri(f"occurrence/{provider_record_id}", base_iri)
-        provider_record_id_biodiversity_record = utils.rdf.uri(f"biodiversityRecord/{provider_record_id}", base_iri)
+        provider_record_id_occurrence = utils.rdf.uri_slugified(
+            base_iri, "occurrence/{provider_record_id}", provider_record_id=provider_record_id
+        )
+        provider_record_id_biodiversity_record = utils.rdf.uri_slugified(
+            base_iri, "biodiversityRecord/{provider_record_id}", provider_record_id=provider_record_id
+        )
 
         # Create URIs for Observations and Observation Values
         observation_scientific_name = utils.iri_patterns.observation_iri(base_iri, "scientificName", provider_record_id)

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -165,12 +165,18 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_source: str = row["providerRecordIDSource"]
 
         # Create URIs
-        provider_identified = utils.iri_patterns.agent_iri("org", row["identifiedBy"])
+        if identified_by := row["identifiedBy"]:
+            provider_identified = utils.iri_patterns.agent_iri("org", identified_by)
+        else:
+            provider_identified = None
         sample_specimen = utils.iri_patterns.sample_iri(base_iri, "specimen", provider_record_id)
         sampling_specimen = utils.iri_patterns.sampling_iri(base_iri, "specimen", provider_record_id)
         sample_sequence = utils.iri_patterns.sample_iri(base_iri, "sequence", provider_record_id)
         sampling_sequencing = utils.iri_patterns.sampling_iri(base_iri, "sequencing", provider_record_id)
-        provider_determined_by = utils.iri_patterns.agent_iri("org", row["threatStatusDeterminedBy"])
+        if threat_status_determined_by := row["threatStatusDeterminedBy"]:
+            provider_determined_by = utils.iri_patterns.agent_iri("org", threat_status_determined_by)
+        else:
+            provider_determined_by = None
 
         provider_record_id_datatype = utils.iri_patterns.datatype_iri("recordID", provider_record_id_source)
         provider_record_id_agent = utils.iri_patterns.agent_iri("org", provider_record_id_source)
@@ -1109,19 +1115,19 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_provider_identified(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identified By Provider to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
+            uri: URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             graph (rdflib.Graph): Graph to add to
         """
         # Check for identifiedBy
-        if not row["identifiedBy"]:
+        if not uri:
             return
 
         # Add to Graph
@@ -1133,7 +1139,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
-        provider: rdflib.URIRef,
+        provider: rdflib.URIRef | None,
         provider_record_id_occurrence: rdflib.URIRef,
         scientific_name: rdflib.URIRef,
         graph: rdflib.Graph,
@@ -1146,7 +1152,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
-            provider (rdflib.URIRef): Provider associated with this node
+            provider: Provider associated with this node
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this
                 node
             scientific_name (rdflib.URIRef): Scientific Name associated with
@@ -1182,7 +1188,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         graph.add((uri, rdflib.SOSA.usedProcedure, term))
 
         # Check for identifiedBy
-        if row["identifiedBy"]:
+        if provider:
             graph.add((uri, rdflib.PROV.wasAssociatedWith, provider))
 
         # Check for dateIdentified
@@ -1196,7 +1202,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
-        provider: rdflib.URIRef,
+        provider: rdflib.URIRef | None,
         provider_record_id_occurrence: rdflib.URIRef,
         sample_specimen: rdflib.URIRef,
         verbatim_id: rdflib.URIRef,
@@ -1210,7 +1216,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
-            provider (rdflib.URIRef): Provider associated with this node
+            provider: Provider associated with this node
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this
                 node
             sample_specimen (rdflib.URIRef): Sample Specimen associated with
@@ -1256,7 +1262,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         graph.add((uri, rdflib.SOSA.usedProcedure, term))
 
         # Check for identifiedBy
-        if row["identifiedBy"]:
+        if provider:
             graph.add((uri, rdflib.PROV.wasAssociatedWith, provider))
 
         # Check for dateIdentified
@@ -3467,19 +3473,19 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_provider_determined_by(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Determined By Provider to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
+            uri: URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             graph (rdflib.Graph): Graph to add to
         """
         # Check for threatStatusDeterminedBy
-        if not row["threatStatusDeterminedBy"]:
+        if not uri:
             return
 
         # Add to Graph
@@ -3493,7 +3499,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         provider_record_id_occurrence: rdflib.URIRef,
         threat_status_value: rdflib.URIRef,
-        determined_by: rdflib.URIRef,
+        determined_by: rdflib.URIRef | None,
         graph: rdflib.Graph,
         base_iri: rdflib.Namespace,
         submission_iri: rdflib.URIRef | None,
@@ -3507,8 +3513,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this node
             threat_status_value (rdflib.URIRef): Threat Status Value associated
                 with this node
-            determined_by (rdflib.URIRef): Determined By Provider associated
-                with this node
+            determined_by: Determined By Provider associated with this node
             graph (rdflib.Graph): Graph to add to
             base_iri (rdflib.Namespace): Namespace used to construct IRIs
         """
@@ -3546,7 +3551,7 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         graph.add((temporal_entity, date_determined.rdf_in_xsd, date_determined.to_rdf_literal()))
 
         # Check for threatStatusDeterminedBy
-        if row["threatStatusDeterminedBy"]:
+        if determined_by:
             # Add wasAssociatedWith
             graph.add((uri, rdflib.PROV.wasAssociatedWith, determined_by))
 

--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -3586,14 +3586,15 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         if not row["threatStatus"]:
             return
 
-        # Combine conservationAuthority and threatStatus
-        value = f"{row['conservationAuthority']}/{row['threatStatus']}"
-
         # Retrieve vocab for field
         vocab = self.fields()["threatStatus"].get_flexible_vocab()
+        if not issubclass(vocab, vocabs.threat_status.ThreatStatus):
+            raise RuntimeError("threatStatus vocabulary is expected to be ThreatStatus")
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get_threat_status(
+            conservation_authority=row["conservationAuthority"], threat_status=row["threatStatus"]
+        )
 
         # Threat Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))

--- a/abis_mapping/templates/survey_metadata_v2/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v2/mapping.py
@@ -130,7 +130,9 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
         if submission_iri is None:
             # Legacy: When using the metadata form v1, Create BDR project IRI
-            project_iri = utils.rdf.uri(f"project/SSD-Survey-Project/{row_num}", base_iri)
+            project_iri = utils.rdf.uri_slugified(
+                base_iri, "project/SSD-Survey-Project/{row_num}", row_num=str(row_num)
+            )
         else:
             # When using metadata form v2, Use project_iri as-is, Can be None when no Project in Form.
             pass

--- a/abis_mapping/templates/survey_metadata_v3/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v3/mapping.py
@@ -163,7 +163,9 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
 
         if submission_iri is None:
             # Legacy: When using the metadata form v1, Create BDR project IRI
-            project_iri = utils.rdf.uri(f"project/SSD-Survey-Project/{row_num}", base_iri)
+            project_iri = utils.rdf.uri_slugified(
+                base_iri, "project/SSD-Survey-Project/{row_num}", row_num=str(row_num)
+            )
         else:
             # When using metadata form v2, Use project_iri as-is, Can be None when no Project in Form.
             pass

--- a/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v2/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -999,7 +999,7 @@
     skos:prefLabel "new sequencing method" ;
     schema:citation "https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000"^^xsd:anyURI .
 
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https-www-dpaw-wa-gov-au-plants-and-animals-threatened-species-and-communities-threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
     skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
     skos:definition "A type of threatStatusCheckProtocol." ;
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
@@ -1082,7 +1082,7 @@
     sosa:hasResult <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/result/threatStatus/VU> ;
     sosa:hasSimpleResult "VU" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
-    sosa:usedProcedure <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> ;
+    sosa:usedProcedure <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https-www-dpaw-wa-gov-au-plants-and-animals-threatened-species-and-communities-threatened-animals-Last-updated-13-June-2022> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/observation/threatStatus/ABC123> a tern:Observation ;

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -289,12 +289,18 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_source: str = row["providerRecordIDSource"]
 
         # Create URIs
-        provider_identified = utils.iri_patterns.agent_iri("org", row["identifiedBy"])
+        if identified_by := row["identifiedBy"]:
+            provider_identified = utils.iri_patterns.agent_iri("org", identified_by)
+        else:
+            provider_identified = None
         sample_specimen = utils.iri_patterns.sample_iri(base_iri, "specimen", provider_record_id)
         sampling_specimen = utils.iri_patterns.sampling_iri(base_iri, "specimen", provider_record_id)
         sample_sequence = utils.iri_patterns.sample_iri(base_iri, "sequence", provider_record_id)
         sampling_sequencing = utils.iri_patterns.sampling_iri(base_iri, "sequencing", provider_record_id)
-        provider_determined_by = utils.iri_patterns.agent_iri("org", row["threatStatusDeterminedBy"])
+        if threat_status_determined_by := row["threatStatusDeterminedBy"]:
+            provider_determined_by = utils.iri_patterns.agent_iri("org", threat_status_determined_by)
+        else:
+            provider_determined_by = None
 
         provider_record_id_datatype = utils.iri_patterns.datatype_iri("recordID", provider_record_id_source)
         provider_record_id_agent = utils.iri_patterns.agent_iri("org", provider_record_id_source)
@@ -1273,19 +1279,19 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_provider_identified(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identified By Provider to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
+            uri: URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             graph (rdflib.Graph): Graph to add to
         """
         # Check for identifiedBy
-        if not row["identifiedBy"]:
+        if not uri:
             return
 
         # Add to Graph
@@ -1363,7 +1369,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
-        provider: rdflib.URIRef,
+        provider: rdflib.URIRef | None,
         provider_record_id_occurrence: rdflib.URIRef,
         scientific_name: rdflib.URIRef,
         site_visit_id_temporal_map: dict[str, str] | None,
@@ -1376,7 +1382,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
-            provider (rdflib.URIRef): Provider associated with this node
+            provider: Provider associated with this node
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this
                 node
             scientific_name (rdflib.URIRef): Scientific Name associated with
@@ -1432,7 +1438,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 graph.add((temporal_entity, rdflib.RDFS.comment, rdflib.Literal(comment)))
 
         # Check for identifiedBy
-        if row["identifiedBy"]:
+        if provider:
             graph.add((uri, rdflib.PROV.wasAssociatedWith, provider))
 
     def add_observation_verbatim_id(
@@ -1440,7 +1446,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
-        provider: rdflib.URIRef,
+        provider: rdflib.URIRef | None,
         provider_record_id_occurrence: rdflib.URIRef,
         sample_specimen: rdflib.URIRef,
         verbatim_id: rdflib.URIRef,
@@ -1454,7 +1460,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
-            provider (rdflib.URIRef): Provider associated with this node
+            provider: Provider associated with this node
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this
                 node
             sample_specimen (rdflib.URIRef): Sample Specimen associated with
@@ -1520,7 +1526,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 graph.add((temporal_entity, rdflib.RDFS.comment, rdflib.Literal(comment)))
 
         # Check for identifiedBy
-        if row["identifiedBy"]:
+        if provider:
             graph.add((uri, rdflib.PROV.wasAssociatedWith, provider))
 
     def add_provider_recorded_by_agent(
@@ -3717,19 +3723,19 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_provider_determined_by(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Determined By Provider to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
+            uri: URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             graph (rdflib.Graph): Graph to add to
         """
         # Check for threatStatusDeterminedBy
-        if not row["threatStatusDeterminedBy"]:
+        if not uri:
             return
 
         # Add to Graph
@@ -3743,7 +3749,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         provider_record_id_occurrence: rdflib.URIRef,
         threat_status_value: rdflib.URIRef,
-        determined_by: rdflib.URIRef,
+        determined_by: rdflib.URIRef | None,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
         base_iri: rdflib.Namespace,
@@ -3758,8 +3764,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 node
             threat_status_value (rdflib.URIRef): Threat Status Value associated
                 with this node
-            determined_by (rdflib.URIRef): Determined By Provider associated
-                with this node
+            determined_by: Determined By Provider associated with this node
             site_visit_id_temporal_map (dict[str, str] | None): Map of site visit
                 id to default temporal entity as rdf.
             graph (rdflib.Graph): Graph to add to
@@ -3800,7 +3805,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((temporal_entity, a, rdflib.TIME.Instant))
             graph.add((temporal_entity, date_determined.rdf_in_xsd, date_determined.to_rdf_literal()))
             # Check for threatStatusDeterminedBy
-            if row["threatStatusDeterminedBy"]:
+            if determined_by:
                 # Add wasAssociatedWith
                 graph.add((uri, rdflib.PROV.wasAssociatedWith, determined_by))
             # Check for threatStatusDateDetermined

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -3850,14 +3850,15 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         if not row["threatStatus"]:
             return
 
-        # Combine conservationAuthority and threatStatus
-        value = f"{row['conservationAuthority']}/{row['threatStatus']}"
-
         # Retrieve vocab for field
         vocab = self.fields()["threatStatus"].get_flexible_vocab()
+        if not issubclass(vocab, vocabs.threat_status.ThreatStatus):
+            raise RuntimeError("threatStatus vocabulary is expected to be ThreatStatus")
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get_threat_status(
+            conservation_authority=row["conservationAuthority"], threat_status=row["threatStatus"]
+        )
 
         # Threat Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -301,8 +301,12 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_attribution = utils.iri_patterns.attribution_iri(
             base_iri, "resourceProvider", provider_record_id_source
         )
-        provider_record_id_occurrence = utils.rdf.uri(f"occurrence/{provider_record_id}", base_iri)
-        provider_record_id_biodiversity_record = utils.rdf.uri(f"biodiversityRecord/{provider_record_id}", base_iri)
+        provider_record_id_occurrence = utils.rdf.uri_slugified(
+            base_iri, "occurrence/{provider_record_id}", provider_record_id=provider_record_id
+        )
+        provider_record_id_biodiversity_record = utils.rdf.uri_slugified(
+            base_iri, "biodiversityRecord/{provider_record_id}", provider_record_id=provider_record_id
+        )
 
         # Create URIs for Observations and Observation Values
         observation_scientific_name = utils.iri_patterns.observation_iri(base_iri, "scientificName", provider_record_id)

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -1100,7 +1100,7 @@
     skos:prefLabel "new sequencing method" ;
     schema:citation "https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000"^^xsd:anyURI .
 
-<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
+<https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https-www-dpaw-wa-gov-au-plants-and-animals-threatened-species-and-communities-threatened-animals-Last-updated-13-June-2022> a skos:Concept ;
     skos:broader <http://example.com/bdr-cv/methods/threatStatusCheckProtocol> ;
     skos:definition "A type of threatStatusCheckProtocol." ;
     skos:inScheme <http://linked.data.gov.au/def/tern-cv/2fd44aca-168f-4177-b393-0688ce38102c> ;
@@ -1186,7 +1186,7 @@
     sosa:hasResult <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/result/threatStatus/VU> ;
     sosa:hasSimpleResult "VU" ;
     sosa:observedProperty <http://linked.data.gov.au/def/tern-cv/1466cc29-350d-4a23-858b-3da653fd24a6> ;
-    sosa:usedProcedure <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https//www-dpaw-wa-gov-au/plants-and-animals/threatened-species-and-communities/threatened-animals-Last-updated-13-June-2022> ;
+    sosa:usedProcedure <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/bdr-cv/methods/threatStatusCheckProtocol/Check-against-Threatened-and-Priority-Fauna-List-WA-available-from-https-www-dpaw-wa-gov-au-plants-and-animals-threatened-species-and-communities-threatened-animals-Last-updated-13-June-2022> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> .
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/observation/threatStatus/ABC123> a tern:Observation ;

--- a/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
@@ -312,12 +312,18 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_source: str = row["providerRecordIDSource"]
 
         # Create URIs
-        provider_identified = utils.iri_patterns.agent_iri("org", row["identifiedBy"])
+        if identified_by := row["identifiedBy"]:
+            provider_identified = utils.iri_patterns.agent_iri("org", identified_by)
+        else:
+            provider_identified = None
         sample_specimen = utils.iri_patterns.sample_iri(base_iri, "specimen", provider_record_id)
         sampling_specimen = utils.iri_patterns.sampling_iri(base_iri, "specimen", provider_record_id)
         sample_sequence = utils.iri_patterns.sample_iri(base_iri, "sequence", provider_record_id)
         sampling_sequencing = utils.iri_patterns.sampling_iri(base_iri, "sequencing", provider_record_id)
-        provider_determined_by = utils.iri_patterns.agent_iri("org", row["threatStatusDeterminedBy"])
+        if threat_status_determined_by := row["threatStatusDeterminedBy"]:
+            provider_determined_by = utils.iri_patterns.agent_iri("org", threat_status_determined_by)
+        else:
+            provider_determined_by = None
 
         provider_record_id_datatype = utils.iri_patterns.datatype_iri("recordID", provider_record_id_source)
         provider_record_id_agent = utils.iri_patterns.agent_iri("org", provider_record_id_source)
@@ -1385,19 +1391,19 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_provider_identified(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Identified By Provider to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
+            uri: URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             graph (rdflib.Graph): Graph to add to
         """
         # Check for identifiedBy
-        if not row["identifiedBy"]:
+        if not uri:
             return
 
         # Add to Graph
@@ -1477,7 +1483,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
-        provider: rdflib.URIRef,
+        provider: rdflib.URIRef | None,
         provider_record_id_occurrence: rdflib.URIRef,
         scientific_name: rdflib.URIRef,
         site_visit_id_temporal_map: dict[str, str] | None,
@@ -1491,7 +1497,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
-            provider (rdflib.URIRef): Provider associated with this node
+            provider: Provider associated with this node
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this
                 node
             scientific_name (rdflib.URIRef): Scientific Name associated with
@@ -1550,7 +1556,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 graph.add((temporal_entity, rdflib.RDFS.comment, rdflib.Literal(comment)))
 
         # Check for identifiedBy
-        if row["identifiedBy"]:
+        if provider:
             graph.add((uri, rdflib.PROV.wasAssociatedWith, provider))
 
     def add_observation_verbatim_id(
@@ -1558,7 +1564,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         uri: rdflib.URIRef,
         row: frictionless.Row,
         dataset: rdflib.URIRef,
-        provider: rdflib.URIRef,
+        provider: rdflib.URIRef | None,
         provider_record_id_occurrence: rdflib.URIRef,
         sample_specimen: rdflib.URIRef,
         verbatim_id: rdflib.URIRef,
@@ -1573,7 +1579,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             uri (rdflib.URIRef): URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             dataset (rdflib.URIRef): Dataset this belongs to
-            provider (rdflib.URIRef): Provider associated with this node
+            provider: Provider associated with this node
             provider_record_id_occurrence (rdflib.URIRef): Occurrence associated with this
                 node
             sample_specimen (rdflib.URIRef): Sample Specimen associated with
@@ -1642,7 +1648,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 graph.add((temporal_entity, rdflib.RDFS.comment, rdflib.Literal(comment)))
 
         # Check for identifiedBy
-        if row["identifiedBy"]:
+        if provider:
             graph.add((uri, rdflib.PROV.wasAssociatedWith, provider))
 
     def add_provider_recorded_by_agent(
@@ -3917,19 +3923,19 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
 
     def add_provider_determined_by(
         self,
-        uri: rdflib.URIRef,
+        uri: rdflib.URIRef | None,
         row: frictionless.Row,
         graph: rdflib.Graph,
     ) -> None:
         """Adds Determined By Provider to the Graph
 
         Args:
-            uri (rdflib.URIRef): URI to use for this node.
+            uri: URI to use for this node.
             row (frictionless.Row): Row to retrieve data from
             graph (rdflib.Graph): Graph to add to
         """
         # Check for threatStatusDeterminedBy
-        if not row["threatStatusDeterminedBy"]:
+        if not uri:
             return
 
         # Add to Graph
@@ -3943,7 +3949,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         dataset: rdflib.URIRef,
         provider_record_id_occurrence: rdflib.URIRef,
         threat_status_value: rdflib.URIRef,
-        determined_by: rdflib.URIRef,
+        determined_by: rdflib.URIRef | None,
         site_visit_id_temporal_map: dict[str, str] | None,
         graph: rdflib.Graph,
         base_iri: rdflib.Namespace,
@@ -3959,8 +3965,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 node
             threat_status_value (rdflib.URIRef): Threat Status Value associated
                 with this node
-            determined_by (rdflib.URIRef): Determined By Provider associated
-                with this node
+            determined_by: Determined By Provider associated with this node
             site_visit_id_temporal_map (dict[str, str] | None): Map of site visit
                 id to default temporal entity as rdf.
             graph (rdflib.Graph): Graph to add to
@@ -4004,7 +4009,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
             graph.add((temporal_entity, a, rdflib.TIME.Instant))
             graph.add((temporal_entity, date_determined.rdf_in_xsd, date_determined.to_rdf_literal()))
             # Check for threatStatusDeterminedBy
-            if row["threatStatusDeterminedBy"]:
+            if determined_by:
                 # Add wasAssociatedWith
                 graph.add((uri, rdflib.PROV.wasAssociatedWith, determined_by))
             # Check for threatStatusDateDetermined

--- a/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
@@ -324,8 +324,12 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_attribution = utils.iri_patterns.attribution_iri(
             base_iri, "resourceProvider", provider_record_id_source
         )
-        provider_record_id_occurrence = utils.rdf.uri(f"occurrence/{provider_record_id}", base_iri)
-        provider_record_id_biodiversity_record = utils.rdf.uri(f"biodiversityRecord/{provider_record_id}", base_iri)
+        provider_record_id_occurrence = utils.rdf.uri_slugified(
+            base_iri, "occurrence/{provider_record_id}", provider_record_id=provider_record_id
+        )
+        provider_record_id_biodiversity_record = utils.rdf.uri_slugified(
+            base_iri, "biodiversityRecord/{provider_record_id}", provider_record_id=provider_record_id
+        )
 
         # Create URIs for Observations and Observation Values
         observation_scientific_name = utils.iri_patterns.observation_iri(base_iri, "scientificName", provider_record_id)

--- a/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
@@ -4054,14 +4054,15 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         if not row["threatStatus"]:
             return
 
-        # Combine conservationAuthority and threatStatus
-        value = f"{row['conservationAuthority']}/{row['threatStatus']}"
-
         # Retrieve vocab for field
         vocab = self.fields()["threatStatus"].get_flexible_vocab()
+        if not issubclass(vocab, vocabs.threat_status.ThreatStatus):
+            raise RuntimeError("threatStatus vocabulary is expected to be ThreatStatus")
 
         # Retrieve term or Create on the Fly
-        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get(value)
+        term = vocab(graph=graph, source=dataset, base_iri=base_iri).get_threat_status(
+            conservation_authority=row["conservationAuthority"], threat_status=row["threatStatus"]
+        )
 
         # Threat Status Value
         graph.add((uri, a, utils.namespaces.TERN.IRI))

--- a/abis_mapping/utils/iri_patterns.py
+++ b/abis_mapping/utils/iri_patterns.py
@@ -124,7 +124,7 @@ def attribute_iri(
     Returns:
         IRI for the tern:Attribute node.
     """
-    return utils.rdf.uri(f"attribute/{attribute}/{value}", namespace=base_iri)
+    return utils.rdf.uri_slugified(base_iri, "attribute/{attribute}/{value}", attribute=attribute, value=value)
 
 
 def attribute_value_iri(
@@ -143,7 +143,7 @@ def attribute_value_iri(
     Returns:
         IRI for the tern:Value node.
     """
-    return utils.rdf.uri(f"value/{attribute}/{value}", namespace=base_iri)
+    return utils.rdf.uri_slugified(base_iri, "value/{attribute}/{value}", attribute=attribute, value=value)
 
 
 def attribute_collection_iri(
@@ -164,7 +164,13 @@ def attribute_collection_iri(
     Returns:
         IRI for the schema:Collection node.
     """
-    return utils.rdf.uri(f"{collection_type}Collection/{attribute}/{value}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "{collection_type}Collection/{attribute}/{value}",
+        collection_type=collection_type,
+        attribute=attribute,
+        value=value,
+    )
 
 
 def datatype_iri(
@@ -184,15 +190,17 @@ def datatype_iri(
     Returns:
         URIRef for the rdfs:Datatype node.
     """
-    return utils.rdf.uri(
-        f"{identifier_type}/{identifier_source}",
-        namespace=utils.namespaces.BDR_DATATYPES,
+    return utils.rdf.uri_slugified(
+        utils.namespaces.BDR_DATATYPES,
+        "{identifier_type}/{identifier_source}",
+        identifier_type=identifier_type,
+        identifier_source=identifier_source,
     )
 
 
 def agent_iri(
     agent_type: Literal["org", "person", "software"],
-    agent: str,
+    agent: str | None,
     /,
 ) -> rdflib.URIRef:
     """Get the IRI to use for a prov:Agent node.
@@ -204,9 +212,13 @@ def agent_iri(
     Returns:
         URIRef for the prov:Agent node.
     """
-    return utils.rdf.uri(
-        f"{agent_type}/{agent}",
-        namespace=utils.namespaces.DATASET_BDR,
+    return utils.rdf.uri_slugified(
+        utils.namespaces.DATASET_BDR,
+        "{agent_type}/{agent}",
+        agent_type=agent_type,
+        # Should probably be refactored to return None when agent is None
+        # but that would need lots of changes to mapping.
+        agent=str(agent),
     )
 
 
@@ -226,7 +238,12 @@ def observation_iri(
     Returns:
         The IRI for the tern:Observation node.
     """
-    return utils.rdf.uri(f"observation/{observation_type}/{provider_record_id}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "observation/{observation_type}/{provider_record_id}",
+        observation_type=observation_type,
+        provider_record_id=provider_record_id,
+    )
 
 
 def observation_value_iri(
@@ -245,7 +262,14 @@ def observation_value_iri(
     Returns:
         The IRI for the tern:Value node.
     """
-    return utils.rdf.uri(f"result/{observation_type}/{observation_value}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "result/{observation_type}/{observation_value}",
+        observation_type=observation_type,
+        # Should probably be refactored to return None when observation_value is None
+        # but that would need lots of changes to mapping.
+        observation_value=str(observation_value),
+    )
 
 
 def specimen_observation_iri(
@@ -264,7 +288,12 @@ def specimen_observation_iri(
     Returns:
         The IRI for the tern:Observation node.
     """
-    return utils.rdf.uri(f"observation/specimen/{observation_type}/{provider_record_id}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "observation/specimen/{observation_type}/{provider_record_id}",
+        observation_type=observation_type,
+        provider_record_id=provider_record_id,
+    )
 
 
 def specimen_observation_value_iri(
@@ -283,7 +312,14 @@ def specimen_observation_value_iri(
     Returns:
         The IRI for the tern:Value node.
     """
-    return utils.rdf.uri(f"result/specimen/{observation_type}/{observation_value}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "result/specimen/{observation_type}/{observation_value}",
+        observation_type=observation_type,
+        # Should probably be refactored to return None when observation_value is None
+        # but that would need lots of changes to mapping.
+        observation_value=str(observation_value),
+    )
 
 
 def sample_iri(
@@ -302,7 +338,12 @@ def sample_iri(
     Returns:
         The IRI for the tern:Sample node.
     """
-    return utils.rdf.uri(f"sample/{sample_type}/{provider_record_id}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "sample/{sample_type}/{provider_record_id}",
+        sample_type=sample_type,
+        provider_record_id=provider_record_id,
+    )
 
 
 def sampling_iri(
@@ -321,7 +362,12 @@ def sampling_iri(
     Returns:
         The IRI for the tern:Sampling node.
     """
-    return utils.rdf.uri(f"sampling/{sampling_type}/{provider_record_id}", namespace=base_iri)
+    return utils.rdf.uri_slugified(
+        base_iri,
+        "sampling/{sampling_type}/{provider_record_id}",
+        sampling_type=sampling_type,
+        provider_record_id=provider_record_id,
+    )
 
 
 def plan_iri(
@@ -374,4 +420,4 @@ def attribution_iri(
     Returns:
         The IRI for the prov:Attribution node.
     """
-    return utils.rdf.uri(f"attribution/{source}/{role}", namespace=base_iri)
+    return utils.rdf.uri_slugified(base_iri, "attribution/{source}/{role}", source=source, role=role)

--- a/abis_mapping/utils/iri_patterns.py
+++ b/abis_mapping/utils/iri_patterns.py
@@ -8,7 +8,6 @@ import urllib.parse
 
 # third party
 import rdflib
-import slugify
 
 # local
 from abis_mapping import utils
@@ -87,7 +86,7 @@ def site_iri(
     """
     # Note: the site_id_source (typically an organisation name) is slugified for readability,
     # But the site_id is url-quoted, to preserve any special characters with their representation.
-    site_id_source = slugify.slugify(site_id_source, lowercase=False)
+    site_id_source = utils.rdf.slugify_for_uri(site_id_source)
     site_id = urllib.parse.quote(site_id, safe="")
     return utils.namespaces.DATASET_BDR[f"sites/{site_id_source}/{site_id}"]
 

--- a/abis_mapping/utils/iri_patterns.py
+++ b/abis_mapping/utils/iri_patterns.py
@@ -200,7 +200,7 @@ def datatype_iri(
 
 def agent_iri(
     agent_type: Literal["org", "person", "software"],
-    agent: str | None,
+    agent: str,
     /,
 ) -> rdflib.URIRef:
     """Get the IRI to use for a prov:Agent node.
@@ -216,9 +216,7 @@ def agent_iri(
         utils.namespaces.DATASET_BDR,
         "{agent_type}/{agent}",
         agent_type=agent_type,
-        # Should probably be refactored to return None when agent is None
-        # but that would need lots of changes to mapping.
-        agent=str(agent),
+        agent=agent,
     )
 
 

--- a/abis_mapping/utils/iri_patterns.py
+++ b/abis_mapping/utils/iri_patterns.py
@@ -3,9 +3,6 @@
 This is important when the exact same IRI needs to be constructed from multiple template
 mappings so that the output RDF links together on these IRIs."""
 
-# Standard Library
-import urllib.parse
-
 # third party
 import rdflib
 
@@ -87,7 +84,7 @@ def site_iri(
     # Note: the site_id_source (typically an organisation name) is slugified for readability,
     # But the site_id is url-quoted, to preserve any special characters with their representation.
     site_id_source = utils.rdf.slugify_for_uri(site_id_source)
-    site_id = urllib.parse.quote(site_id, safe="")
+    site_id = utils.rdf.quote_for_uri(site_id)
     return utils.namespaces.DATASET_BDR[f"sites/{site_id_source}/{site_id}"]
 
 

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -158,6 +158,9 @@ def uri_quoted(
         KeyError: When the path string contains a field not specified in kwargs.
     """
     # fill in any {field} names in path with url-quoted kwargs.
+    # By url-quoting each value individually, and then formatting into the path,
+    # Any slashes (/) in the path are kept, but any slashes in each value are
+    # removed as part of the url-quoting process.
     path = path.format_map({field: quote_for_uri(value) for field, value in kwargs.items()})
 
     # Create URIRef and Return

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -66,10 +66,18 @@ def uri(
     # We split and re-join on the `/`, as forward-slashes are valid for our
     # internal URIs, but python-slugify removes them. This is the recommended
     # way to keep the slashes as per python-slugify GitHub issues.
-    internal_id = "/".join(slugify.slugify(part, lowercase=False) for part in internal_id.split("/"))
+    internal_id = "/".join(slugify_for_uri(part) for part in internal_id.split("/"))
 
     # Create URIRef and Return
     return namespace[internal_id]
+
+
+def slugify_for_uri(string: str, /) -> str:
+    """The standard way to slugify a string for use in an RDF URI.
+
+    Slugify-ing is used when readability is more important than preserving the exact value.
+    """
+    return slugify.slugify(string, lowercase=False)
 
 
 def uri_quoted(

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -50,10 +50,9 @@ def create_graph() -> rdflib.Graph:
 def uri(
     internal_id: str,
     namespace: rdflib.Namespace,
+    /,
 ) -> rdflib.URIRef:
     """Generates an rdflib.URIRef using the supplied namespace
-
-    The internal id is sanitised (slugified).
 
     Args:
         internal_id: ID to add to the namespace.
@@ -62,12 +61,6 @@ def uri(
     Returns:
         rdflib.URIRef: Generated URI for internal usage.
     """
-    # Slugify
-    # We split and re-join on the `/`, as forward-slashes are valid for our
-    # internal URIs, but python-slugify removes them. This is the recommended
-    # way to keep the slashes as per python-slugify GitHub issues.
-    internal_id = "/".join(slugify_for_uri(part) for part in internal_id.split("/"))
-
     # Create URIRef and Return
     return namespace[internal_id]
 

--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -80,6 +80,14 @@ def slugify_for_uri(string: str, /) -> str:
     return slugify.slugify(string, lowercase=False)
 
 
+def quote_for_uri(string: str, /) -> str:
+    """The standard way to URL-quote a string for use in an RDF URI.
+
+    URL-quoting is used when preserving the exact value is important.
+    """
+    return urllib.parse.quote(string, safe="")
+
+
 def uri_quoted(
     namespace: rdflib.Namespace,
     path: str,
@@ -117,7 +125,7 @@ def uri_quoted(
         KeyError: When the path string contains a field not specified in kwargs.
     """
     # fill in any {field} names in path with url-quoted kwargs.
-    path = path.format_map({field: urllib.parse.quote(value, safe="") for field, value in kwargs.items()})
+    path = path.format_map({field: quote_for_uri(value) for field, value in kwargs.items()})
 
     # Create URIRef and Return
     return namespace[path]

--- a/abis_mapping/utils/vocabs.py
+++ b/abis_mapping/utils/vocabs.py
@@ -257,12 +257,27 @@ class FlexibleVocabulary(Vocabulary):
 
         # Create our Own Concept IRI
         iri = rdf.uri(self.base + value, namespace=self.base_iri)
+        self.create(iri=iri, preferred_label=value)
+        # Return
+        return iri
 
+    def create(
+        self,
+        *,
+        iri: rdflib.URIRef,
+        preferred_label: str,
+    ) -> None:
+        """Create a new vocabulary term and add it to the graph.
+
+        Args:
+            iri: The IRI for the new vocabulary term.
+            preferred_label: The preffered label for the new vocabulary term.
+        """
         # Add to Graph
         self.graph.add((iri, a, rdflib.SKOS.Concept))
         self.graph.add((iri, rdflib.SKOS.definition, self.definition))
         self.graph.add((iri, rdflib.SKOS.inScheme, self.scheme))
-        self._add_pref_label(iri, value)
+        self._add_pref_label(iri, preferred_label)
 
         # Check for Broader IRI
         if self.broader:
@@ -279,9 +294,6 @@ class FlexibleVocabulary(Vocabulary):
 
         if self.scope_note is not None:
             self.graph.add((iri, rdflib.SKOS.scopeNote, self.scope_note))
-
-        # Return
-        return iri
 
 
 class VocabularyError(Exception):

--- a/abis_mapping/utils/vocabs.py
+++ b/abis_mapping/utils/vocabs.py
@@ -256,7 +256,7 @@ class FlexibleVocabulary(Vocabulary):
             raise VocabularyError("Value not supplied for vocabulary with no default")
 
         # Create our Own Concept IRI
-        iri = rdf.uri(self.base + value, namespace=self.base_iri)
+        iri = rdf.uri_slugified(self.base_iri, self.base + "{value}", value=value)
         self.create(iri=iri, preferred_label=value)
         # Return
         return iri

--- a/abis_mapping/vocabs/threat_status.py
+++ b/abis_mapping/vocabs/threat_status.py
@@ -844,6 +844,55 @@ class ThreatStatus(utils.vocabs.FlexibleVocabulary):
     )
     publish = False
 
+    def get(self, value: str | None) -> rdflib.URIRef:
+        raise RuntimeError("Use get_threat_status() instead of get() for the ThreatStatus vocab")
+
+    def get_threat_status(
+        self,
+        *,
+        conservation_authority: str | None,
+        threat_status: str | None,
+    ) -> rdflib.URIRef:
+        """Retrieves an IRI from the Vocabulary, or creates one on-the fly.
+
+        Does the same thing as FlexibleVocab.get() but takes the two values
+        (conservationAuthority and threatStatus) used in this vocab,
+        and combines them as appropriate.
+
+        Args:
+            conservation_authority: conservationAuthority value from the row
+            threat_status: threatStatus value from the row
+
+        Returns:
+            IRI for the Term.
+        """
+        # Combine conservationAuthority and threatStatus
+        combined_value = f"{conservation_authority}/{threat_status}"
+
+        # Sanitise Value if provided
+        sanitised_value = utils.strings.sanitise(combined_value) if conservation_authority and threat_status else None
+
+        # Retrieve if Applicable
+        if iri := self._mapping.get(sanitised_value):
+            # Return
+            return iri
+
+        # Check for Value
+        if not (conservation_authority and threat_status):
+            # Raise Error
+            raise utils.vocabs.VocabularyError("Value not supplied for vocabulary with no default")
+
+        # Create our Own Concept IRI
+        iri = utils.rdf.uri_slugified(
+            self.base_iri,
+            self.base + "{conservation_authority}/{threat_status}",
+            conservation_authority=conservation_authority,
+            threat_status=threat_status,
+        )
+        self.create(iri=iri, preferred_label=combined_value)
+        # Return
+        return iri
+
 
 # Register
 utils.vocabs.register(ThreatStatus)

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -123,3 +123,10 @@ def test_slugify_for_uri() -> None:
     assert utils.rdf.slugify_for_uri("Hëllõ 👋 Wőrľd 🌏") == "Hello-World"
     # Test RDF injection
     assert utils.rdf.slugify_for_uri("hello> .\n <evil-iri> a <hello> .\n") == "hello-evil-iri-a-hello"
+
+
+def test_quote_for_uri() -> None:
+    """Tests the quote_for_uri function"""
+    assert utils.rdf.quote_for_uri("hello world") == "hello%20world"
+    # test quotes slashes
+    assert utils.rdf.quote_for_uri("hello/world") == "hello%2Fworld"

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -103,3 +103,23 @@ def test_rdf_uri_or_string_literal(raw: str, expected: rdflib.Literal) -> None:
     """
     # Call and assert
     assert utils.rdf.uri_or_string_literal(raw) == expected
+
+
+def test_slugify_for_uri() -> None:
+    """Tests the slugify_for_uri function"""
+    assert utils.rdf.slugify_for_uri("hello world") == "hello-world"
+    # test case maintained
+    assert utils.rdf.slugify_for_uri("Hello World") == "Hello-World"
+    assert utils.rdf.slugify_for_uri("HeLLo wOrLd") == "HeLLo-wOrLd"
+    # test whitespace
+    assert utils.rdf.slugify_for_uri("  Hello  World  ") == "Hello-World"
+    assert utils.rdf.slugify_for_uri("\tHello\tWorld\t") == "Hello-World"
+    assert utils.rdf.slugify_for_uri("\r\nHello\r\nWorld\r\n") == "Hello-World"
+    # test special chars
+    assert utils.rdf.slugify_for_uri("'Hello'@World!?") == "Hello-World"
+    assert utils.rdf.slugify_for_uri("<Hello>=[World]") == "Hello-World"
+    assert utils.rdf.slugify_for_uri("Hello/World") == "Hello-World"
+    # test Unicode
+    assert utils.rdf.slugify_for_uri("Hëllõ 👋 Wőrľd 🌏") == "Hello-World"
+    # Test RDF injection
+    assert utils.rdf.slugify_for_uri("hello> .\n <evil-iri> a <hello> .\n") == "hello-evil-iri-a-hello"

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -55,6 +55,71 @@ def test_rdf_uri() -> None:
         ),
         pytest.param(
             rdflib.Namespace("https://test.com/foo/"),
+            "bar/123",
+            {},
+            rdflib.URIRef("https://test.com/foo/bar/123"),
+            id="static path with slash",
+        ),
+        pytest.param(
+            rdflib.Namespace("https://test.com/foo/"),
+            "bar/{v}",
+            {"v": "123"},
+            rdflib.URIRef("https://test.com/foo/bar/123"),
+            id="path with field to replace",
+        ),
+        pytest.param(
+            rdflib.Namespace("https://test.com/foo/"),
+            "bar/{v1}/{v2}",
+            {"v1": "123", "v2": "456"},
+            rdflib.URIRef("https://test.com/foo/bar/123/456"),
+            id="path with multiple fields to replace",
+        ),
+        pytest.param(
+            rdflib.Namespace("https://test.com/foo/"),
+            "bar/{v1}/cat/{v2}",
+            {"v1": "12/34", "v2": "A=B C?!"},
+            rdflib.URIRef("https://test.com/foo/bar/12-34/cat/A-B-C"),
+            id="path with fields to replace with special chars",
+        ),
+    ],
+)
+def test_uri_slugified(
+    namespace: rdflib.Namespace,
+    path: str,
+    fields: dict[str, str],
+    expected: rdflib.URIRef,
+) -> None:
+    """Test the uri_slugified function.
+
+    Args:
+        namespace: The namespace for the uri_slugified function
+        path: The path for the uri_slugified function
+        fields: The fields to pass as kwargs to uri_slugified
+        expected: The expected return for the uri_slugified function
+    """
+    result = utils.rdf.uri_slugified(namespace, path, **fields)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("namespace", "path", "fields", "expected"),
+    [
+        pytest.param(
+            rdflib.Namespace("https://test.com/foo/"),
+            "",
+            {},
+            rdflib.URIRef("https://test.com/foo/"),
+            id="empty path",
+        ),
+        pytest.param(
+            rdflib.Namespace("https://test.com/foo/"),
+            "bar",
+            {},
+            rdflib.URIRef("https://test.com/foo/bar"),
+            id="static path",
+        ),
+        pytest.param(
+            rdflib.Namespace("https://test.com/foo/"),
             "bar/{v}",
             {"v": "123"},
             rdflib.URIRef("https://test.com/foo/bar/123"),

--- a/tests/utils/test_rdf.py
+++ b/tests/utils/test_rdf.py
@@ -29,7 +29,7 @@ def test_rdf_uri() -> None:
     namespace = rdflib.Namespace("http://hello.org/")
 
     # Create URI
-    result = utils.rdf.uri(internal_id="world", namespace=namespace)
+    result = utils.rdf.uri("world", namespace)
 
     # Asserts
     assert isinstance(result, rdflib.URIRef)


### PR DESCRIPTION
Add new `uri_slugified()` function and use it everywhere appropriate, so that slashes (`/`) in field values are replaced with dashes when being slugified.

The old function `uri()` purposely kept slashes, this was intended for keeping slashes **between** field values, but unintentionally also kept slashes **in** field values.

Since `uri()` is now only ever called with static values, its slugifying has been removed, since all static values passed to it are already slugified.

Also did a improvement so `agent_iri()` is only called when there is an actual value in the field being used for the IRI.