### PR TITLE
BDRSS-656 Fix generate_example_ttl_files.py script 

### DIFF
--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -1151,7 +1151,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/8022FSJMJ079c5cf> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N379318f147aeb91b318c456100000001 ;
+    geo:hasGeometry _:N3bb12ed5a66f4695174d6bd600000001 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "sequencing-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sample/specimen/8022FSJMJ079c5cf> ;
@@ -1164,7 +1164,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/ABC123> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N379318f147aeb91b318c456100000003 ;
+    geo:hasGeometry _:N3bb12ed5a66f4695174d6bd600000003 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "sequencing-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sample/specimen/ABC123> ;
@@ -1570,7 +1570,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/13> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N2a4aaba5767794f3d704f7fc00000001 ;
+    geo:hasGeometry _:Nfc9ba55a50d500211c02e20000000001 ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/13> ;
     sosa:hasResult <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sample/specimen/13> ;
@@ -1582,7 +1582,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N2a4aaba5767794f3d704f7fc00000003 ;
+    geo:hasGeometry _:Nfc9ba55a50d500211c02e20000000003 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8022FSJMJ079c5cf> ;
@@ -1594,7 +1594,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N2a4aaba5767794f3d704f7fc00000005 ;
+    geo:hasGeometry _:Nfc9ba55a50d500211c02e20000000005 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/ABC123> ;
@@ -1658,7 +1658,7 @@
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000016 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000016 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
@@ -1682,7 +1682,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000000 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000000 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1694,7 +1694,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000012 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000012 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1706,7 +1706,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000014 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000014 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1718,7 +1718,7 @@
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:identifier "PE:12:8831" ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000002 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000002 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1730,7 +1730,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/c6c0efa61d3303c1> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000004 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000004 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1742,7 +1742,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000006 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000006 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1754,7 +1754,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000008 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000008 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1766,7 +1766,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d20000000a ;
+    schema:spatial _:N489292b7f1191795326ddd220000000a ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1778,7 +1778,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d20000000c ;
+    schema:spatial _:N489292b7f1191795326ddd220000000c ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1790,7 +1790,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d20000000e ;
+    schema:spatial _:N489292b7f1191795326ddd220000000e ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1802,7 +1802,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000010 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000010 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1834,7 +1834,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d200000018 ;
+    schema:spatial _:N489292b7f1191795326ddd2200000018 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1848,7 +1848,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d20000001a ;
+    schema:spatial _:N489292b7f1191795326ddd220000001a ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1893,7 +1893,7 @@
         "MR-456"^^<https://linked.data.gov.au/dataset/bdr/datatypes/recordID/Stream-Environment-and-Water-Pty-Ltd>,
         "PE:12:8832"^^<https://linked.data.gov.au/dataset/bdr/datatypes/recordNumber/Stream-Environment-and-Water-Pty-Ltd> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d20000001c ;
+    schema:spatial _:N489292b7f1191795326ddd220000001c ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1911,7 +1911,7 @@
         "MR-457"^^<https://linked.data.gov.au/dataset/bdr/datatypes/recordID/Stream-Environment-and-Water-Pty-Ltd>,
         "PE:12:8833"^^<https://linked.data.gov.au/dataset/bdr/datatypes/recordNumber/Stream-Environment-and-Water-Pty-Ltd> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N5285e686355d0c112335e3d20000001e ;
