### PR TITLE
BDRSPS-1205 Url-quote providerRecordID when used in IRIs

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/mapping.py
@@ -183,11 +183,9 @@ class IncidentalOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_attribution = utils.iri_patterns.attribution_iri(
             base_iri, "resourceProvider", provider_record_id_source
         )
-        provider_record_id_occurrence = utils.rdf.uri_slugified(
-            base_iri, "occurrence/{provider_record_id}", provider_record_id=provider_record_id
-        )
-        provider_record_id_biodiversity_record = utils.rdf.uri_slugified(
-            base_iri, "biodiversityRecord/{provider_record_id}", provider_record_id=provider_record_id
+        provider_record_id_occurrence = utils.iri_patterns.occurrence_iri(base_iri, provider_record_id)
+        provider_record_id_biodiversity_record = utils.iri_patterns.biodiversity_record_iri(
+            base_iri, provider_record_id
         )
 
         # Create URIs for Observations and Observation Values

--- a/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v2/mapping.py
@@ -307,11 +307,9 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_attribution = utils.iri_patterns.attribution_iri(
             base_iri, "resourceProvider", provider_record_id_source
         )
-        provider_record_id_occurrence = utils.rdf.uri_slugified(
-            base_iri, "occurrence/{provider_record_id}", provider_record_id=provider_record_id
-        )
-        provider_record_id_biodiversity_record = utils.rdf.uri_slugified(
-            base_iri, "biodiversityRecord/{provider_record_id}", provider_record_id=provider_record_id
+        provider_record_id_occurrence = utils.iri_patterns.occurrence_iri(base_iri, provider_record_id)
+        provider_record_id_biodiversity_record = utils.iri_patterns.biodiversity_record_iri(
+            base_iri, provider_record_id
         )
 
         # Create URIs for Observations and Observation Values

--- a/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
@@ -330,11 +330,9 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
         provider_record_id_attribution = utils.iri_patterns.attribution_iri(
             base_iri, "resourceProvider", provider_record_id_source
         )
-        provider_record_id_occurrence = utils.rdf.uri_slugified(
-            base_iri, "occurrence/{provider_record_id}", provider_record_id=provider_record_id
-        )
-        provider_record_id_biodiversity_record = utils.rdf.uri_slugified(
-            base_iri, "biodiversityRecord/{provider_record_id}", provider_record_id=provider_record_id
+        provider_record_id_occurrence = utils.iri_patterns.occurrence_iri(base_iri, provider_record_id)
+        provider_record_id_biodiversity_record = utils.iri_patterns.biodiversity_record_iri(
+            base_iri, provider_record_id
         )
 
         # Create URIs for Observations and Observation Values

--- a/abis_mapping/utils/iri_patterns.py
+++ b/abis_mapping/utils/iri_patterns.py
@@ -108,6 +108,50 @@ def site_visit_iri(
     return utils.rdf.uri_quoted(base_iri, "SiteVisit/{site_visit_id}", site_visit_id=site_visit_id)
 
 
+def occurrence_iri(
+    base_iri: rdflib.Namespace,
+    provider_record_id: str,
+    /,
+) -> rdflib.URIRef:
+    """
+    Get the IRI to use for a dwc:Occurrence node.
+
+    Args:
+        base_iri: The Namespace to construct the IRI from.
+        provider_record_id: The providerRecordID field from the template.
+
+    Returns:
+        The IRI for the dwc:Occurrence node.
+    """
+    return utils.rdf.uri_quoted(
+        base_iri,
+        "occurrence/{provider_record_id}",
+        provider_record_id=provider_record_id,
+    )
+
+
+def biodiversity_record_iri(
+    base_iri: rdflib.Namespace,
+    provider_record_id: str,
+    /,
+) -> rdflib.URIRef:
+    """
+    Get the IRI to use for an abis:BiodiversityRecord node.
+
+    Args:
+        base_iri: The Namespace to construct the IRI from.
+        provider_record_id: The providerRecordID field from the template.
+
+    Returns:
+        The IRI for the abis:BiodiversityRecord node.
+    """
+    return utils.rdf.uri_quoted(
+        base_iri,
+        "biodiversityRecord/{provider_record_id}",
+        provider_record_id=provider_record_id,
+    )
+
+
 def attribute_iri(
     base_iri: rdflib.Namespace,
     attribute: str,
@@ -236,7 +280,7 @@ def observation_iri(
     Returns:
         The IRI for the tern:Observation node.
     """
-    return utils.rdf.uri_slugified(
+    return utils.rdf.uri_quoted(
         base_iri,
         "observation/{observation_type}/{provider_record_id}",
         observation_type=observation_type,
@@ -286,7 +330,7 @@ def specimen_observation_iri(
     Returns:
         The IRI for the tern:Observation node.
     """
-    return utils.rdf.uri_slugified(
+    return utils.rdf.uri_quoted(
         base_iri,
         "observation/specimen/{observation_type}/{provider_record_id}",
         observation_type=observation_type,
@@ -322,7 +366,7 @@ def specimen_observation_value_iri(
 
 def sample_iri(
     base_iri: rdflib.Namespace,
-    sample_type: str,
+    sample_type: Literal["specimen", "sequence"],
     provider_record_id: str,
     /,
 ) -> rdflib.URIRef:
@@ -336,7 +380,7 @@ def sample_iri(
     Returns:
         The IRI for the tern:Sample node.
     """
-    return utils.rdf.uri_slugified(
+    return utils.rdf.uri_quoted(
         base_iri,
         "sample/{sample_type}/{provider_record_id}",
         sample_type=sample_type,
@@ -346,7 +390,7 @@ def sample_iri(
 
 def sampling_iri(
     base_iri: rdflib.Namespace,
-    sampling_type: str,
+    sampling_type: Literal["specimen", "sequencing"],
     provider_record_id: str,
     /,
 ) -> rdflib.URIRef:
@@ -360,7 +404,7 @@ def sampling_iri(
     Returns:
         The IRI for the tern:Sampling node.
     """
-    return utils.rdf.uri_slugified(
+    return utils.rdf.uri_quoted(
         base_iri,
         "sampling/{sampling_type}/{provider_record_id}",
         sampling_type=sampling_type,


### PR DESCRIPTION
This ensures that its impossible for two different record IDs, to resolve to the same IRI.
This was possible when the record ID was being slugified.

This is also consistent with our convention of url-quote IDs, slugify other values.