### PR TITLE
BDRSPS-1213 Cache `fields()` mapper method

### DIFF
--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 import json
 import pathlib
+import types
 
 # Third-Party
 import frictionless
@@ -21,7 +22,7 @@ from abis_mapping import utils
 
 
 # Typing
-from collections.abc import Iterator, Set
+from collections.abc import Iterator, Set, Mapping
 from typing import Any, Final, Optional, final
 
 
@@ -428,7 +429,8 @@ class ABISMapper(abc.ABC):
 
     @final
     @classmethod
-    def fields(cls) -> dict[str, models.schema.Field]:
+    @functools.cache
+    def fields(cls) -> Mapping[str, models.schema.Field]:
         """Indexed dictionary of all fields' metadata.
 
         Returns:
@@ -438,8 +440,8 @@ class ABISMapper(abc.ABC):
         # Get schema
         schema = models.schema.Schema.model_validate(cls.schema())
 
-        # Return dictionary of fields
-        return {f.name: f for f in schema.fields}
+        # Return read-only dictionary of fields
+        return types.MappingProxyType({f.name: f for f in schema.fields})
 
     @final
     def root_dir(self) -> pathlib.Path:

--- a/abis_mapping/base/mapper.py
+++ b/abis_mapping/base/mapper.py
@@ -280,6 +280,22 @@ class ABISMapper(abc.ABC):
 
     @final
     @classmethod
+    def regular_fields_schema(cls) -> frictionless.Schema:
+        """Construct a frictionless.Schema for the regular fields in this Template.
+
+        i.e. not including any extra fields.
+        Not cached, since the frictionless.Schema class is mutable.
+
+        NOTE: different to the schema() method, which returns our internal
+        abis_mapping.models.schema.Schema class.
+
+        Returns:
+            The frictionless.Schema for this Template.
+        """
+        return frictionless.Schema.from_descriptor(cls.schema())
+
+    @final
+    @classmethod
     def extra_fields_schema(
         cls,
         data: frictionless.Row | base_types.ReadableType,
@@ -304,7 +320,7 @@ class ABISMapper(abc.ABC):
                 any fields that are duplicated within the labels of the supplied data.
         """
         # Construct schema
-        existing_schema: frictionless.Schema = frictionless.Schema.from_descriptor(cls.schema())
+        existing_schema = cls.regular_fields_schema()
 
         if isinstance(data, frictionless.Row):
             # Get list of fieldnames of row

--- a/abis_mapping/models/schema.py
+++ b/abis_mapping/models/schema.py
@@ -7,7 +7,7 @@ import pydantic
 from abis_mapping import utils
 
 # Typing
-from typing import Any, Type, Annotated
+from typing import Any, Type, Annotated, Sequence
 
 
 class Constraints(pydantic.BaseModel):