+    schema:spatial _:N489292b7f1191795326ddd220000001e ;
     schema:temporal [ a time:TemporalEntity ;
             time:hasBeginning [ a time:Instant ;
                     time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1931,7 +1931,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000000 ;
+    rdf:object _:N489292b7f1191795326ddd2200000000 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/1> ;
     rdfs:comment "supplied as" .
@@ -1939,7 +1939,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000002 ;
+    rdf:object _:N489292b7f1191795326ddd2200000002 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/2> ;
     rdfs:comment "supplied as" .
@@ -1947,7 +1947,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000004 ;
+    rdf:object _:N489292b7f1191795326ddd2200000004 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/3> ;
     rdfs:comment "supplied as" .
@@ -1955,7 +1955,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000006 ;
+    rdf:object _:N489292b7f1191795326ddd2200000006 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/4> ;
     rdfs:comment "supplied as" .
@@ -1963,7 +1963,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000008 ;
+    rdf:object _:N489292b7f1191795326ddd2200000008 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/5> ;
     rdfs:comment "supplied as" .
@@ -1971,7 +1971,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d20000000a ;
+    rdf:object _:N489292b7f1191795326ddd220000000a ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/6> ;
     rdfs:comment "supplied as" .
@@ -1979,7 +1979,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d20000000c ;
+    rdf:object _:N489292b7f1191795326ddd220000000c ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/7> ;
     rdfs:comment "supplied as" .
@@ -1987,7 +1987,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d20000000e ;
+    rdf:object _:N489292b7f1191795326ddd220000000e ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8> ;
     rdfs:comment "supplied as" .
@@ -1995,7 +1995,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000010 ;
+    rdf:object _:N489292b7f1191795326ddd2200000010 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/9> ;
     rdfs:comment "supplied as" .
@@ -2003,7 +2003,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000012 ;
+    rdf:object _:N489292b7f1191795326ddd2200000012 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/10> ;
     rdfs:comment "supplied as" .
@@ -2011,7 +2011,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000014 ;
+    rdf:object _:N489292b7f1191795326ddd2200000014 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/11> ;
     rdfs:comment "supplied as" .
@@ -2019,7 +2019,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000016 ;
+    rdf:object _:N489292b7f1191795326ddd2200000016 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/12> ;
     rdfs:comment "supplied as" .
@@ -2027,7 +2027,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N5285e686355d0c112335e3d200000018 ;
+    rdf:object _:N489292b7f1191795326ddd2200000018 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/13> ;
     rdfs:comment "supplied as" .
@@ -2036,7 +2036,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 2e+01 ] ;
-    rdf:object _:N5285e686355d0c112335e3d20000001a ;
+    rdf:object _:N489292b7f1191795326ddd220000001a ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/14> ;
     rdfs:comment "supplied as" .
@@ -2045,7 +2045,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:N5285e686355d0c112335e3d20000001c ;
+    rdf:object _:N489292b7f1191795326ddd220000001c ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" .
@@ -2054,7 +2054,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 3e+01 ] ;
-    rdf:object _:N5285e686355d0c112335e3d20000001e ;
+    rdf:object _:N489292b7f1191795326ddd220000001e ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/ABC123> ;
     rdfs:comment "supplied as" .
@@ -2062,7 +2062,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N379318f147aeb91b318c456100000001 ;
+    rdf:object _:N3bb12ed5a66f4695174d6bd600000001 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" .
@@ -2070,7 +2070,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N379318f147aeb91b318c456100000003 ;
+    rdf:object _:N3bb12ed5a66f4695174d6bd600000003 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/ABC123> ;
     rdfs:comment "supplied as" .
@@ -2078,7 +2078,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:N2a4aaba5767794f3d704f7fc00000001 ;
+    rdf:object _:Nfc9ba55a50d500211c02e20000000001 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/13> ;
     rdfs:comment "supplied as" .
@@ -2086,7 +2086,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N2a4aaba5767794f3d704f7fc00000003 ;
+    rdf:object _:Nfc9ba55a50d500211c02e20000000003 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" .
@@ -2094,79 +2094,79 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N2a4aaba5767794f3d704f7fc00000005 ;
+    rdf:object _:Nfc9ba55a50d500211c02e20000000005 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> ;
     rdfs:comment "supplied as" .
 
-_:N2a4aaba5767794f3d704f7fc00000001 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:N2a4aaba5767794f3d704f7fc00000003 a geo:Geometry ;
+_:N3bb12ed5a66f4695174d6bd600000001 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N2a4aaba5767794f3d704f7fc00000005 a geo:Geometry ;
+_:N3bb12ed5a66f4695174d6bd600000003 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:N379318f147aeb91b318c456100000001 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:N379318f147aeb91b318c456100000003 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
-    rdfs:comment "Location unknown, location of field sampling used as proxy" .
-
-_:N5285e686355d0c112335e3d200000000 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000000 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000002 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000002 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000004 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000004 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000006 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000006 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000008 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000008 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d20000000a a geo:Geometry ;
+_:N489292b7f1191795326ddd220000000a a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d20000000c a geo:Geometry ;
+_:N489292b7f1191795326ddd220000000c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d20000000e a geo:Geometry ;
+_:N489292b7f1191795326ddd220000000e a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000010 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000010 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000012 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000012 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000014 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000014 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000016 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000016 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d200000018 a geo:Geometry ;
+_:N489292b7f1191795326ddd2200000018 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:N5285e686355d0c112335e3d20000001a a geo:Geometry ;
+_:N489292b7f1191795326ddd220000001a a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 2e+01 .
 
