### PR TITLE
BDRHD-38 Output latlongs in RDF with same precision as CSV input

### DIFF
--- a/abis_mapping/models/spatial.py
+++ b/abis_mapping/models/spatial.py
@@ -167,28 +167,31 @@ class Geometry:
             ValueError: If the supplied literal does not match GeoSPARQL
                 format
         """
-        # Compile regex
-        regex = re.compile(r"^(?:<(\S+)>)? ?(.*)$")
+        # Common case - Point with datum, string like "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"
+        # This is what SurveySiteMapper.extract_geometry_defaults() produces.
+        if match := re.match(r"^<(\S+)> ?POINT ?\(([-.0-9]+) ([-.0-9]+)\)$", str(literal)):
+            datum = match.group(1)
+            # making raw a LatLong instance means that precision of the input is preserved.
+            raw = LatLong(decimal.Decimal(match.group(2)), decimal.Decimal(match.group(3)))
 
-        # Perform match
-        match = regex.match(str(literal))
-        if match is None:
+        # Less likely - any other WKT with or without datum
+        elif match := re.match(r"^(?:<(\S+)>)? ?(.*)$", str(literal)):
+            try:
+                raw = shapely.from_wkt(match.group(2))
+            except shapely.errors.ShapelyError as exc:
+                raise GeometryError from exc
+            # Check to see if datum provided
+            datum = match.group(1)
+            if datum:
+                # Flip the coordinates from lat-long to long-lat
+                # NOTE: Assumption is that the datum provided is of lat-long orientation.
+                raw = _swap_coordinates(raw)
+
+        else:
             # NOTE 11/11/2024 @jcrowleygaia: It is currently pretty impossible for a non-match to occur
             # however it may be necessary to keep this check in case of a change to the above
             # compiled regex in the future.
             raise ValueError(f"supplied literal '{literal}' is not GeoSPARQL WKT format.")
-
-        # Attempt to make shapely geometry and catch errors
-        try:
-            raw = shapely.from_wkt(match.group(2))
-        except shapely.errors.ShapelyError as exc:
-            raise GeometryError from exc
-
-        # Check to see if datum provided
-        if datum := match.group(1):
-            # Flip the coordinates from lat-long to long-lat
-            # NOTE: Assumption is that the datum provided is of lat-long orientation.
-            raw = _swap_coordinates(raw)
 
         # Create and return Geometry object
         return Geometry(

--- a/abis_mapping/models/spatial.py
+++ b/abis_mapping/models/spatial.py
@@ -37,6 +37,8 @@ class LatLong(NamedTuple):
 class Geometry:
     """Class for all geographical coordinate transformations."""
 
+    _precision: int | None = None  # Number of decimal places in the input geometry coordinates
+
     def __init__(
         self,
         raw: LatLong | str | shapely.Geometry,
@@ -63,6 +65,7 @@ class Geometry:
         if isinstance(raw, LatLong):
             # Make shapely point
             self._geometry: shapely.Geometry = shapely.Point(raw.longitude, raw.latitude)
+            self._precision = max(_num_decimal_places(coord) for coord in raw)
         elif isinstance(raw, str):
             # Attempt to make shapely geometry and catch errors
             try:
@@ -208,10 +211,7 @@ class Geometry:
         geometry = _swap_coordinates(self._geometry) if datum_string else self._geometry
 
         # Construct  and return rdf literal
-        wkt_string = shapely.to_wkt(
-            geometry=geometry,
-            rounding_precision=settings.SETTINGS.DEFAULT_WKT_ROUNDING_PRECISION,
-        )
+        wkt_string = self._to_wkt_string(geometry)
 
         return rdflib.Literal(
             lexical_or_value=datum_string + wkt_string,
@@ -233,14 +233,28 @@ class Geometry:
         geometry = _swap_coordinates(self._transformed_geometry) if datum_string else self._transformed_geometry
 
         # Construct and return rdf literal
-        wkt_string = shapely.to_wkt(
-            geometry=geometry,
-            rounding_precision=settings.SETTINGS.DEFAULT_WKT_ROUNDING_PRECISION,
-        )
+        wkt_string = self._to_wkt_string(geometry)
         return rdflib.Literal(
             lexical_or_value=datum_string + wkt_string,
             datatype=namespaces.GEO.wktLiteral,
         )
+
+    def _to_wkt_string(self, geometry: shapely.Geometry) -> str:
+        """Transform geometry to WKT string, using precision if available."""
+        wkt_string: str
+        if self._precision is not None:
+            wkt_string = shapely.to_wkt(
+                geometry=geometry,
+                # Round to the precision of the input, without trimming significant trailing zeros
+                rounding_precision=self._precision,
+                trim=False,
+            )
+        else:
+            wkt_string = shapely.to_wkt(
+                geometry=geometry,
+                rounding_precision=settings.SETTINGS.DEFAULT_WKT_ROUNDING_PRECISION,
+            )
+        return wkt_string
 
 
 def _swap_coordinates(original: shapely.Geometry) -> shapely.Geometry:
@@ -266,6 +280,21 @@ def _swap_coordinates(original: shapely.Geometry) -> shapely.Geometry:
 
     # Return transformed geometry
     return txd
+
+
+def _num_decimal_places(number: float | int | decimal.Decimal, /) -> int:
+    """Determine the number of decimal places in a number."""
+    if isinstance(number, decimal.Decimal):
+        decimal_number = number
+    else:
+        # Note the str() is important so that floats are 'rounded' to their approximate value.
+        # e.g. '1.1' instead of 1.100000000000000088817841970012523233890533447265625
+        decimal_number = decimal.Decimal(str(number))
+
+    exponent = decimal_number.as_tuple().exponent
+    if isinstance(exponent, int):
+        return abs(exponent)
+    raise ValueError(f"Cant count decimal places of: {decimal_number}")
 
 
 class GeometryError(Exception):

--- a/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/incidental_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -2006,7 +2006,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/1> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:N489292b7f1191795326ddd2200000002 ;
@@ -2094,7 +2094,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/12> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:N489292b7f1191795326ddd2200000018 ;
@@ -2119,7 +2119,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] .
 
 [] a rdf:Statement ;
@@ -2128,7 +2128,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/ABC123> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 3e+01 ] .
 
 [] a rdf:Statement ;
@@ -2137,7 +2137,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:N3bb12ed5a66f4695174d6bd600000003 ;
@@ -2145,7 +2145,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/ABC123> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:Nfc9ba55a50d500211c02e20000000001 ;
@@ -2161,7 +2161,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:Nfc9ba55a50d500211c02e20000000005 ;
@@ -2169,18 +2169,18 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 _:N3bb12ed5a66f4695174d6bd600000001 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:N3bb12ed5a66f4695174d6bd600000003 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:N489292b7f1191795326ddd2200000000 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral .
 
 _:N489292b7f1191795326ddd2200000002 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
@@ -2213,7 +2213,7 @@ _:N489292b7f1191795326ddd2200000014 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
 _:N489292b7f1191795326ddd2200000016 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral .
 
 _:N489292b7f1191795326ddd2200000018 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
@@ -2223,11 +2223,11 @@ _:N489292b7f1191795326ddd220000001a a geo:Geometry ;
     geo:hasMetricSpatialAccuracy 2e+01 .
 
 _:N489292b7f1191795326ddd220000001c a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
 _:N489292b7f1191795326ddd220000001e a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 3e+01 .
 
 _:Nfc9ba55a50d500211c02e20000000001 a geo:Geometry ;
@@ -2235,10 +2235,10 @@ _:Nfc9ba55a50d500211c02e20000000001 a geo:Geometry ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:Nfc9ba55a50d500211c02e20000000003 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:Nfc9ba55a50d500211c02e20000000005 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/margaret_river_flora/margaret_river_flora.ttl
@@ -1931,7 +1931,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:Nbaf38917362852ca9a9a0d2500000003 ;
@@ -1939,7 +1939,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/sequencing/ABC123> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:N7bfc9936b099cf9353fc575500000000 ;
@@ -1947,7 +1947,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/1> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:N7bfc9936b099cf9353fc575500000002 ;
@@ -2035,7 +2035,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/12> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:N7bfc9936b099cf9353fc575500000018 ;
@@ -2060,7 +2060,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 5e+01 ] .
 
 [] a rdf:Statement ;
@@ -2069,7 +2069,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/ABC123> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ;
             geo:hasMetricSpatialAccuracy 3e+01 ] .
 
 [] a rdf:Statement ;
@@ -2086,7 +2086,7 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/8022FSJMJ079c5cf> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 [] a rdf:Statement ;
     rdf:object _:Nfcd8f1042640aeab2a686b1700000005 ;
@@ -2094,10 +2094,10 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/sampling/specimen/ABC123> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 _:N7bfc9936b099cf9353fc575500000000 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral .
 
 _:N7bfc9936b099cf9353fc575500000002 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.01)"^^geo:wktLiteral .
@@ -2130,7 +2130,7 @@ _:N7bfc9936b099cf9353fc575500000014 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
 
 _:N7bfc9936b099cf9353fc575500000016 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral .
 
 _:N7bfc9936b099cf9353fc575500000018 a geo:Geometry ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.86 115.02)"^^geo:wktLiteral .
@@ -2140,19 +2140,19 @@ _:N7bfc9936b099cf9353fc57550000001a a geo:Geometry ;
     geo:hasMetricSpatialAccuracy 2e+01 .
 
 _:N7bfc9936b099cf9353fc57550000001c a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 5e+01 .
 
 _:N7bfc9936b099cf9353fc57550000001e a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     geo:hasMetricSpatialAccuracy 3e+01 .
 
 _:Nbaf38917362852ca9a9a0d2500000001 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:Nbaf38917362852ca9a9a0d2500000003 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:Nfcd8f1042640aeab2a686b1700000001 a geo:Geometry ;
@@ -2160,10 +2160,10 @@ _:Nfcd8f1042640aeab2a686b1700000001 a geo:Geometry ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:Nfcd8f1042640aeab2a686b1700000003 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 
 _:Nfcd8f1042640aeab2a686b1700000005 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral ;
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral ;
     rdfs:comment "Location unknown, location of field sampling used as proxy" .
 

--- a/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
+++ b/abis_mapping/templates/survey_occurrence_data_v3/examples/organism_qty.ttl
@@ -111,8 +111,8 @@
     rdf:subject <https://linked.data.gov.au/dataset/bdr/00000000-0000-0000-0000-000000000000/occurrence/A0010> ;
     rdfs:comment "supplied as" ;
     schema:spatial [ a geo:Geometry ;
-            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.8 115.21)"^^geo:wktLiteral ] .
+            geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (-33.80 115.21)"^^geo:wktLiteral ] .
 
 _:Nb0c3d4fa822b88b4d3f8743700000000 a geo:Geometry ;
-    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.8 115.21)"^^geo:wktLiteral .
+    geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-33.80 115.21)"^^geo:wktLiteral .
 

--- a/abis_mapping/templates/survey_site_data_v3/mapping.py
+++ b/abis_mapping/templates/survey_site_data_v3/mapping.py
@@ -228,7 +228,7 @@ class SurveySiteMapper(base.mapper.ABISMapper):
                         # Create string and add to map for site id
                         result[site_identifier] = str(
                             models.spatial.Geometry(
-                                raw=shapely.Point([float(longitude), float(latitude)]),
+                                raw=models.spatial.LatLong(latitude, longitude),
                                 datum=datum,
                             ).to_rdf_literal()
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "abis-mapping"
-version = "9.0.1"
+version = "9.0.2-rc1"
 description = "Provides templates and mappings to translate tabular data to ABIS rdf"
 authors = [
-    {name = "Gaia Resources", email = "dev@gaiaresources.com.au"}
+    { name = "Gaia Resources", email = "dev@gaiaresources.com.au" }
 ]
 dynamic = ["requires-python", "dependencies"]
 
@@ -18,7 +18,7 @@ requires-poetry = ">=2.0.0, <3"
 python = "^3.11"
 rdflib = "==7.1.1"
 python-slugify = "^8.0.4"
-frictionless = {extras = ["excel"], version = "^5.18.1"}
+frictionless = { extras = ["excel"], version = "^5.18.1" }
 python-dateutil = "^2.9.0.post0"
 shapely = "^2.1.1"
 pyproj = "^3.7.2"
@@ -72,12 +72,12 @@ select = [
     # Default rules
     "E4", "E7", "E9", "F",
     # additional rules
-    "B",  # bugbear
-    "A",  # builtins
-    "S",  # bandit
-    "G",  # logging-format
+    "B", # bugbear
+    "A", # builtins
+    "S", # bandit
+    "G", # logging-format
     "RUF100", # unused suppressions
-    "INP001",  # no namespace packages
+    "INP001", # no namespace packages
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/models/test_spatial.py
+++ b/tests/models/test_spatial.py
@@ -207,6 +207,52 @@ def test_geometry_from_geosparql_wkt_literal_invalid(
         models.spatial.Geometry.from_geosparql_wkt_literal(literal_in)
 
 
+@pytest.mark.parametrize(
+    ("literal_in", "literal_out", "transformed_literal_out"),
+    [
+        # no decimals
+        (
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (1 2)",
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (1 2)",
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (1 2)",
+        ),
+        # Decimals are preserved to same precision
+        (
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-20.00000 130.00000)",
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-20.00000 130.00000)",
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-20.00000 130.00000)",
+        ),
+        # Datum conversion is done to the same precision
+        (
+            "<http://www.opengis.net/def/crs/EPSG/0/4283> POINT (-20.000000 130.000000)",
+            "<http://www.opengis.net/def/crs/EPSG/0/4283> POINT (-20.000000 130.000000)",
+            "<http://www.opengis.net/def/crs/EPSG/0/7844> POINT (-19.999986 130.000009)",
+        ),
+    ],
+)
+def test_geometry_from_geosparql_wkt_literal_valid_preserves_point_precision(
+    literal_in: str,
+    literal_out: str,
+    transformed_literal_out: str,
+) -> None:
+    """Tests the geometry from_geosparql_wkt_literal method preserves POINT precision.
+
+    POINT precision should be preserved in the rdf literal output.
+    """
+    # Create geometry
+    geometry = models.spatial.Geometry.from_geosparql_wkt_literal(literal_in)
+
+    # Assert
+    assert geometry.to_rdf_literal() == rdflib.Literal(
+        literal_out,
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+    assert geometry.to_transformed_crs_rdf_literal() == rdflib.Literal(
+        transformed_literal_out,
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+
+
 def test_geometry_to_rdf_literal() -> None:
     """Tests the Geometry to_rdf_literal method."""
     # Create geometry

--- a/tests/models/test_spatial.py
+++ b/tests/models/test_spatial.py
@@ -2,6 +2,7 @@
 
 # Standard
 import copy
+import decimal
 
 # Third-party
 import shapely
@@ -222,6 +223,43 @@ def test_geometry_to_rdf_literal() -> None:
 
 
 @pytest.mark.parametrize(
+    ("lat_long", "rdf_output"),
+    [
+        (models.spatial.LatLong(0, 0), "0 0"),
+        (models.spatial.LatLong(-20, 115), "-20 115"),
+        (models.spatial.LatLong(-20.15, 115.26), "-20.15 115.26"),
+        (models.spatial.LatLong(-20.1500, 115.2600), "-20.15 115.26"),
+        (models.spatial.LatLong(decimal.Decimal(-20), decimal.Decimal(115)), "-20 115"),
+        (models.spatial.LatLong(decimal.Decimal("-20.1"), decimal.Decimal("115.2")), "-20.1 115.2"),
+        (models.spatial.LatLong(decimal.Decimal("-20.12"), decimal.Decimal("115.23")), "-20.12 115.23"),
+        (models.spatial.LatLong(decimal.Decimal("-20.123"), decimal.Decimal("115.234")), "-20.123 115.234"),
+        (models.spatial.LatLong(decimal.Decimal("-20.1234"), decimal.Decimal("115.2345")), "-20.1234 115.2345"),
+        (models.spatial.LatLong(decimal.Decimal("-20.12345"), decimal.Decimal("115.23456")), "-20.12345 115.23456"),
+        (models.spatial.LatLong(decimal.Decimal("-20.123456"), decimal.Decimal("115.234567")), "-20.123456 115.234567"),
+        (models.spatial.LatLong(decimal.Decimal("-20.000"), decimal.Decimal("115.000")), "-20.000 115.000"),
+        (models.spatial.LatLong(decimal.Decimal("-20.000000"), decimal.Decimal("115.000000")), "-20.000000 115.000000"),
+        (models.spatial.LatLong(decimal.Decimal("-20.00"), decimal.Decimal("115")), "-20.00 115.00"),
+    ],
+)
+def test_geometry_to_rdf_literal_precision(
+    lat_long: models.spatial.LatLong,
+    rdf_output: str,
+) -> None:
+    """Tests the Geometry to_rdf_literal method outputs a literal with same precision as the input LatLong."""
+    # Create geometry
+    geometry = models.spatial.Geometry(raw=lat_long, datum="GDA2020")
+
+    # Expected output
+    expected = rdflib.Literal(
+        f"<http://www.opengis.net/def/crs/EPSG/0/7844> POINT ({rdf_output})",
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+
+    # Assert
+    assert geometry.to_rdf_literal() == expected
+
+
+@pytest.mark.parametrize(
     "raw,datum,expected_str",
     [
         (
@@ -247,6 +285,97 @@ def test_geometry_to_tranformed_crs_rdf_literal(raw: str, datum: str, expected_s
     # Expected output
     expected = rdflib.Literal(
         lexical_or_value=expected_str,
+        datatype=utils.namespaces.GEO.wktLiteral,
+    )
+
+    # Assert
+    assert geometry.to_transformed_crs_rdf_literal() == expected
+
+
+@pytest.mark.parametrize(
+    ("lat_long", "datum", "rdf_output"),
+    [
+        # At low precision, datum conversion makes no changes to coordinates
+        (models.spatial.LatLong(decimal.Decimal("-25"), decimal.Decimal("130")), "AGD66", "-25 130"),
+        (models.spatial.LatLong(decimal.Decimal("-25"), decimal.Decimal("130")), "AGD84", "-25 130"),
+        (models.spatial.LatLong(decimal.Decimal("-25"), decimal.Decimal("130")), "GDA2020", "-25 130"),
+        (models.spatial.LatLong(decimal.Decimal("-25"), decimal.Decimal("130")), "GDA94", "-25 130"),
+        (models.spatial.LatLong(decimal.Decimal("-25"), decimal.Decimal("130")), "WGS84", "-25 130"),
+        # At 100m precision, there is a change in coordinates for one datum
+        (models.spatial.LatLong(decimal.Decimal("-25.000"), decimal.Decimal("130.000")), "AGD66", "-25.000 130.000"),
+        (models.spatial.LatLong(decimal.Decimal("-25.000"), decimal.Decimal("130.000")), "AGD84", "-24.999 130.001"),
+        (models.spatial.LatLong(decimal.Decimal("-25.000"), decimal.Decimal("130.000")), "GDA2020", "-25.000 130.000"),
+        (models.spatial.LatLong(decimal.Decimal("-25.000"), decimal.Decimal("130.000")), "GDA94", "-25.000 130.000"),
+        (models.spatial.LatLong(decimal.Decimal("-25.000"), decimal.Decimal("130.000")), "WGS84", "-25.000 130.000"),
+        # At 0.1m precision, there is a change in coordinates for two datums
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.000000"), decimal.Decimal("130.000000")),
+            "AGD66",
+            "-25.000000 130.000000",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.000000"), decimal.Decimal("130.000000")),
+            "AGD84",
+            "-24.998564 130.001327",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.000000"), decimal.Decimal("130.000000")),
+            "GDA2020",
+            "-25.000000 130.000000",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.000000"), decimal.Decimal("130.000000")),
+            "GDA94",
+            "-24.999986 130.000009",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.000000"), decimal.Decimal("130.000000")),
+            "WGS84",
+            "-25.000000 130.000000",
+        ),
+        # At 0.001m precision, there is a change in coordinates for two datums
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.00000000"), decimal.Decimal("130.00000000")),
+            "AGD66",
+            "-25.00000000 130.00000000",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.00000000"), decimal.Decimal("130.00000000")),
+            "AGD84",
+            "-24.99856427 130.00132675",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.00000000"), decimal.Decimal("130.00000000")),
+            "GDA2020",
+            "-25.00000000 130.00000000",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.00000000"), decimal.Decimal("130.00000000")),
+            "GDA94",
+            "-24.99998621 130.00000870",
+        ),
+        (
+            models.spatial.LatLong(decimal.Decimal("-25.00000000"), decimal.Decimal("130.00000000")),
+            "WGS84",
+            "-25.00000000 130.00000000",
+        ),
+    ],
+)
+def test_geometry_to_tranformed_crs_rdf_literal_precision(
+    lat_long: models.spatial.LatLong,
+    datum: str,
+    rdf_output: str,
+) -> None:
+    """Tests the Geometry to_transformed_crs_rdf_literal method outputs a literal with same precision as the input LatLong."""
+    # Create geometry
+    geometry = models.spatial.Geometry(
+        raw=lat_long,
+        datum=datum,
+    )
+
+    # Expected output
+    expected = rdflib.Literal(
+        f"<http://www.opengis.net/def/crs/EPSG/0/7844> POINT ({rdf_output})",
         datatype=utils.namespaces.GEO.wktLiteral,
     )
 
@@ -290,3 +419,55 @@ def test_swap_coordinates_3d() -> None:
     # Should raise GeometryError
     with pytest.raises(models.spatial.GeometryError):
         models.spatial._swap_coordinates(geometry)
+
+
+@pytest.mark.parametrize(
+    ("number", "expected_decimal_places"),
+    [
+        (1, 0),
+        (10, 0),
+        (100, 0),
+        (1000, 0),
+        (-1, 0),
+        (-10, 0),
+        (-100, 0),
+        (-1000, 0),
+        (1.0, 1),
+        (1.0000, 1),
+        (1.3, 1),
+        (1.33, 2),
+        (1.333, 3),
+        (-1.0, 1),
+        (-1.0000, 1),
+        (-1.3, 1),
+        (-1.33, 2),
+        (-1.333, 3),
+        (decimal.Decimal("1"), 0),
+        (decimal.Decimal("10"), 0),
+        (decimal.Decimal("100"), 0),
+        (decimal.Decimal("-1"), 0),
+        (decimal.Decimal("-10"), 0),
+        (decimal.Decimal("-100"), 0),
+        (decimal.Decimal("1.1"), 1),
+        (decimal.Decimal("1.11"), 2),
+        (decimal.Decimal("1.111"), 3),
+        (decimal.Decimal("1.1111"), 4),
+        (decimal.Decimal("-1.1"), 1),
+        (decimal.Decimal("-1.11"), 2),
+        (decimal.Decimal("-1.111"), 3),
+        (decimal.Decimal("1.1111"), 4),
+        (decimal.Decimal("1.0"), 1),
+        (decimal.Decimal("1.00"), 2),
+        (decimal.Decimal("1.000"), 3),
+        (decimal.Decimal("1.0000"), 4),
+        (decimal.Decimal("-1.0"), 1),
+        (decimal.Decimal("-1.00"), 2),
+        (decimal.Decimal("-1.000"), 3),
+        (decimal.Decimal("-1.0000"), 4),
+    ],
+)
+def test_number_of_decimal_places(number: int | float | decimal.Decimal, expected_decimal_places: int) -> None:
+    """Tests the _num_decimal_places function."""
+    actual = models.spatial._num_decimal_places(number)
+
+    assert actual == expected_decimal_places

--- a/tests/templates/test_survey_site_data_v3.py
+++ b/tests/templates/test_survey_site_data_v3.py
@@ -92,16 +92,16 @@ def test_extract_geometry_defaults(
         ): "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (2.5 2.5)",
         (
             models.identifier.SiteIdentifier(site_id="site3", site_id_source="ORG", existing_bdr_site_iri=None)
-        ): "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (20 10)",
+        ): "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (20.0 10.0)",
         (
             models.identifier.SiteIdentifier(site_id="site4", site_id_source="ORG", existing_bdr_site_iri=None)
-        ): "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (20 10)",
+        ): "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (20.0 10.0)",
         (
             models.identifier.SiteIdentifier(site_id="site5", site_id_source="ORG", existing_bdr_site_iri=None)
-        ): "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (21 11)",
+        ): "<http://www.opengis.net/def/crs/EPSG/0/4202> POINT (21.0 11.0)",
         (
             models.identifier.SiteIdentifier(site_id=None, site_id_source=None, existing_bdr_site_iri="SITE-IRI")
-        ): "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (25 15)",
+        ): "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT (25.0 15.0)",
     }
     # Invoke method
     assert hasattr(mapper, "extract_geometry_defaults")


### PR DESCRIPTION
Output occurrence lat/long in RDF with the same precision (i.e. decimal places) as in the input CSV, even if there has been a datum transformation.

This means that 
* Lots of decimal places are not added by a datum transformation
* Significant trailing zeros are not lost 