@@ -15,6 +15,13 @@ class Constraints(pydantic.BaseModel):
 
     Currently all defined below are a subset of those available from [frictionless](https://specs.frictionlessdata.io/table-schema/#constraints).
     """
+
+    model_config = pydantic.ConfigDict(
+        # Frozen because this class is returned by the cached ABISMapper.fields() method
+        frozen=True,
+        # Forbid extra fields to catch typos in json.
+        extra="forbid",
+    )
 
     required: Annotated[
         bool,
@@ -38,7 +45,7 @@ class Constraints(pydantic.BaseModel):
         float | int | None, pydantic.Field(description="As for `minimum`, but specifies a maximum value for a field.")
     ] = None
     enum: Annotated[
-        list[str] | None,
+        Sequence[str] | None,
         pydantic.Field(description="The value of the field must exactly match a value in the enum array."),
     ] = None
 
@@ -51,6 +58,13 @@ class Field(pydantic.BaseModel):
     of instruction documentation.
     [Frictionless reference](https://specs.frictionlessdata.io/table-schema).
     """
+
+    model_config = pydantic.ConfigDict(
+        # Frozen because this class is returned by the cached ABISMapper.fields() method
+        frozen=True,
+        # Forbid extra fields to catch typos in json.
+        extra="forbid",
+    )
 
     name: Annotated[
         str,
@@ -91,15 +105,12 @@ class Field(pydantic.BaseModel):
     url: Annotated[pydantic.AnyUrl | None, pydantic.Field(description="The IRI of the field's concept.")] = None
     constraints: Constraints
     vocabularies: Annotated[
-        list[str],
+        Sequence[str],
         pydantic.Field(
             description="Optional list of vocabulary IDs, defined internally within the project. Provided IDs need to have been registered to be valid. See [`abis_mapping.vocabs`](/abis_mapping/vocabs/).",
             default_factory=list,
         ),
     ]
-
-    # Allow extra fields to be captured mainly to catch errors in json
-    model_config = pydantic.ConfigDict(extra="allow")
 
     @pydantic.field_serializer("url")
     def serialize_url(self, url: pydantic.AnyUrl) -> str:
@@ -115,7 +126,7 @@ class Field(pydantic.BaseModel):
 
     @pydantic.field_validator("vocabularies", mode="after")
     @classmethod
-    def check_vocabularies(cls, values: list[str]) -> list[str]:
+    def check_vocabularies(cls, values: Sequence[str]) -> Sequence[str]:
         """Custom validation of the vocabularies field.
 
         Args:

--- a/abis_mapping/templates/survey_metadata_v3/mapping.py
+++ b/abis_mapping/templates/survey_metadata_v3/mapping.py
@@ -115,7 +115,7 @@ class SurveyMetadataMapper(base.mapper.ABISMapper):
             The set of surveyID values, as a dict.
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(

--- a/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_occurrence_data_v3/mapping.py
@@ -228,7 +228,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 in the data, values are all 'True',
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(
@@ -261,7 +261,7 @@ class SurveyOccurrenceMapper(base.mapper.ABISMapper):
                 in the data, values are all 'True',
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(

--- a/abis_mapping/templates/survey_site_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v3/mapping.py
@@ -141,7 +141,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             data: Raw data to be mapped
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(source=data, format="csv", schema=schema, encoding="utf-8")
@@ -177,7 +177,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
             datum uri.
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(

--- a/abis_mapping/templates/survey_site_visit_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_site_visit_data_v3/mapping.py
@@ -113,7 +113,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
             or None for value if there is no identifier.
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(source=data, format="csv", schema=schema, encoding="utf-8")
@@ -153,7 +153,7 @@ class SurveySiteVisitMapper(base.mapper.ABISMapper):
                 RDF (turtle) containing the default temporal entity.
         """
         # Construct schema
-        schema = frictionless.Schema.from_descriptor(self.schema())
+        schema = self.regular_fields_schema()
 
         # Construct resource
         resource = frictionless.Resource(source=data, format="csv", schema=schema, encoding="utf-8")

--- a/docs/models/markdown/Schema.schema.md
+++ b/docs/models/markdown/Schema.schema.md
@@ -27,6 +27,8 @@ Currently all defined below are a subset of those available from [frictionless](
 
 #### Type: `object`
 
+> ⚠️ Additional properties are not allowed.
+
 | Property | Type | Required | Possible values | Description |
 | -------- | ---- | -------- | --------------- | ----------- |
 | required | `boolean` | ✅ | boolean | Indicates whether this field cannot be null. If required is false (the default), then null is allowed. |
@@ -45,6 +47,8 @@ of instruction documentation.
 [Frictionless reference](https://specs.frictionlessdata.io/table-schema).
 
 #### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
 
 | Property | Type | Required | Possible values | Description |
 | -------- | ---- | -------- | --------------- | ----------- |

--- a/tests/base/test_mapper.py
+++ b/tests/base/test_mapper.py
@@ -23,17 +23,6 @@ from typing import Any
 from abis_mapping.base import types as base_types
 
 
-class ContextualStringIO(io.StringIO):
-    """An implementation to allow examining the final value of a StringIO prior to close."""
-
-    final_buffer: str
-
-    def close(self) -> None:
-        """Sets the final_buffer prior to close."""
-        self.final_buffer = self.getvalue()
-        super().close()
-
-
 class StubMapper(base.mapper.ABISMapper):
     def apply_mapping_row(
         self,

--- a/tests/templates/test_common.py
+++ b/tests/templates/test_common.py
@@ -16,6 +16,9 @@ import abis_mapping.base
 import abis_mapping.models
 from tests.templates import conftest
 
+# Typing
+from collections.abc import Mapping
+
 
 def test_registered_templates() -> None:
     """Test to check/document which templates are registered."""
@@ -165,9 +168,20 @@ class TestTemplateBasicSuite:
         for field in descriptor["fields"]:
             valid_field = abis_mapping.models.schema.Field.model_validate(field, strict=True)
             assert valid_field
-            # Should have no extra fields defined but if it does then needs to
-            # be reviewed and decided to be added to model
-            assert valid_field.__pydantic_extra__ == {}
+
+    def test_fields(self, test_params: conftest.TemplateTestParameters) -> None:
+        """Test that the fields() method works"""
+        # Get mapper
+        mapper = abis_mapping.get_mapper(test_params.template_id)
+        assert mapper
+
+        # This should raise an error if there are any errors in the field json.
+        fields = mapper.fields()
+        assert isinstance(fields, Mapping)
+
+        for key, field in fields.items():
+            assert isinstance(key, str)
+            assert isinstance(field, abis_mapping.models.schema.Field)
 
     def test_validation_empty_template(self, test_params: conftest.TemplateTestParameters) -> None:
         """Tests validation fails for empty template."""


### PR DESCRIPTION
The `fields()` method does an expensive `models.schema.Schema.model_validate(...)` call,
but is also called multiple times per row when mapping.

This PR adds a `functools.cache` to it, so the return values is cached per mapper class.
To the prevent the cached value being mutated, it also makes its return value immutable.

It also refactors some repeated code into a new `regular_fields_schema` method.