-_:N5285e686355d0c112335e3d20000001c a geo:Geometry ;
+_:N489292b7f1191795326ddd220000001c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
-_:N5285e686355d0c112335e3d20000001e a geo:Geometry ;
+_:N489292b7f1191795326ddd220000001e a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 3e+01 .
+
+_:Nfc9ba55a50d500211c02e20000000001 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:Nfc9ba55a50d500211c02e20000000003 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
+
+_:Nfc9ba55a50d500211c02e20000000005 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    rdfs:comment "Location unknown, location of field sampling used as proxy" .
 

--- a/abis_mapping/templates/survey_metadata_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_metadata_v3/examples/minimal.ttl
@@ -140,7 +140,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL1> a tern:Survey ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N9ccb189beb09dc137aaa1fb400000000 ;
+    geo:hasGeometry _:N27fdbd9c9077333e51ac0d0600000000 ;
     prov:hadPlan <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/survey/plan/COL1> ;
     bdr:purpose "Summer sampling for peak insect diversity." ;
     bdr:target "Coleoptera",
@@ -164,7 +164,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL2> a tern:Survey ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N9ccb189beb09dc137aaa1fb400000001 ;
+    geo:hasGeometry _:N27fdbd9c9077333e51ac0d0600000001 ;
     prov:hadPlan <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/survey/plan/COL2> ;
     bdr:purpose "Winter sampling for peak insect diversity." ;
     bdr:target "Coleoptera",
@@ -205,7 +205,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.826 146.363, -33.826 148.499, -34.411 148.499, -33.826 146.363))"^^geo:wktLiteral ] ;
-    rdf:object _:N9ccb189beb09dc137aaa1fb400000000 ;
+    rdf:object _:N27fdbd9c9077333e51ac0d0600000000 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL1> ;
     rdfs:comment "supplied as" .
@@ -213,14 +213,14 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.826 146.363, -33.826 148.499, -34.411 148.499, -33.826 146.363))"^^geo:wktLiteral ] ;
-    rdf:object _:N9ccb189beb09dc137aaa1fb400000001 ;
+    rdf:object _:N27fdbd9c9077333e51ac0d0600000001 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/COL2> ;
     rdfs:comment "supplied as" .
 
-_:N9ccb189beb09dc137aaa1fb400000000 a geo:Geometry ;
+_:N27fdbd9c9077333e51ac0d0600000000 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.826 146.363, -33.826 148.499, -34.411 148.499, -33.826 146.363))"^^geo:wktLiteral .
 
-_:N9ccb189beb09dc137aaa1fb400000001 a geo:Geometry ;
+_:N27fdbd9c9077333e51ac0d0600000001 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.826 146.363, -33.826 148.499, -34.411 148.499, -33.826 146.363))"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -1145,7 +1145,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/8022FSJMJ079c5cf> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:Nc9e80a8065e2af27e3990a2c00000001 ;
+    geo:hasGeometry _:Nbaf38917362852ca9a9a0d2500000001 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "sequencing-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sample/specimen/8022FSJMJ079c5cf> ;
@@ -1158,7 +1158,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/ABC123> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:Nc9e80a8065e2af27e3990a2c00000003 ;
+    geo:hasGeometry _:Nbaf38917362852ca9a9a0d2500000003 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "sequencing-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sample/specimen/ABC123> ;
@@ -1569,7 +1569,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/13> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:Ne577c38a66af45121bf5425100000001 ;
+    geo:hasGeometry _:Nfcd8f1042640aeab2a686b1700000001 ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/13> ;
     sosa:hasResult <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sample/specimen/13> ;
@@ -1581,7 +1581,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:Ne577c38a66af45121bf5425100000003 ;
+    geo:hasGeometry _:Nfcd8f1042640aeab2a686b1700000003 ;
     geo:hasMetricSpatialAccuracy 5e+01 ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8022FSJMJ079c5cf> ;
@@ -1593,7 +1593,7 @@
 
 <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> a tern:Sampling ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:Ne577c38a66af45121bf5425100000005 ;
+    geo:hasGeometry _:Nfcd8f1042640aeab2a686b1700000005 ;
     geo:hasMetricSpatialAccuracy 3e+01 ;
     rdfs:comment "specimen-sampling" ;
     sosa:hasFeatureOfInterest <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/ABC123> ;
