### PR TITLE
BDRSPS-1216 Cache `quote_for_uri()`

### DIFF
--- a/abis_mapping/utils/rdf.py
+++ b/abis_mapping/utils/rdf.py
@@ -115,6 +115,7 @@ def uri_slugified(
     return namespace[path]
 
 
+@functools.lru_cache()
 def quote_for_uri(string: str, /) -> str:
     """The standard way to URL-quote a string for use in an RDF URI.
 


### PR DESCRIPTION
Since this is often called with the same string inputs