@@ -1661,7 +1661,7 @@
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000016 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000016 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> .
@@ -1685,7 +1685,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000000 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000000 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1697,7 +1697,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000012 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000012 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1709,7 +1709,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000014 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000014 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1721,7 +1721,7 @@
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:identifier "PE:12:8831" ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000002 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000002 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1733,7 +1733,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/c6c0efa61d3303c1> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000004 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000004 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1745,7 +1745,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000006 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000006 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1757,7 +1757,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000008 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000008 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1769,7 +1769,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d550000000a ;
+    schema:spatial _:N7bfc9936b099cf9353fc57550000000a ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1781,7 +1781,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d550000000c ;
+    schema:spatial _:N7bfc9936b099cf9353fc57550000000c ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1793,7 +1793,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d550000000e ;
+    schema:spatial _:N7bfc9936b099cf9353fc57550000000e ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1805,7 +1805,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000010 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000010 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1837,7 +1837,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d5500000018 ;
+    schema:spatial _:N7bfc9936b099cf9353fc575500000018 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1851,7 +1851,7 @@
     prov:wasAssociatedWith <https://linked.data.gov.au/dataset/bdr/person/109931be4a60d874> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d550000001a ;
+    schema:spatial _:N7bfc9936b099cf9353fc57550000001a ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1898,7 +1898,7 @@
         "PE:12:8832"^^<https://linked.data.gov.au/dataset/bdr/datatypes/recordNumber/Stream-Environment-and-Water-Pty-Ltd> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000>,
         <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/MR-R1> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d550000001c ;
+    schema:spatial _:N7bfc9936b099cf9353fc57550000001c ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-26"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -1919,7 +1919,7 @@
         "PE:12:8833"^^<https://linked.data.gov.au/dataset/bdr/datatypes/recordNumber/Stream-Environment-and-Water-Pty-Ltd> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000>,
         <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/Survey/MR-R1> ;
-    schema:spatial _:Na409e7548401ac9b4eb79d550000001e ;
+    schema:spatial _:N7bfc9936b099cf9353fc57550000001e ;
     schema:temporal [ a time:TemporalEntity ;
             time:hasBeginning [ a time:Instant ;
                     time:inXSDDate "2019-09-26"^^xsd:date ] ;
@@ -1939,7 +1939,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nc9e80a8065e2af27e3990a2c00000001 ;
+    rdf:object _:Nbaf38917362852ca9a9a0d2500000001 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" .
@@ -1947,39 +1947,15 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Nc9e80a8065e2af27e3990a2c00000003 ;
+    rdf:object _:Nbaf38917362852ca9a9a0d2500000003 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/ABC123> ;
     rdfs:comment "supplied as" .
 
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Ne577c38a66af45121bf5425100000001 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/13> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Ne577c38a66af45121bf5425100000003 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Ne577c38a66af45121bf5425100000005 ;
-    rdf:predicate geo:hasGeometry ;
-    rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> ;
-    rdfs:comment "supplied as" .
-
-[] a rdf:Statement ;
-    geo:hasGeometry [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000000 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000000 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/1> ;
     rdfs:comment "supplied as" .
@@ -1987,7 +1963,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000002 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000002 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/2> ;
     rdfs:comment "supplied as" .
@@ -1995,7 +1971,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000004 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000004 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/3> ;
     rdfs:comment "supplied as" .
@@ -2003,7 +1979,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.01)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000006 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000006 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/4> ;
     rdfs:comment "supplied as" .
@@ -2011,7 +1987,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000008 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000008 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/5> ;
     rdfs:comment "supplied as" .
@@ -2019,7 +1995,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d550000000a ;
+    rdf:object _:N7bfc9936b099cf9353fc57550000000a ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/6> ;
     rdfs:comment "supplied as" .
@@ -2027,7 +2003,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d550000000c ;
+    rdf:object _:N7bfc9936b099cf9353fc57550000000c ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/7> ;
     rdfs:comment "supplied as" .
@@ -2035,7 +2011,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 114.99)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d550000000e ;
+    rdf:object _:N7bfc9936b099cf9353fc57550000000e ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8> ;
     rdfs:comment "supplied as" .
@@ -2043,7 +2019,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000010 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000010 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/9> ;
     rdfs:comment "supplied as" .
@@ -2051,7 +2027,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000012 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000012 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/10> ;
     rdfs:comment "supplied as" .
@@ -2059,7 +2035,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000014 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000014 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/11> ;
     rdfs:comment "supplied as" .
@@ -2067,7 +2043,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000016 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000016 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/12> ;
     rdfs:comment "supplied as" .
@@ -2075,7 +2051,7 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d5500000018 ;
+    rdf:object _:N7bfc9936b099cf9353fc575500000018 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/13> ;
     rdfs:comment "supplied as" .
@@ -2084,7 +2060,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 2e+01 ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d550000001a ;
+    rdf:object _:N7bfc9936b099cf9353fc57550000001a ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/14> ;
     rdfs:comment "supplied as" .
@@ -2093,7 +2069,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d550000001c ;
+    rdf:object _:N7bfc9936b099cf9353fc57550000001c ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" .
@@ -2102,79 +2078,103 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 3e+01 ] ;
-    rdf:object _:Na409e7548401ac9b4eb79d550000001e ;
+    rdf:object _:N7bfc9936b099cf9353fc57550000001e ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/ABC123> ;
     rdfs:comment "supplied as" .
 
-_:Na409e7548401ac9b4eb79d5500000000 a geo:Geometry ;
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.86 115.02)"^^geo:wktLiteral ] ;
+    rdf:object _:Nfcd8f1042640aeab2a686b1700000001 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/13> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Nfcd8f1042640aeab2a686b1700000003 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> ;
+    rdfs:comment "supplied as" .
+
+[] a rdf:Statement ;
+    geo:hasGeometry [ a geo:Geometry ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
+    rdf:object _:Nfcd8f1042640aeab2a686b1700000005 ;
+    rdf:predicate geo:hasGeometry ;
+    rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> ;
+    rdfs:comment "supplied as" .
+
+_:N7bfc9936b099cf9353fc575500000000 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000002 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000002 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000004 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000004 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000006 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000006 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000008 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000008 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d550000000a a geo:Geometry ;
+_:N7bfc9936b099cf9353fc57550000000a a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d550000000c a geo:Geometry ;
+_:N7bfc9936b099cf9353fc57550000000c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d550000000e a geo:Geometry ;
+_:N7bfc9936b099cf9353fc57550000000e a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 114.99)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000010 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000010 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000012 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000012 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000014 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000014 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000016 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000016 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d5500000018 a geo:Geometry ;
+_:N7bfc9936b099cf9353fc575500000018 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
-_:Na409e7548401ac9b4eb79d550000001a a geo:Geometry ;
+_:N7bfc9936b099cf9353fc57550000001a a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 2e+01 .
 
-_:Na409e7548401ac9b4eb79d550000001c a geo:Geometry ;
+_:N7bfc9936b099cf9353fc57550000001c a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
-_:Na409e7548401ac9b4eb79d550000001e a geo:Geometry ;
+_:N7bfc9936b099cf9353fc57550000001e a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 3e+01 .
 
-_:Nc9e80a8065e2af27e3990a2c00000001 a geo:Geometry ;
+_:Nbaf38917362852ca9a9a0d2500000001 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:Nc9e80a8065e2af27e3990a2c00000003 a geo:Geometry ;
+_:Nbaf38917362852ca9a9a0d2500000003 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:Ne577c38a66af45121bf5425100000001 a geo:Geometry ;
+_:Nfcd8f1042640aeab2a686b1700000001 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:Ne577c38a66af45121bf5425100000003 a geo:Geometry ;
+_:Nfcd8f1042640aeab2a686b1700000003 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
-_:Ne577c38a66af45121bf5425100000005 a geo:Geometry ;
+_:Nfcd8f1042640aeab2a686b1700000005 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
@@ -95,7 +95,7 @@
     sosa:isSampleOf <https://linked.data.gov.au/dataset/bdr/sites/TERN/P1> ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/a8db263e-7a39-5b85-a5d2-8e1af7ce1e39> ;
     schema:isPartOf <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000> ;
-    schema:spatial _:N4b9625d9f7e27173ca9dc16700000000 ;
+    schema:spatial _:Nb0c3d4fa822b88b4d3f8743700000000 ;
     schema:temporal [ a time:Instant ;
             time:inXSDDate "2019-09-24"^^xsd:date ] ;
     tern:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
@@ -109,11 +109,11 @@
 [] a rdf:Statement ;
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] ;
-    rdf:object _:N4b9625d9f7e27173ca9dc16700000000 ;
+    rdf:object _:Nb0c3d4fa822b88b4d3f8743700000000 ;
     rdf:predicate schema:spatial ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/A0010> ;
     rdfs:comment "supplied as" .
 
-_:N4b9625d9f7e27173ca9dc16700000000 a geo:Geometry ;
+_:Nb0c3d4fa822b88b4d3f8743700000000 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/survey_site_data_v3/examples/minimal.ttl
+++ b/abis_mapping/templates/survey_site_data_v3/examples/minimal.ttl
@@ -63,7 +63,7 @@
     schema:name "WAM" .
 
 <https://example.com/site/WAM/P0> a tern:Site ;
-    geo:hasGeometry _:N5d102da50a40cbfd9a88c4a700000000 ;
+    geo:hasGeometry _:N9466fd6e9e4c9aa92b83d28000000000 ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     schema:description "Footprint of study area" ;
     schema:identifier "P0"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
@@ -72,8 +72,8 @@
     tern:locationDescription "Cowaramup Bay Road" .
 
 <https://example.com/site/WAM/P1> a tern:Site ;
-    geo:hasGeometry _:N5d102da50a40cbfd9a88c4a700000001,
-        _:Na5a70e7930f8a7b79ec1dd3200000000 ;
+    geo:hasGeometry _:N3bba75fe5be4a400a5af80dd00000000,
+        _:N9466fd6e9e4c9aa92b83d28000000001 ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
     schema:isPartOf <https://example.com/site/WAM/P0> ;
@@ -83,8 +83,8 @@
 
 <https://linked.data.gov.au/dataset/bdr/sites/WAM/P3> a tern:Site ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N5d102da50a40cbfd9a88c4a700000003,
-        _:Na5a70e7930f8a7b79ec1dd3200000002 ;
+    geo:hasGeometry _:N3bba75fe5be4a400a5af80dd00000002,
+        _:N9466fd6e9e4c9aa92b83d28000000003 ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
     schema:identifier "P3"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
@@ -97,8 +97,8 @@
 
 <https://linked.data.gov.au/dataset/bdr/sites/WAM/P2> a tern:Site ;
     void:inDataset <https://linked.data.gov.au/dataset/bdr/submission/00000000-0000-0000-0000-000000000000> ;
-    geo:hasGeometry _:N5d102da50a40cbfd9a88c4a700000002,
-        _:Na5a70e7930f8a7b79ec1dd3200000001 ;
+    geo:hasGeometry _:N3bba75fe5be4a400a5af80dd00000001,
+        _:N9466fd6e9e4c9aa92b83d28000000002 ;
     schema:additionalType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
     schema:description "Fine woody debris." ;
     schema:identifier "P2"^^<https://linked.data.gov.au/dataset/bdr/datatypes/siteID/WAM> ;
@@ -113,7 +113,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POLYGON ((-33.85 114.98, -33.85 115.01, -33.87 115.01, -33.87 114.98, -33.85 114.98))"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:N5d102da50a40cbfd9a88c4a700000000 ;
+    rdf:object _:N9466fd6e9e4c9aa92b83d28000000000 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://example.com/site/WAM/P0> ;
     rdfs:comment "supplied as" .
@@ -122,7 +122,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:N5d102da50a40cbfd9a88c4a700000001 ;
+    rdf:object _:N9466fd6e9e4c9aa92b83d28000000001 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://example.com/site/WAM/P1> ;
     rdfs:comment "supplied as" .
@@ -131,7 +131,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:N5d102da50a40cbfd9a88c4a700000002 ;
+    rdf:object _:N9466fd6e9e4c9aa92b83d28000000002 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/sites/WAM/P2> ;
     rdfs:comment "supplied as" .
@@ -140,7 +140,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:N5d102da50a40cbfd9a88c4a700000003 ;
+    rdf:object _:N9466fd6e9e4c9aa92b83d28000000003 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/sites/WAM/P3> ;
     rdfs:comment "supplied as" .
@@ -149,7 +149,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.85 114.99)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:Na5a70e7930f8a7b79ec1dd3200000000 ;
+    rdf:object _:N3bba75fe5be4a400a5af80dd00000000 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://example.com/site/WAM/P1> ;
     rdfs:comment "supplied as" .
@@ -158,7 +158,7 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.85 114.99)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:Na5a70e7930f8a7b79ec1dd3200000001 ;
+    rdf:object _:N3bba75fe5be4a400a5af80dd00000001 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/sites/WAM/P2> ;
     rdfs:comment "supplied as" .
@@ -167,36 +167,36 @@
     geo:hasGeometry [ a geo:Geometry ;
             geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.85 114.99)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] ;
-    rdf:object _:Na5a70e7930f8a7b79ec1dd3200000002 ;
+    rdf:object _:N3bba75fe5be4a400a5af80dd00000002 ;
     rdf:predicate geo:hasGeometry ;
     rdf:subject <https://linked.data.gov.au/dataset/bdr/sites/WAM/P3> ;
     rdfs:comment "supplied as" .
 
-_:N5d102da50a40cbfd9a88c4a700000000 a geo:Geometry ;
+_:N3bba75fe5be4a400a5af80dd00000000 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
+    geo:hasMetricSpatialAccuracy 5e+01 .
+
+_:N3bba75fe5be4a400a5af80dd00000001 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
+    geo:hasMetricSpatialAccuracy 5e+01 .
+
+_:N3bba75fe5be4a400a5af80dd00000002 a geo:Geometry ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
+    geo:hasMetricSpatialAccuracy 5e+01 .
+
+_:N9466fd6e9e4c9aa92b83d28000000000 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POLYGON ((-33.85 114.98, -33.85 115.01, -33.87 115.01, -33.87 114.98, -33.85 114.98))"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
-_:N5d102da50a40cbfd9a88c4a700000001 a geo:Geometry ;
+_:N9466fd6e9e4c9aa92b83d28000000001 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
-_:N5d102da50a40cbfd9a88c4a700000002 a geo:Geometry ;
+_:N9466fd6e9e4c9aa92b83d28000000002 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
-_:N5d102da50a40cbfd9a88c4a700000003 a geo:Geometry ;
+_:N9466fd6e9e4c9aa92b83d28000000003 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> LINESTRING (-33.85 114.99, -33.85 115)"^^geo:wktLiteral ;
-    geo:hasMetricSpatialAccuracy 5e+01 .
-
-_:Na5a70e7930f8a7b79ec1dd3200000000 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
-    geo:hasMetricSpatialAccuracy 5e+01 .
-
-_:Na5a70e7930f8a7b79ec1dd3200000001 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
-    geo:hasMetricSpatialAccuracy 5e+01 .
-
-_:Na5a70e7930f8a7b79ec1dd3200000002 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.85 114.99)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 

--- a/scripts/generate_example_ttl_files.py
+++ b/scripts/generate_example_ttl_files.py
@@ -23,7 +23,7 @@ import tests.templates.conftest
 
 # Global vars
 COUNTERS: collections.abc.Mapping[bytes, collections.abc.Iterator[int]] = collections.defaultdict(itertools.count)
-TTL_FILE_PATH: str = ""
+TTL_FILE_PATH: pathlib.Path = pathlib.Path()
 
 
 def main() -> None:
@@ -73,7 +73,7 @@ def main() -> None:
         print(f"Generating {output_ttl_file_path}...")
 
         # set global var
-        TTL_FILE_PATH = str(output_ttl_file_path)
+        TTL_FILE_PATH = output_ttl_file_path
 
         # Get Mapper
         mapper = abis_mapping.get_mapper(template_id)
@@ -112,8 +112,10 @@ def _custom_sn_gen() -> str:
     # i.e. when the same hash occurs, they will be numbered 0,1,2,etc. at the end of the ID.
     # This ensures each ID should be globally unique.
     code_path_hash = hashlib.blake2b(digest_size=12, person=b"gen_b_node_id")
-    # hash ttl file path.
-    code_path_hash.update(TTL_FILE_PATH.encode("utf-8"))
+    # hash ttl file path;
+    # Cast path to PurePosixPath before getting a str representation,
+    # So that the string representation is the same on linux and windows.
+    code_path_hash.update(str(pathlib.PurePosixPath(TTL_FILE_PATH)).encode("utf-8"))
     # Hash functions in the abis_mapping module called to make this BNode()
     for frame in inspect.stack():
         # NOTE "abis_mapping" with underscore is the module name.


### PR DESCRIPTION
so the output is the same on windows and linux

Note: all the `.ttl` diff is because the script was last ran and committed on windows, this PR returns it to the linux output,
which should also be the output on windows once this PR is merged.